### PR TITLE
Fix left/right panel sync in dev view

### DIFF
--- a/accessibility-checker-extension/src/ts/devtools/DevToolsPanelApp.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/DevToolsPanelApp.tsx
@@ -134,10 +134,8 @@ export default class DevToolsPanelApp extends React.Component<IPanelProps, IPane
 
     collapseAll() {
         if (this.state.report) {
-            if (!this.ignoreNext) {
-                this.state.report.filterstamp = new Date().getTime();
-            }
-            this.setState({ filter: null, report: preprocessReport(this.state.report, null), selectedItem: undefined, selectedCheckpoint: undefined });
+            this.state.report.filterstamp = new Date().getTime();
+            this.setState({ filter: null, report: preprocessReport(this.state.report, null, false), selectedItem: undefined, selectedCheckpoint: undefined });
         }
     }
 
@@ -152,7 +150,7 @@ export default class DevToolsPanelApp extends React.Component<IPanelProps, IPane
             this.setState({ 
                 filter: null, 
                 numScanning: Math.max(0, this.state.numScanning - 1), 
-                report: preprocessReport(report, null), 
+                report: preprocessReport(report, null, false), 
                 selectedItem: undefined
             });
         }
@@ -161,10 +159,8 @@ export default class DevToolsPanelApp extends React.Component<IPanelProps, IPane
 
     onFilter(filter: string) {
         if (this.state.report) {
-            if (!this.ignoreNext) {
-                this.state.report.filterstamp = new Date().getTime();
-            }
-            this.setState({ filter: filter, report: preprocessReport(this.state.report, filter) });
+            this.state.report.filterstamp = new Date().getTime();
+            this.setState({ filter: filter, report: preprocessReport(this.state.report, filter, !this.ignoreNext) });
         }
     }
 

--- a/accessibility-checker-extension/src/ts/devtools/Report.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/Report.tsx
@@ -99,8 +99,13 @@ export const valueMap: { [key: string]: { [key2: string]: string } } = {
     }
 };
 
-export function preprocessReport(report: IReport, filter: string | null) {
-    let first = true;
+/**
+ * Check report against filters and set the selections / scroll position
+ * @param report 
+ * @param filter Filter to use
+ * @param scroll If true, will set a scroll position on the report. If false, will not scroll.
+ */
+export function preprocessReport(report: IReport, filter: string | null, scroll: boolean) {
     report.counts = {
         "total": {},
         "filtered": {}
@@ -118,15 +123,13 @@ export function preprocessReport(report: IReport, filter: string | null) {
                 filtVal = "=";
                 item.selected = true;
                 if (item.value[1] !== "PASS") {
-                    item.scrollTo = first;
-                    first = false;
+                    item.scrollTo = scroll;
                 }
             } else if (xpath.startsWith(filter)) {
                 item.selectedChild = true;
                 filtVal = "^";
                 if (item.value[1] !== "PASS") {
-                    item.scrollTo = first;
-                    first = false;
+                    item.scrollTo = scroll;
                 }
             }
         }

--- a/accessibility-checker-extension/src/ts/devtools/ReportChecklist.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/ReportChecklist.tsx
@@ -64,7 +64,8 @@ export default class ReportChecklist extends React.Component<IReportChecklistPro
             }
         }
 
-        for (const item of this.props.report.results) {
+        let myResults = JSON.parse(JSON.stringify(this.props.report.results));
+        for (const item of myResults) {
             if (item.value[1] === "PASS") {
                 continue;
             }
@@ -84,6 +85,7 @@ export default class ReportChecklist extends React.Component<IReportChecklistPro
         // })
         let idx=0;
         groups = groups.filter(group => group.items.length > 0);
+        let scrollFirst = true;
         return <div className="bx--grid report">
             <div role="rowgroup">
                 <div className="bx--row reportHeader" role="row">
@@ -99,6 +101,10 @@ export default class ReportChecklist extends React.Component<IReportChecklistPro
                 {groups.map(group => {
                     let thisIdx = idx;
                     idx += group.items.length+1;
+                    group.items.map(item => {
+                        item.scrollTo = item.scrollTo && scrollFirst;
+                        scrollFirst = scrollFirst && !item.scrollTo;
+                    })
                     return <ReportRow 
                         idx={thisIdx} 
                         report={this.props.report} 

--- a/accessibility-checker-extension/src/ts/devtools/ReportElements.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/ReportElements.tsx
@@ -47,7 +47,8 @@ export default class ReportElements extends React.Component<IReportElementsProps
         let groupMap : {
             [key: string]: IGroup
         } | null = {};
-        for (const item of this.props.report.results) {
+        let myResults = JSON.parse(JSON.stringify(this.props.report.results));
+        for (const item of myResults) {
             if (item.value[1] === "PASS") {
                 continue;
             }
@@ -72,6 +73,7 @@ export default class ReportElements extends React.Component<IReportElementsProps
         //     return a.path.aria.localeCompare(b.path.aria);
         // })
         let idx=0;
+        let scrollFirst = true;
         return <div className="bx--grid report">
             <div role="rowgroup">
                 <div className="bx--row reportHeader" role="row">
@@ -86,7 +88,11 @@ export default class ReportElements extends React.Component<IReportElementsProps
             <div role="rowgroup">  
                 {groups.map(group => {
                     let thisIdx = idx;
-                    idx += group.items.length+1;                    
+                    idx += group.items.length+1;
+                    group.items.map(item => {
+                        item.scrollTo = item.scrollTo && scrollFirst;
+                        scrollFirst = scrollFirst && !item.scrollTo;
+                    })
                     return <ReportRow 
                         idx={thisIdx} 
                         report={this.props.report} 

--- a/accessibility-checker-extension/src/ts/devtools/ReportRow.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/ReportRow.tsx
@@ -104,11 +104,7 @@ export default class ReportRow extends React.Component<IReportRowProps, IReportR
                         parentPanel = parentPanel?.parentElement;
                     }
                     if (parentPanel && parentPanel.getAttribute("aria-hidden") !== "true") {
-                        const elementRect = element.getBoundingClientRect();
-                        const absoluteElementTop = elementRect.top + window.pageYOffset;
-                        const middle = absoluteElementTop - 144;
-                        element.ownerDocument?.defaultView?.scrollTo({
-                            top: middle,
+                        element.scrollIntoView({
                             behavior: 'smooth'
                         });
                     }
@@ -141,7 +137,6 @@ export default class ReportRow extends React.Component<IReportRowProps, IReportR
                             {val === "Needs review" && <span><img src={NeedsReview16} style={{verticalAlign:"middle",marginBottom:"4px"}} alt="Needs review" /></span>}
                             {val === "Recommendation" && <span><img src={Recommendation16} style={{verticalAlign:"middle",marginBottom:"2px"}} alt="Recommendation" /></span>}
                             <span style={{fontSize:"12px"}}>{item.message}</span>
-                            {console.log("this.props.layout = ",this.props.layout)}
                             {this.props.layout === "sub" ? (<React.Fragment><span> </span><a className="helpLink" href="#" style={{cursor:'default'}} onClick={this.props.getItem.bind(this, item)} >Learn more</a></React.Fragment>) : ""}
                             
                         </div>

--- a/accessibility-checker-extension/src/ts/devtools/ReportRules.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/ReportRules.tsx
@@ -45,7 +45,8 @@ export default class ReportRules extends React.Component<IReportRulesProps, IRep
         let groupMap : {
             [key: string]: IGroup
         } | null = {};
-        for (const item of this.props.report.results) {
+        let myResults = JSON.parse(JSON.stringify(this.props.report.results));
+        for (const item of myResults) {
             if (item.value[1] === "PASS") {
                 continue;
             }
@@ -73,6 +74,7 @@ export default class ReportRules extends React.Component<IReportRulesProps, IRep
         //     return a.path.aria.localeCompare(b.path.aria);
         // })
         let idx=0;
+        let scrollFirst = true;
         return <div className="bx--grid report">
             <div role="rowgroup">
                 <div className="bx--row reportHeader" role="row">
@@ -87,7 +89,11 @@ export default class ReportRules extends React.Component<IReportRulesProps, IRep
             <div role="rowgroup">
                 {groups.map(group => {
                     let thisIdx = idx;
-                    idx += group.items.length+1;               
+                    idx += group.items.length+1; 
+                    group.items.map(item => {
+                        item.scrollTo = item.scrollTo && scrollFirst;
+                        scrollFirst = scrollFirst && !item.scrollTo;
+                    })       
                     return <ReportRow
                         idx={thisIdx} 
                         report={this.props.report} 


### PR DESCRIPTION
Clicking on the right and left should have the same select / expand behavior. Only clicking on the left should scroll the report on the right. It should scroll to the first item selected.