### PR TITLE
replaces png logos

### DIFF
--- a/accessibility-checker-extension/src/assets/Bee_Logo@128px.svg
+++ b/accessibility-checker-extension/src/assets/Bee_Logo@128px.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="128px" height="128px" viewBox="0 0 128 128" style="enable-background:new 0 0 128 128;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:none;}
+	.st1{filter:url(#Adobe_OpacityMaskFilter);}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st3{mask:url(#mask-2_2_);fill-rule:evenodd;clip-rule:evenodd;fill:#924CFC;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;}
+</style>
+<rect class="st0" width="128" height="128"/>
+<g id="Group-4_1_" transform="translate(0.000000, 0.333400)">
+	<g id="Clip-3_1_">
+	</g>
+	<defs>
+		<filter id="Adobe_OpacityMaskFilter" filterUnits="userSpaceOnUse" x="8" y="23.7" width="112" height="82.2">
+			<feColorMatrix  type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+		</filter>
+	</defs>
+	<mask maskUnits="userSpaceOnUse" x="8" y="23.7" width="112" height="82.2" id="mask-2_2_">
+		<g class="st1">
+			<polygon id="path-1_2_" class="st2" points="8,23.7 120,23.7 120,108.7 8,108.7 			"/>
+		</g>
+	</mask>
+	<path id="Fill-2_1_" class="st3" d="M110.1,63.7L82,51.3l9.5,30.1c1.8,5.4,6.3,10.6,14,10.6c8,0,14.5-6.5,14.5-14.5
+		C120,70.8,115.8,66.3,110.1,63.7L110.1,63.7z M48,95.7c2.8,6,8.9,10.2,16,10.2c7.1,0,13.2-4.2,16-10.2H48z M80,55.7
+		c-2.8-6-8.9-10.2-16-10.2c-7.1,0-13.2,4.2-16,10.2H80z M8,77.6c0,8,6.5,14.5,14.5,14.5c7.7,0,12.2-5.3,14-10.6L46,51.3L17.9,63.7
+		C12.2,66.3,8,70.8,8,77.6L8,77.6z M74.4,23.7c-4.4,0-8,3.6-8,8c0,4.4,3.6,8,8,8c4.4,0,8-3.6,8-8C82.4,27.2,78.8,23.7,74.4,23.7
+		L74.4,23.7z M53.6,23.7c-4.4,0-8,3.6-8,8c0,4.4,3.6,8,8,8c4.4,0,8-3.6,8-8C61.6,27.2,58,23.7,53.6,23.7L53.6,23.7z"/>
+</g>
+<path id="Fill-1_3_" class="st4" d="M80,64H48v8h32V64z"/>
+<path id="Fill-1_2_" class="st4" d="M80,80H48v8h32V80z"/>
+</svg>

--- a/accessibility-checker-extension/src/assets/Bee_Logo@16px.svg
+++ b/accessibility-checker-extension/src/assets/Bee_Logo@16px.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="16px" height="16px" viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<style type="text/css">
+	.st0{filter:url(#Adobe_OpacityMaskFilter);}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st2{mask:url(#mask-2_2_);fill-rule:evenodd;clip-rule:evenodd;fill:#924CFC;}
+	.st3{fill-rule:evenodd;clip-rule:evenodd;}
+</style>
+<g id="Group-4_1_" transform="translate(0.000000, 0.333400)">
+	<g id="Clip-3_1_">
+	</g>
+	<defs>
+		<filter id="Adobe_OpacityMaskFilter" filterUnits="userSpaceOnUse" x="1" y="2.7" width="14" height="10.3">
+			<feColorMatrix  type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+		</filter>
+	</defs>
+	<mask maskUnits="userSpaceOnUse" x="1" y="2.7" width="14" height="10.3" id="mask-2_2_">
+		<g class="st0">
+			<polygon id="path-1_2_" class="st1" points="1,2.7 15,2.7 15,13.3 1,13.3 			"/>
+		</g>
+	</mask>
+	<path id="Fill-2_1_" class="st2" d="M13.8,7.7l-3.5-1.6l1.2,3.8c0.2,0.7,0.8,1.3,1.8,1.3c1,0,1.8-0.8,1.8-1.8
+		C15,8.6,14.5,8,13.8,7.7L13.8,7.7z M6,11.7c0.4,0.8,1.1,1.3,2,1.3c0.9,0,1.6-0.5,2-1.3H6z M10,6.7C9.6,5.9,8.9,5.4,8,5.4
+		c-0.9,0-1.6,0.5-2,1.3H10z M1,9.4c0,1,0.8,1.8,1.8,1.8c1,0,1.5-0.7,1.8-1.3l1.2-3.8L2.2,7.7C1.5,8,1,8.6,1,9.4L1,9.4z M9.3,2.7
+		c-0.6,0-1,0.4-1,1c0,0.6,0.4,1,1,1c0.6,0,1-0.4,1-1C10.3,3.1,9.9,2.7,9.3,2.7L9.3,2.7z M6.7,2.7c-0.6,0-1,0.4-1,1c0,0.6,0.4,1,1,1
+		c0.6,0,1-0.4,1-1C7.7,3.1,7.3,2.7,6.7,2.7L6.7,2.7z"/>
+</g>
+<path id="Fill-1_3_" class="st3" d="M10,8H6v1h4V8z"/>
+<path id="Fill-1_2_" class="st3" d="M10,10H6v1h4V10z"/>
+</svg>

--- a/accessibility-checker-extension/src/assets/Bee_Logo@32px.svg
+++ b/accessibility-checker-extension/src/assets/Bee_Logo@32px.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="32px" height="32px" viewBox="0 0 32 32" style="enable-background:new 0 0 32 32;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:none;}
+	.st1{filter:url(#Adobe_OpacityMaskFilter);}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st3{mask:url(#mask-2_2_);fill-rule:evenodd;clip-rule:evenodd;fill:#924CFC;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;}
+</style>
+<rect class="st0" width="32" height="32"/>
+<g id="Group-4_1_" transform="translate(0.000000, 0.333400)">
+	<g id="Clip-3_1_">
+	</g>
+	<defs>
+		<filter id="Adobe_OpacityMaskFilter" filterUnits="userSpaceOnUse" x="2" y="5.7" width="28" height="20.5">
+			<feColorMatrix  type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+		</filter>
+	</defs>
+	<mask maskUnits="userSpaceOnUse" x="2" y="5.7" width="28" height="20.5" id="mask-2_2_">
+		<g class="st1">
+			<polygon id="path-1_2_" class="st2" points="2,5.7 30,5.7 30,26.9 2,26.9 			"/>
+		</g>
+	</mask>
+	<path id="Fill-2_1_" class="st3" d="M27.5,15.7l-7-3.1l2.4,7.5c0.5,1.3,1.6,2.7,3.5,2.7c2,0,3.6-1.6,3.6-3.6
+		C30,17.5,29,16.3,27.5,15.7L27.5,15.7z M12,23.7c0.7,1.5,2.2,2.5,4,2.5c1.8,0,3.3-1,4-2.5H12z M20,13.7c-0.7-1.5-2.2-2.5-4-2.5
+		c-1.8,0-3.3,1-4,2.5H20z M2,19.1c0,2,1.6,3.6,3.6,3.6c1.9,0,3.1-1.3,3.5-2.7l2.4-7.5l-7,3.1C3,16.3,2,17.5,2,19.1L2,19.1z
+		 M18.6,5.7c-1.1,0-2,0.9-2,2c0,1.1,0.9,2,2,2c1.1,0,2-0.9,2-2C20.6,6.6,19.7,5.7,18.6,5.7L18.6,5.7z M13.4,5.7c-1.1,0-2,0.9-2,2
+		c0,1.1,0.9,2,2,2c1.1,0,2-0.9,2-2C15.4,6.6,14.5,5.7,13.4,5.7L13.4,5.7z"/>
+</g>
+<path id="Fill-1_3_" class="st4" d="M20,16h-8v2h8V16z"/>
+<path id="Fill-1_2_" class="st4" d="M20,20h-8v2h8V20z"/>
+<rect class="st0" width="32" height="32"/>
+</svg>

--- a/accessibility-checker-extension/src/assets/Bee_Logo@48px.svg
+++ b/accessibility-checker-extension/src/assets/Bee_Logo@48px.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="48px" height="48px" viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:none;}
+	.st1{filter:url(#Adobe_OpacityMaskFilter);}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st3{mask:url(#mask-2_2_);fill-rule:evenodd;clip-rule:evenodd;fill:#924CFC;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;}
+</style>
+<rect class="st0" width="48" height="48"/>
+<g id="Group-4_1_" transform="translate(0.000000, 0.333400)">
+	<g id="Clip-3_1_">
+	</g>
+	<defs>
+		<filter id="Adobe_OpacityMaskFilter" filterUnits="userSpaceOnUse" x="3" y="8.7" width="42" height="30.8">
+			<feColorMatrix  type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+		</filter>
+	</defs>
+	<mask maskUnits="userSpaceOnUse" x="3" y="8.7" width="42" height="30.8" id="mask-2_2_">
+		<g class="st1">
+			<polygon id="path-1_2_" class="st2" points="3,8.7 45,8.7 45,40.6 3,40.6 			"/>
+		</g>
+	</mask>
+	<path id="Fill-2_1_" class="st3" d="M41.3,23.7L30.7,19l3.6,11.3c0.7,2,2.4,4,5.3,4c3,0,5.4-2.4,5.4-5.4
+		C45,26.3,43.4,24.7,41.3,23.7L41.3,23.7z M18,35.7c1.1,2.3,3.4,3.8,6,3.8c2.7,0,4.9-1.6,6-3.8H18z M30,20.7c-1.1-2.3-3.4-3.8-6-3.8
+		c-2.7,0-4.9,1.6-6,3.8H30z M3,28.9c0,3,2.5,5.4,5.4,5.4c2.9,0,4.6-2,5.3-4L17.3,19L6.7,23.7C4.6,24.7,3,26.3,3,28.9L3,28.9z
+		 M27.9,8.7c-1.7,0-3,1.3-3,3c0,1.7,1.3,3,3,3s3-1.3,3-3C30.9,10,29.6,8.7,27.9,8.7L27.9,8.7z M20.1,8.7c-1.7,0-3,1.3-3,3
+		c0,1.7,1.3,3,3,3c1.7,0,3-1.3,3-3C23.1,10,21.8,8.7,20.1,8.7L20.1,8.7z"/>
+</g>
+<path id="Fill-1_3_" class="st4" d="M30,24H18v3h12V24z"/>
+<path id="Fill-1_2_" class="st4" d="M30,30H18v3h12V30z"/>
+</svg>

--- a/accessibility-checker-extension/src/assets/Bee_Logo@64px.svg
+++ b/accessibility-checker-extension/src/assets/Bee_Logo@64px.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="64px" height="64px" viewBox="0 0 64 64" style="enable-background:new 0 0 64 64;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:none;}
+	.st1{filter:url(#Adobe_OpacityMaskFilter);}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st3{mask:url(#mask-2_2_);fill-rule:evenodd;clip-rule:evenodd;fill:#924CFC;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;}
+</style>
+<rect class="st0" width="64" height="64"/>
+<g id="Group-4_1_" transform="translate(0.000000, 0.333400)">
+	<g id="Clip-3_1_">
+	</g>
+	<defs>
+		<filter id="Adobe_OpacityMaskFilter" filterUnits="userSpaceOnUse" x="4" y="11.7" width="56" height="41.1">
+			<feColorMatrix  type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
+		</filter>
+	</defs>
+	<mask maskUnits="userSpaceOnUse" x="4" y="11.7" width="56" height="41.1" id="mask-2_2_">
+		<g class="st1">
+			<polygon id="path-1_2_" class="st2" points="4,11.7 60,11.7 60,54.2 4,54.2 			"/>
+		</g>
+	</mask>
+	<path id="Fill-2_1_" class="st3" d="M55.1,31.7L41,25.5l4.7,15.1c0.9,2.7,3.2,5.3,7,5.3c4,0,7.3-3.3,7.3-7.3
+		C60,35.2,57.9,33,55.1,31.7L55.1,31.7z M24,47.7c1.4,3,4.5,5.1,8,5.1c3.5,0,6.6-2.1,8-5.1H24z M40,27.7c-1.4-3-4.5-5.1-8-5.1
+		c-3.5,0-6.6,2.1-8,5.1H40z M4,38.6c0,4,3.3,7.3,7.3,7.3c3.8,0,6.1-2.6,7-5.3L23,25.5L8.9,31.7C6.1,33,4,35.2,4,38.6L4,38.6z
+		 M37.2,11.7c-2.2,0-4,1.8-4,4c0,2.2,1.8,4,4,4c2.2,0,4-1.8,4-4C41.2,13.5,39.4,11.7,37.2,11.7L37.2,11.7z M26.8,11.7
+		c-2.2,0-4,1.8-4,4c0,2.2,1.8,4,4,4c2.2,0,4-1.8,4-4C30.8,13.5,29,11.7,26.8,11.7L26.8,11.7z"/>
+</g>
+<path id="Fill-1_3_" class="st4" d="M40,32H24v4h16V32z"/>
+<path id="Fill-1_2_" class="st4" d="M40,40H24v4h16V40z"/>
+</svg>


### PR DESCRIPTION
pull request adds:
`accessibility-checker-extension/src/assets/Bee_Logo@16px.svg`
`accessibility-checker-extension/src/assets/Bee_Logo@32px.svg`
`accessibility-checker-extension/src/assets/Bee_Logo@48px.svg`
`accessibility-checker-extension/src/assets/Bee_Logo@64px.svg`
`accessibility-checker-extension/src/assets/Bee_Logo@128px.svg`

use these instead of 
`accessibility-checker-extension/src/assets/Bee_Logo@*px.png`

(you could ship _only_ `accessibility-checker-extension/src/assets/Bee_Logo@16px.svg` and scale it up to all of the other sizes if you want to.)

**removing references to `accessibility-checker-extension/src/assets/Bee_Logo@*px.png` will require a separate issue and PR**