### PR TITLE
Add 'request' to list of dependencies; update readme

### DIFF
--- a/accessibility-checker/README.md
+++ b/accessibility-checker/README.md
@@ -18,7 +18,7 @@ $ npm install
 ```bash
 $ npm install
 $ npm run build
-$ npm run package
+$ npm run package:zip  or  npm run package:npm
 ```
 
 ### Test

--- a/accessibility-checker/package.json
+++ b/accessibility-checker/package.json
@@ -22,7 +22,8 @@
     "chromedriver": "^80.0.1",
     "deep-diff": "^0.3.4",
     "js-yaml": "^3.13.1",
-    "puppeteer": "^2.0.0"
+    "puppeteer": "^2.0.0",
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "adm-zip": "^0.4.13",

--- a/accessibility-checker/src/package.json
+++ b/accessibility-checker/src/package.json
@@ -20,7 +20,8 @@
     "chromedriver": "^80.0.1",
     "deep-diff": "^0.3.4",
     "js-yaml": "^3.13.1",
-    "puppeteer": "^2.0.0"
+    "puppeteer": "^2.0.0",
+    "request": "^2.88.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
PR contains two small changes

## 1. README
The readme for `accessibility-checker` referred to `npm run package` which wasn't a script.  I modified it to reflect the two package.json scripts.

## 2. Missing dependency
The node `accessibility-checker` appears to be missing a dependency against the `request` package.  I updated the package.json to add it as a dependency and ran the build and package steps to verify the small repo below works after adding the dependency.

### Changes

I created a very basic repo to show the problem below.

1.  Clone https://github.com/dstanich/accessibility-checker-dep-issue
2. `npm install`
3. `npm start`

You will see an error indicating it can't find the request package.
```
% npm start

> accessibility-checker-dep-issue@1.0.0 start /Users/drstanic@us.ibm.com/code/accessibility-checker-dep-issue
> node index.js

internal/modules/cjs/loader.js:638
    throw err;
    ^

Error: Cannot find module 'request'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:690:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/Users/drstanic@us.ibm.com/code/accessibility-checker-dep-issue/node_modules/accessibility-checker/lib/ACHelper.js:17:17)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! accessibility-checker-dep-issue@1.0.0 start: `node index.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the accessibility-checker-dep-issue@1.0.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/drstanic@us.ibm.com/.npm/_logs/2020-05-13T13_43_46_510Z-debug.log
```

### Questions
1. There appears to be two package.json files for the `accessibility-checker`.  I updated both but I don't know if both are necessary.
1. While investigating this, I found that `request` is deprecated.  Probably not urgent, but in the future maybe a good issue would be to update it to something newer: https://www.npmjs.com/package/request

