### PR TITLE
#1169 Children elements won’t be highlighted after clicking Reset button, and then same parent element.

### DIFF
--- a/accessibility-checker-extension/src/ts/devtools/DevToolsPanelApp.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/DevToolsPanelApp.tsx
@@ -307,6 +307,8 @@ selectPath("${item.path.dom}");
                             console.log('Could not select element, it may have moved');
                         }
                     });
+
+                    this.onFilter(item.path.dom)
                 }
             }
         }


### PR DESCRIPTION
https://github.ibm.com/IBMa/E2E/issues/1169