### PR TITLE
Fix lone checkbox issue

### DIFF
--- a/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-input-rules.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-input-rules.ts
@@ -396,7 +396,7 @@ let a11yRulesInput: Rule[] = [
                     // Must be an unnamed checkbox
                     if (ctxGroup === null) {
                         if ((formCache.checkboxByName[""] || []).length > 1) {
-                            return RulePotential("Potential_UnnamedCheckbox");
+                            return RulePotential("Potential_UnnamedCheckbox", [ctxType]);
                         } else {
                             return RulePass("Pass_LoneNogroup", [ctxType]);
                         }
@@ -422,11 +422,11 @@ let a11yRulesInput: Rule[] = [
                     } else {
                         return RulePass("Pass_Grouped", [ctxType]);
                     }
-                } else if (ctxType === "Checkbox" && formCache.numCheckboxes > 1 && numCheckboxesWithName.length === 1) {
+                } else if (ctxType === "Checkbox" && formCache.numCheckboxes > 1 && numCheckboxesWithName === 1) {
                     // We have only one checkbox with this name, but there are other checkboxes in the form. 
                     // If we're not grouped, ask them to examine it
                     if (ctxGroup === null) {
-                        return RulePotential("Potential_LoneCheckbox");
+                        return RulePotential("Potential_LoneCheckbox", [ctxType]);
                     } else {
                         return RulePass("Pass_Grouped", [ctxType]);
                     }
@@ -445,7 +445,7 @@ let a11yRulesInput: Rule[] = [
                         return RuleFail("Fail_NotSameGroup", [ctxType, ctxName]);
                     } else {
                         // We're all grouped up!
-                        return RulePass("Pass_Grouped");
+                        return RulePass("Pass_Grouped", [ctxType]);
                     }
                 }
             }

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Input_RadioChkInFieldSet_ruleunit/Lonecheckbox.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Input_RadioChkInFieldSet_ruleunit/Lonecheckbox.html
@@ -1,0 +1,143 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>checkbox group issue</title>
+</head>
+<body>
+<main>
+    <h1>checkbox group issue</h1>
+<form aria-label="GitHub Enterprise Whitewater for " autocomplete="off">
+	<div class="form-content-div">
+		<div class="bx--form-item" data-type="label">
+			<div class="detailsFormInputDiv">
+				<div class="markdown labelInfo" id="undefined-undefined">
+					<p><strong><span>Note:</span></strong><span> All users with </span><a class="bx--link" href="https://cloud.ibm.com/docs/services/ContinuousDelivery?topic=ContinuousDelivery-toolchains-using#managing_access" target="_blank"><span>access to this toolchain</span></a><span> will be able to access artifacts derived from this repository, such as build artifacts in the Delivery Pipeline.</span></p>
+				</div>
+			</div>
+		</div>
+		<div class="bx--form-item" data-type="boolean">
+			<div class="detailsFormLabelDiv"><span class="checkBoxSpan"><div class="bx--form-item bx--checkbox-wrapper"><input name="undefined_legal" data-paramdef-type="boolean" type="checkbox" class="bx--checkbox" id="undefined_legal"><label for="undefined_legal" class="bx--checkbox-label"><span class="bx--checkbox-label-text">I understand</span></label>
+			</div><span class="checkbox-error"><svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" class="checkbox-error-icon" style="will-change: transform;"><path d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L4.5,5.3l0.8-0.8l6.2,6.2L10.7,11.5z"></path><path fill="none" d="M10.7,11.5L4.5,5.3l0.8-0.8l6.2,6.2L10.7,11.5z" data-icon-path="inner-path" opacity="0"></path></svg></span>
+			<span
+				class="checkbox-text">You must confirm that you understand the note before proceeding.</span>
+				</span>
+		</div>
+	</div>
+	<div class="bx--form-item" data-type="selectfieldset">
+		<div class="detailsFormInputDiv">
+			<fieldset>
+				<legend>Repository options</legend>
+				<div class="bx--form-item" data-type="selectfieldset">
+					<div class="bx--select">
+						<div class="bx--select-input__wrapper"><select name="type" aria-label="Repository type" class="bx--select-input"><option class="bx--select-option" value="new">New</option><option class="bx--select-option" value="fork">Fork</option><option class="bx--select-option" value="clone">Clone</option><option class="bx--select-option" value="link">Existing</option></select></div>
+					</div>
+				</div>
+				<div>
+					<div class="bx--form-item" data-type="boolean">
+						<div class="detailsFormLabelDiv"><span class="checkBoxSpan"><div class="bx--form-item bx--checkbox-wrapper"><input name="undefined_private_repo" data-paramdef-type="boolean" type="checkbox" class="bx--checkbox" id="undefined_private_repo"><label for="undefined_private_repo" class="bx--checkbox-label"><span class="bx--checkbox-label-text">Make this repository private</span></label>
+						</div>
+						</span>
+					</div>
+				</div>
+				<div class="bx--form-item" data-type="boolean">
+					<div class="detailsFormLabelDiv"><span class="checkBoxSpan"><div class="bx--form-item bx--checkbox-wrapper"><input name="undefined_has_issues" data-paramdef-type="boolean" type="checkbox" class="bx--checkbox" id="undefined_has_issues"><label for="undefined_has_issues" class="bx--checkbox-label"><span class="bx--checkbox-label-text">Enable GitHub Issues</span></label>
+					</div>
+					</span>
+				</div>
+		</div>
+		<div class="bx--form-item" data-type="boolean">
+			<div class="detailsFormLabelDiv"><span class="checkBoxSpan"><div class="bx--form-item bx--checkbox-wrapper"><input name="undefined_enable_traceability" data-paramdef-type="boolean" type="checkbox" class="bx--checkbox" id="undefined_enable_traceability"><label for="undefined_enable_traceability" class="bx--checkbox-label"><span class="bx--checkbox-label-text">Track deployment of code changes</span></label>
+			</div>
+			</span>
+		</div>
+	</div>
+	</div>
+	</fieldset>
+	</div>
+	</div>
+	</div>
+</form>
+</main>
+<script type="text/javascript">
+    UnitTest = {
+        ruleIds: ["WCAG20_Input_RadioChkInFieldSet"],
+        results: [
+          {
+            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[2]/div[1]/span[1]/div[1]/input[1]",
+              "aria": "/document[1]/main[1]/form[1]/checkbox[1]"
+            },
+            "reasonId": "Potential_LoneCheckbox",
+            "message": "Verify that this ungrouped checkbox input is not related to other checkboxes",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[1]/div[1]/span[1]/div[1]/input[1]",
+              "aria": "/document[1]/main[1]/form[1]/checkbox[2]"
+            },
+            "reasonId": "Pass_Grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[2]/div[1]/span[1]/div[1]/input[1]",
+              "aria": "/document[1]/main[1]/form[1]/checkbox[3]"
+            },
+            "reasonId": "Pass_Grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[3]/div[1]/span[1]/div[1]/input[1]",
+              "aria": "/document[1]/main[1]/form[1]/checkbox[4]"
+            },
+            "reasonId": "Pass_Grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
Addresses a bad reference in `WCAG20_Input_RadioChkInFieldSet` that was referencing the `.length` of a number rather than just referencing the number itself.

Also provides appropriate rule messages for the PASS cases.