### PR TITLE
Fix error handling when requesting ruleArchiveFile

### DIFF
--- a/accessibility-checker/src/lib/ACConfigLoader.js
+++ b/accessibility-checker/src/lib/ACConfigLoader.js
@@ -106,6 +106,9 @@ async function processACConfig(ACConfig) {
         try {
             ruleArchiveParse = await new Promise((resolve, reject) => {
                 request.get(ruleArchiveFile, function (error, response, body) {
+                    if (error) {
+                        throw error;
+                    }
                     resolve(JSON.parse(body));
                 });
             });

--- a/accessibility-checker/src/lib/ACConfigLoader.js
+++ b/accessibility-checker/src/lib/ACConfigLoader.js
@@ -108,8 +108,9 @@ async function processACConfig(ACConfig) {
                 request.get(ruleArchiveFile, function (error, response, body) {
                     if (error) {
                         reject(error);
+                    } else {
+                        resolve(JSON.parse(body));
                     }
-                    resolve(JSON.parse(body));
                 });
             });
         } catch (err) {

--- a/accessibility-checker/src/lib/ACConfigLoader.js
+++ b/accessibility-checker/src/lib/ACConfigLoader.js
@@ -107,7 +107,7 @@ async function processACConfig(ACConfig) {
             ruleArchiveParse = await new Promise((resolve, reject) => {
                 request.get(ruleArchiveFile, function (error, response, body) {
                     if (error) {
-                        throw error;
+                        reject(error);
                     }
                     resolve(JSON.parse(body));
                 });


### PR DESCRIPTION
Resolves #102 

This change could get us more information about why our tests may sometimes fail to reach the `ruleArchiveFile` (as described in #102). 

Please let me know what you think. Thanks!