### PR TITLE
fix(karma-accessibility-checker): fix double JSON.parse

### DIFF
--- a/karma-accessibility-checker/src/lib/ACCommon.js
+++ b/karma-accessibility-checker/src/lib/ACCommon.js
@@ -332,7 +332,11 @@ var ACCommon = {
                     url: `${baseA11yServerURL}/archives.json`, 
                     rejectUnauthorized: false
                 }, function (error, response, body) {
-                    resolve(JSON.parse(body));
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve(body);
+                    }
                 });
             });
             fs.writeFileSync(pathLib.join(__dirname, "archives.json"), archiveJson);


### PR DESCRIPTION
This change fixes an issue where `archives.json` is parsed two times and thus the 2nd parse effectively parses `[object Object]`.

This change also ensures error from `request()` call is not swallowed in a callback.

Fixes #104.