### PR TITLE
fix: modify how cypress assertions are made

### DIFF
--- a/cypress-accessibility-checker/README.md
+++ b/cypress-accessibility-checker/README.md
@@ -64,8 +64,8 @@ Examples on how to use each of the APIs below can be found in the `achecker.js` 
 - `cy.getA11yComplianceOfDocument(label)`
   - Similar to `getCompliance()` in the reference API above, however it will automatically pass in the document.
   - Returned data ([defined here](https://www.npmjs.com/package/accessibility-checker#async-acheckergetcompliance-content--label--string)) will only contain the `report` object.
-- `cy.assertA11yCompliance(shouldFail?: boolean)`
-  - If `shouldFail` is set to false, this will not fail your test.  This is useful for testing what needs to be fixed without failing the test.
+- `cy.assertA11yCompliance(failOnError?: boolean)`
+  - If `failOnError` is set to false, this will not fail your test.  This is useful for testing what needs to be fixed without failing the test. By default this command will fail your test unless you specify `false` here.
 - `cy.getA11yDiffResults(label)`
 - `cy.getA11yBaseline(label)`
 - `cy.diffA11yResultsWithExpected(actual, expected, clean)`

--- a/cypress-accessibility-checker/src/commands.js
+++ b/cypress-accessibility-checker/src/commands.js
@@ -137,16 +137,13 @@ Cypress.Commands.add(
         return cy.wrap(result, { log: false });
       });
 
+    const message =
+      'accessibility-checker: See previous logs for accessibility violation data';
+
     if (shouldFail === true) {
-      assert.fail(
-        'accessibility-checker: See previous logs for accessibility violation data'
-      );
+      assert.fail(message);
     } else if (shouldFail === undefined) {
-      taskResult.should(
-        'eq',
-        0,
-        'accessibility-checker: See previous logs for accessibility violation data'
-      );
+      taskResult.should('eq', 0, message);
     }
 
     return taskResult;

--- a/cypress-accessibility-checker/src/commands.js
+++ b/cypress-accessibility-checker/src/commands.js
@@ -58,10 +58,11 @@ Cypress.Commands.add(
   'assertA11yCompliance',
   { prevSubject: true },
   (priorResults, shouldFail) => {
-    cy.task('accessibilityChecker', {
-      task: 'assertCompliance',
-      data: { report: priorResults.report }
-    })
+    const taskResult = cy
+      .task('accessibilityChecker', {
+        task: 'assertCompliance',
+        data: { report: priorResults.report }
+      })
       .then((result) => {
         const name = 'A11y';
         if (result === 0) {
@@ -133,13 +134,22 @@ Cypress.Commands.add(
         }
       })
       .then((result) => {
-        if ((result !== 0 && shouldFail === undefined) || shouldFail === true) {
-          assert.fail(
-            'accessibility-checker: See previous logs for accessibility violation data'
-          );
-        }
         return cy.wrap(result, { log: false });
       });
+
+    if (shouldFail === true) {
+      assert.fail(
+        'accessibility-checker: See previous logs for accessibility violation data'
+      );
+    } else if (shouldFail === undefined) {
+      taskResult.should(
+        'eq',
+        0,
+        'accessibility-checker: See previous logs for accessibility violation data'
+      );
+    }
+
+    return taskResult;
   }
 );
 

--- a/cypress-accessibility-checker/src/commands.js
+++ b/cypress-accessibility-checker/src/commands.js
@@ -57,7 +57,7 @@ Cypress.Commands.add('getA11yComplianceOfDocument', (label) => {
 Cypress.Commands.add(
   'assertA11yCompliance',
   { prevSubject: true },
-  (priorResults, shouldFail) => {
+  (priorResults, failOnError = true) => {
     const taskResult = cy
       .task('accessibilityChecker', {
         task: 'assertCompliance',
@@ -137,12 +137,10 @@ Cypress.Commands.add(
         return cy.wrap(result, { log: false });
       });
 
-    const message =
-      'accessibility-checker: See previous logs for accessibility violation data';
+    if (!!failOnError) {
+      const message =
+        'accessibility-checker: See previous logs for accessibility violation data';
 
-    if (shouldFail === true) {
-      assert.fail(message);
-    } else if (shouldFail === undefined) {
       taskResult.should('eq', 0, message);
     }
 


### PR DESCRIPTION
Currently, when there is a violation, cypress will force the test to fail. In the runner however it just shows that the test failed within an anonymous function. To most devs, this will not be helpful and will just be confusing.

This is a proposed way to improve the assertions in the runner for violations

### Before
![image](https://user-images.githubusercontent.com/2179012/88699929-efeb2d00-d0d5-11ea-8769-c2d35125cb77.png)

### After
![image](https://user-images.githubusercontent.com/2179012/88700183-53755a80-d0d6-11ea-94ce-fd4686772043.png)
