### PR TITLE
change the sequence of deployment guidelines

### DIFF
--- a/rule-server/gulp/gulpfile.js
+++ b/rule-server/gulp/gulpfile.js
@@ -64,7 +64,6 @@ const archivePolicies = () => {
                                 description: rs.description
                             });
                         }
-                        policies.sort((a,b) => a.id.localeCompare(b.id));
                     } catch (e) {}
                     archive.policies = policies;
                     if (archive.latest) {


### PR DESCRIPTION
Issue:  https://github.ibm.com/IBMa/E2E/issues/1540
Restore the guideline list back to their default  sequence

Tom: Can you please review this one line change to the rule server? This issue was brought up by Shari. After approving, can you please help update the rule server? 