### PR TITLE
cypress: minor readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This README covers topics for developers. For non-developer usage, see the follo
 * [accessibility-checker-extension for Firefox](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/) : web browser extensions that adds automated accessibility checking capabilities to Firefox
 * [accessibility-checker](https://www.npmjs.com/package/accessibility-checker): automated accessibility testing for Node-based test environments
 * [karma-accessibility-checker](https://www.npmjs.com/package/karma-accessibility-checker): automated accessibility testing for the Karma environment
-* [cypress-accessibility-checker](https://www.npmjs.com/package/cypress-accessibility-checker): wrapped of accessibility-checker in the Cypress environment
+* [cypress-accessibility-checker](https://www.npmjs.com/package/cypress-accessibility-checker): wrapper of accessibility-checker in the Cypress environment
 
 
 ## Getting started
@@ -33,12 +33,12 @@ $ cd equal-access
 
 ### Install dependencies
 
-Under the equal-access directory 
+Under the equal-access directory
 
 ```
 npm install
 ```
-Now you can select the tool you want to use and follow the README.MD instructions 
+Now you can select the tool you want to use and follow the README.MD instructions
 
 
 ### What's in this repository?
@@ -49,16 +49,16 @@ Tools (description above):
 * [accessibility-checker-extension](accessibility-checker-extension/README.md): A web browser extensions that adds automated accessibility checking capabilities
 * [accessibility-checker](accessibility-checker/README.md): Automated accessibility testing for Node-based test environments
 * [karma-accessibility-checker](karma-accessibility-checker/README.md): Automated accessibility testing for the Karma environment
-* [cypress-accessibility-checker](cypress-accessibility-checker/README.md): Wrapped for accessibility-checker for the Cypress environment
+* [cypress-accessibility-checker](cypress-accessibility-checker/README.md): Wrapper of accessibility-checker for the Cypress environment
 
 Components:
-* [accessibility-checker-engine](accessibility-checker-engine/README.md): accessibility rules and evaluation engine used by 
+* [accessibility-checker-engine](accessibility-checker-engine/README.md): accessibility rules and evaluation engine used by
 * [rule-server](https://github.com/IBMa/equal-access/tree/master/rule-server): deploys the rules and engine for usage by the tools
 
 
 ## Usage
 
-You can build all the tools from the root directory or build each individual tool separately.  
+You can build all the tools from the root directory or build each individual tool separately.
 
 ### Build all the tools from root directory
 
@@ -79,7 +79,7 @@ $ npm run build
 * In the equal-access/accessibility-checker/package directory
   * java script source that can be installed or deployed as npm package that works with an HTML parsing engines such as Selenium, Puppeteer, or Zombie to allow developers to perform integrated accessibility testing within a continuous integration pipeline such as Travis CI. Please view more [details](accessibility-checker/src/README.md).
 * In the equal-access/karma-accessibility-checker/package directory
-  * javascript source that can be used as a Karma plugin, see more [details](karma-accessibility-checker/README.md).  
+  * javascript source that can be used as a Karma plugin, see more [details](karma-accessibility-checker/README.md).
 
 ### Build each individual tool separately
 
@@ -88,4 +88,4 @@ Please check README for each individual tool for its build instruction:
 * [accessibility-checker-engine](accessibility-checker-engine/README.md)
 * [accessibility-checker-extension](accessibility-checker-extension/README.md)
 * [accessibility-checker](accessibility-checker/README.md)
-* [karma-accessibility-checker](karma-accessibility-checker/README.md) 
+* [karma-accessibility-checker](karma-accessibility-checker/README.md)

--- a/cypress-accessibility-checker/README.md
+++ b/cypress-accessibility-checker/README.md
@@ -20,7 +20,7 @@ npm install cypress-accessibility-checker --save-dev
 
 ## Configuration
 
-The configuration for the plugin is driven by a configuration file called `.achecker.yml` that you will need to put in the same directory as your `cypress.json` file. See details on the syntax of this file [here](https://github.com/IBMa/equal-access/blob/master/accessibility-checker/README.md).
+The configuration for the plugin is driven by a configuration file called `.achecker.yml` that you will need to put in the same directory as your `cypress.json` file. See details on the syntax of this file [here](https://github.com/IBMa/equal-access/blob/master/accessibility-checker/src/README.md#configuring-accessibility-checker).
 
 ## Setup Cypress
 


### PR DESCRIPTION
I noticed a few small issues with the readmes and Cypress.

1. Usage of `wrapped` looks like it probably was meant to be `wrapper`.  Let me know if I misinterpreted that.

2. Readme for the Cypress tool pointed to a readme that was essentially blank when referring to setting up the achecker.yml file.  Changed the link to point to the proper readme and section within the readme.