### PR TITLE
Add Playwright support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ $ npm run build
   * ace-node-debug.js: uncompressed javascript library to be used in a NodeJS environment for development
   * ace-node.js: compressed javascript library to be used in a NodeJS environment for production
 * In the equal-access/accessibility-checker/package directory
-  * java script source that can be installed or deployed as npm package that works with an HTML parsing engines such as Selenium, Puppeteer, or Zombie to allow developers to perform integrated accessibility testing within a continuous integration pipeline such as Travis CI. Please view more [details](accessibility-checker/src/README.md).
+  * java script source that can be installed or deployed as npm package that works with an HTML parsing engines such as Selenium, Puppeteer, Playwright, or Zombie to allow developers to perform integrated accessibility testing within a continuous integration pipeline such as Travis CI. Please view more [details](accessibility-checker/src/README.md).
 * In the equal-access/karma-accessibility-checker/package directory
   * javascript source that can be used as a Karma plugin, see more [details](karma-accessibility-checker/README.md).
 

--- a/accessibility-checker/src/README.md
+++ b/accessibility-checker/src/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`accessibility-checker` is a NodeJS Module that allows you to perform integrated accessibility testing within a continuous integration pipeline such as Travis CI. It works with parsing engines such as Selenium, Puppeteer, and Zombie. Note that we have seen some non-standard CSS parsing with Zombie, so be aware of inconsistencies as a result.
+`accessibility-checker` is a NodeJS Module that allows you to perform integrated accessibility testing within a continuous integration pipeline such as Travis CI. It works with parsing engines such as Selenium, Puppeteer, Playwright, and Zombie. Note that we have seen some non-standard CSS parsing with Zombie, so be aware of inconsistencies as a result.
 
 `accessibility-checker` works with a variety of test frameworks such as Cucumber, Mocha, or Jasmine. `accessibility-checker` allows users to scan HTML nodes/widgets, URLs, local files, HTML documents, and HTML content in the form of a string. Aside from just performing accessibility scanning, `accessibility-checker` provides a framework to validate accessibility scan results against baseline files and/or simply failing the testcases based on the levels of violations found during the scan.
 
@@ -37,7 +37,7 @@ $ achecker
 
 1. Install [NodeJS and NPM](https://nodejs.org/en/download/)
 2. Some testing framework (e.g., mocha, jasmine)
-3. Browser automation / parser (e.g., Selenium, Puppeteer, Zombie)
+3. Browser automation / parser (e.g., Selenium, Puppeteer, Playwright, Zombie)
 
 #### Install
 
@@ -183,6 +183,7 @@ Execute accessibility scan on provided content. `content` can be in the followin
 -   Document node (HTMLDocument)
 -   Selenium WebDriver (WebDriver)
 -   Puppeteer page
+-   Playwright page
 
 Note: When using Selenium WebDriver the aChecker.getCompliance API will only take Selenium WebDriver (WebDriver) instance. When using puppeteer, aChecker.getCompliance expects the Page object.
 

--- a/accessibility-checker/src/lib/ACHelper.js
+++ b/accessibility-checker/src/lib/ACHelper.js
@@ -209,8 +209,7 @@ let ace;
         if (isPuppeteer(content) || isPlaywright(content)) {
             aChecker.DEBUG && console.log("[INFO] aChecker.loadEngine detected Puppeteer/Playwright");
             let page = content;
-            const docHandle = await page.evaluateHandle('document');
-            await page.evaluate(({ document, scriptUrl }) => {
+            await page.evaluate((scriptUrl) => {
                 try {
                     if ('undefined' === typeof(ace)) {
                         return new Promise((resolve, reject) => {
@@ -230,7 +229,7 @@ let ace;
                 } catch (e) {
                     return Promise.reject(e);
                 }
-            }, { document: docHandle, scriptUrl: aChecker.Config.rulePack + "/ace.js" });
+            }, aChecker.Config.rulePack + "/ace.js");
             return aChecker.loadLocalEngine();
         } else if (isSelenium(content)) {
             aChecker.DEBUG && console.log("[INFO] aChecker.loadEngine detected Selenium");
@@ -585,8 +584,7 @@ try {
             const startScan = Date.now();
             // NOTE: Engine should already be loaded
             const page = parsed;
-            const winHandle = await page.evaluateHandle("window");
-            let report = await page.evaluate(({ window, policies }) => {
+            let report = await page.evaluate((policies) => {
                 let checker = new window.ace.Checker();
                 return new Promise((resolve, reject) => {
                     setTimeout(function () {
@@ -598,7 +596,7 @@ try {
                         })
                     }, 0)
                 })
-            }, { window: winHandle, policies: aChecker.Config.policies });
+            }, aChecker.Config.policies);
             if (curPol != null && !aChecker.Config.checkPolicy) {
                 const valPolicies = await page.evaluate("new window.ace.Checker().rulesetIds");
                 aChecker.Config.checkPolicy = true;


### PR DESCRIPTION
Add support for [Playwright](https://github.com/microsoft/playwright) pages. The API is very similar to Puppeteer (based on the fact that it has been developed by former Puppeteer engineers). The main difference in the context of `accessibility-checker` is the `evaluate` function:

- Playwright [supports](https://github.com/microsoft/playwright) only a single argument.
- Puppeteer [supports](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pageevaluatepagefunction-args) a list of arguments.

In this PR, I've tried merging multiple arguments into a single object, but Puppeteer doesn't handle it well for passing the `document` handle (internal serialization logic). However, this is not necessary, because the `document` is avaliable within `evaluate` implicitly.

Fixes: #269

Signed-off-by: Darek Kay <hello@darekkay.com>