### PR TITLE
Improve "What to do" help text for labeling controls

### DIFF
--- a/accessibility-checker-engine/help/WCAG20_Input_ExplicitLabel.mdx
+++ b/accessibility-checker-engine/help/WCAG20_Input_ExplicitLabel.mdx
@@ -27,10 +27,11 @@ Associating a meaningful label with every UI control allows the browser and assi
 
 ### What to do
 
-* Add a `for` attribute to a visible label with the `id` of this control (e.g. `<label for="controlID">`);
-* OR put the UI element inside a visible `<label>` element;
+* If the control is a [labelable](https://html.spec.whatwg.org/multipage/forms.html#category-label) element, add a `for` attribute to a visible label with the `id` of this control (e.g. `<label for="controlID">`);
+* OR if the  control is a labelable element, put the control inside a visible `<label>` element;
 * OR add an `aria-labelledby` attribute to the control. It must point to visible text on the page that is meaningful as a label;
-* OR only if the design cannot have a visible label, use the `title` attribute to provide a label.
+* OR if the design cannot have a visible label, provide a label using the `aria-label` attribute (e.g. `aria-label="Activities"`);
+* OR if the design cannot have a visible label, use the `title` attribute to provide a label.
 
 </Column>
 <Column colLg={5} colMd={3} colSm={4} className="toolLeft">


### PR DESCRIPTION
Fixes #294:
- Adds aria-label as a possible solution for labeling controls
- Reminds the user to only use label as a solution when element is labelable