### PR TITLE
Add rule for checking roles on table structure elements

### DIFF
--- a/accessibility-checker-engine/help/table_aria_descendants.mdx
+++ b/accessibility-checker-engine/help/table_aria_descendants.mdx
@@ -1,0 +1,72 @@
+---
+title: "Accessibility Checker Rule Help: Rpt_Aria_ValidRole"
+---
+import "../../../styles/ToolHelp.scss"
+import { CodeSnippet, Tag } from "carbon-components-react";
+
+<div className="toolHelp">
+<Row>
+<Column colLg={16} colMd={8} colSm={4} className="toolHead">
+
+### An explicit WAI-ARIA 'role' is not valid for {0} element within a WAI-ARIA role '{1}' per the ARIA in HTML specification
+
+<div id="locLevel"></div>
+
+Table structure elements cannot specify an explicit 'role' within table containers
+
+</Column>
+</Row>
+<Row>
+<Column colLg={11} colMd={5} colSm={4} className="toolMain">
+
+### Why is this important?
+
+The WAI-ARIA specification provides a collection of accessibility roles as the main indicator 
+of the type of control. This is used to support platform accessibility APIs. Using a valid 
+WAI-ARIA `role` on an element as defined in the WAI-ARIA specification allows assistive 
+technologies to use the role semantics to present and support consistent object interaction.
+
+<div id="locSnippet"></div>
+
+### What to do
+
+* Remove any `role` definitions from table structure elements (`tr`, `th`, `td`) withing any 
+container with `role` of `table`, `grid`, or `treegrid`. The following example shows an element 
+with a valid `role="grid"` with appropriate table structures:
+
+<CodeSnippet type="multi" light={true}> 
+
+&lt;div id="caption" class="caption"&gt;Table caption&lt;/div&gt;
+&lt;table role="grid" aria-labelledby="caption" class="gridCls"&gt;
+  &lt;thead&gt;
+    &lt;tr&gt;
+      &lt;th&gt;Head 1&lt;/th&gt;&lt;th&gt;Head 2&lt;/th&gt;
+    &lt;/tr&gt;
+  &lt;/thead&gt;
+  &lt;tbody&gt;
+    &lt;tr&gt;
+      &lt;td&gt;Cell 1&lt;/td&gt;&lt;td&gt;Cell 2&lt;/td&gt;
+    &lt;/tr&gt;
+  &lt;/tbody&gt;
+&lt;/table&gt;
+
+</CodeSnippet>
+
+</Column>
+<Column colLg={5} colMd={3} colSm={4} className="toolLeft">
+
+### About this requirement
+
+[IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
+[W3C WAI-ARIA 1.2](https://www.w3.org/TR/wai-aria-1.2/)
+
+### Who does this affect?
+
+* Blind people using screen readers
+* People with dexterity impairment using voice control
+
+</Column>
+</Row>
+</div>
+
+export default ({ children, _frontmatter }) => (<React.Fragment>{children}</React.Fragment>)

--- a/accessibility-checker-engine/src/v2/checker/accessibility/nls/index.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/nls/index.ts
@@ -544,6 +544,10 @@ let a11yNls = {
         "Pass_0": "Rule Passed",
         "Fail_1": "The 'role' defined on the element is not valid per WAI-ARIA specification"
     },
+    "table_aria_descendants": {
+        0: "Table structure elements cannot specify an explicit 'role' within table containers",
+        "explicit_role": "An explicit WAI-ARIA 'role' is not valid for <{0}> element within a WAI-ARIA role '{1}' per the ARIA in HTML specification"
+    },
     // JCH - DONE
     "Rpt_Aria_ValidPropertyValue": {
         0: "WAI-ARIA property values must be valid",

--- a/accessibility-checker-engine/src/v2/checker/accessibility/rules/index.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/rules/index.ts
@@ -41,7 +41,7 @@ import { a11yRulesStyle } from "./rpt-style-rules";
 import { a11yRulesLabeling } from "./rpt-ariaLabeling-rules";
 import { a11yRulesFig } from "./rpt-figure-rules";
 import { a11yRulesLabel } from "./rpt-label-rules";
-import { a11yRulesTable } from "./rpt-table-rules";
+import { a11yRulesTable } from "./table-rules";
 import { a11yRulesBlink } from "./rpt-blink-rules";
 import { a11yRulesFocus } from "./rpt-focus-rules";
 import { a11yRulesList } from "./rpt-list-rules";

--- a/accessibility-checker-engine/src/v2/checker/accessibility/rules/table-rules.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/rules/table-rules.ts
@@ -14,7 +14,7 @@
     limitations under the License.
  *****************************************************************************/
 
-import { Rule, RuleResult, RuleFail, RuleContext, RulePotential, RuleManual, RulePass } from "../../../api/IEngine";
+import { Rule, RuleResult, RuleFail, RuleContext, RulePotential, RuleManual, RulePass, RuleContextHierarchy } from "../../../api/IEngine";
 import { FragmentUtil } from "../util/fragment";
 import { RPTUtil } from "../util/legacy";
 
@@ -436,6 +436,19 @@ let a11yRulesTable: Rule[] = [
                 return RuleFail("Fail_1", [currentElementToken, structuralElementTokensStr]);
             }
         }
+    },
+    {
+        /**
+         * See https://github.com/IBMa/equal-access/issues/372
+         */
+         id: "table_aria_descendants",
+         context: "aria:table dom:tr[role], aria:table dom:th[role], aria:table dom:td[role]"
+            + ", aria:grid dom:tr[role], aria:grid dom:th[role], aria:grid dom:td[role]"
+            + ", aria:treegrid dom:tr[role], aria:treegrid dom:th[role], aria:treegrid dom:td[role]",
+         run: (context: RuleContext, options?: {}, hierarchies?: RuleContextHierarchy): RuleResult | RuleResult[] => {
+             let parentRole = hierarchies["aria"].filter(hier => ["table", "grid", "treegrid"].includes(hier.role));
+             return RuleFail("explicit_role", [context["dom"].node.nodeName.toLowerCase(), parentRole[0].role]);
+         }
     }
 
 ]

--- a/accessibility-checker-engine/src/v2/checker/accessibility/rulesets/index.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/rulesets/index.ts
@@ -1060,6 +1060,11 @@ let a11yRulesets: Ruleset[] = [
                     toolkitLevel: eToolkitLevel.LEVEL_ONE
                 },
                 {
+                    id: "table_aria_descendants",
+                    level: eRulePolicy.VIOLATION,
+                    toolkitLevel: eToolkitLevel.LEVEL_ONE
+                },
+                {
                     id: "Rpt_Aria_ValidPropertyValue",
                     level: eRulePolicy.VIOLATION,
                     toolkitLevel: eToolkitLevel.LEVEL_ONE
@@ -2210,6 +2215,11 @@ let a11yRulesets: Ruleset[] = [
                     toolkitLevel: eToolkitLevel.LEVEL_ONE
                 },
                 {
+                    id: "table_aria_descendants",
+                    level: eRulePolicy.VIOLATION,
+                    toolkitLevel: eToolkitLevel.LEVEL_ONE
+                },
+                {
                     id: "Rpt_Aria_ValidPropertyValue",
                     level: eRulePolicy.VIOLATION,
                     toolkitLevel: eToolkitLevel.LEVEL_ONE
@@ -3267,6 +3277,11 @@ let a11yRulesets: Ruleset[] = [
                 },
                 {
                     id: "Rpt_Aria_ValidRole",
+                    level: eRulePolicy.VIOLATION,
+                    toolkitLevel: eToolkitLevel.LEVEL_ONE
+                },
+                {
+                    id: "table_aria_descendants",
                     level: eRulePolicy.VIOLATION,
                     toolkitLevel: eToolkitLevel.LEVEL_ONE
                 },
@@ -4428,6 +4443,11 @@ let a11yRulesets: Ruleset[] = [
                 },
                 {
                     id: "Rpt_Aria_ValidRole",
+                    level: eRulePolicy.VIOLATION,
+                    toolkitLevel: eToolkitLevel.LEVEL_ONE
+                },
+                {
+                    id: "table_aria_descendants",
                     level: eRulePolicy.VIOLATION,
                     toolkitLevel: eToolkitLevel.LEVEL_ONE
                 },

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/table_aria_descendants_ruleunit/basic_fail.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/table_aria_descendants_ruleunit/basic_fail.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en-US">
+
+<head>
+    <title>Sandbox</title>
+    <meta charset="UTF-8" />
+    <!-- <script type="text/javascript" src="src/index.js"></script>
+    <link rel="stylesheet" href="src/styles.css" /> -->
+</head>
+
+<body>
+    <main>
+        <h1>Test page</h1>
+        <div id="testcase1">
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col">Head 1</th>
+                        <th scope="col">Head 2</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Body 1</td>
+                        <td role="link">Body 2</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div id="testcase2">
+            <table role="grid" aria-label="testcase 2">
+                <thead>
+                    <tr>
+                        <th scope="col">Head 1</th>
+                        <th scope="col">Head 2</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Body 1</td>
+                        <td role="link">Body 2</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div id="testcase3">
+            <table role="table">
+                <thead>
+                    <tr>
+                        <th scope="col">Head 1</th>
+                        <th scope="col">Head 2</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Body 1</td>
+                        <td role="link">Body 2</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div id="testcase4">
+            <table role="treegrid" aria-label="testcase 4">
+                <thead>
+                    <tr>
+                        <th scope="col">Head 1</th>
+                        <th scope="col">Head 2</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Body 1</td>
+                        <td role="link">Body 2</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </main>
+    <script>
+        UnitTest = {
+            ruleIds: ["table_aria_descendants"],
+            results: [
+                {
+                    "ruleId": "table_aria_descendants",
+                    "value": [
+                        "INFORMATION",
+                        "FAIL"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/div[1]/table[1]/tbody[1]/tr[1]/td[2]",
+                        "aria": "/document[1]/main[1]/table[1]/rowgroup[2]/row[1]/link[1]"
+                    },
+                    "reasonId": "explicit_role",
+                    "message": "An explicit WAI-ARIA 'role' is not valid for <td> element within a WAI-ARIA role 'table' per the ARIA in HTML specification",
+                    "messageArgs": ["td", "table"],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "table_aria_descendants",
+                    "value": [
+                        "INFORMATION",
+                        "FAIL"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/div[2]/table[1]/tbody[1]/tr[1]/td[2]",
+                        "aria": "/document[1]/main[1]/grid[1]/rowgroup[2]/row[1]/link[1]"
+                    },
+                    "reasonId": "explicit_role",
+                    "message": "An explicit WAI-ARIA 'role' is not valid for <td> element within a WAI-ARIA role 'grid' per the ARIA in HTML specification",
+                    "messageArgs": ["td", "grid"],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "table_aria_descendants",
+                    "value": [
+                        "INFORMATION",
+                        "FAIL"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/div[3]/table[1]/tbody[1]/tr[1]/td[2]",
+                        "aria": "/document[1]/main[1]/table[2]/rowgroup[2]/row[1]/link[1]"
+                    },
+                    "reasonId": "explicit_role",
+                    "message": "An explicit WAI-ARIA 'role' is not valid for <td> element within a WAI-ARIA role 'table' per the ARIA in HTML specification",
+                    "messageArgs": ["td", "table"],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "table_aria_descendants",
+                    "value": [
+                        "INFORMATION",
+                        "FAIL"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/div[4]/table[1]/tbody[1]/tr[1]/td[2]",
+                        "aria": "/document[1]/main[1]/treegrid[1]/rowgroup[2]/row[1]/link[1]"
+                    },
+                    "reasonId": "explicit_role",
+                    "message": "An explicit WAI-ARIA 'role' is not valid for <td> element within a WAI-ARIA role 'treegrid' per the ARIA in HTML specification",
+                    "messageArgs": ["td", "treegrid"],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                }
+            ]
+        };
+    </script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/table_aria_descendants_ruleunit/basic_pass.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/table_aria_descendants_ruleunit/basic_pass.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en-US">
+
+<head>
+    <title>Sandbox</title>
+    <meta charset="UTF-8" />
+    <!-- <script type="text/javascript" src="src/index.js"></script>
+    <link rel="stylesheet" href="src/styles.css" /> -->
+</head>
+
+<body>
+    <main>
+        <h1>Test page</h1>
+        <div id="testcase1">
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col">Head 1</th>
+                        <th scope="col">Head 2</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Body 1</td>
+                        <td>Body 2</td>
+                    </tr>                        
+                </tbody>
+            </table>
+        </div>
+        <div id="testcase2">
+            <table role="grid" aria-label="testcase 2">
+                <thead>
+                    <tr>
+                        <th scope="col">Head 1</th>
+                        <th scope="col">Head 2</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Body 1</td>
+                        <td>Body 2</td>
+                    </tr>                        
+                </tbody>
+            </table>
+        </div>
+        <div id="testcase3">
+            <table role="table">
+                <thead>
+                    <tr>
+                        <th scope="col">Head 1</th>
+                        <th scope="col">Head 2</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Body 1</td>
+                        <td>Body 2</td>
+                    </tr>                        
+                </tbody>
+            </table>
+        </div>
+        <div id="testcase4">
+            <table role="treegrid" aria-label="testcase 4">
+                <thead>
+                    <tr>
+                        <th scope="col">Head 1</th>
+                        <th scope="col">Head 2</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Body 1</td>
+                        <td>Body 2</td>
+                    </tr>                        
+                </tbody>
+            </table>
+        </div>
+    </main>
+    <script>
+        UnitTest = {
+            ruleIds: ["table_aria_descendants"],
+            results: []
+        };
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
Closes issue #372

Need:
* [x] Testcase
* [x] Rule logic: table_aria_descendants
* [x] Generic message: "Table structure elements cannot specify an explicit 'role' within table containers"
* [x] Specific Message: "An explicit WAI-ARIA 'role' is not valid for <{0}> element within a WAI-ARIA role '{1}' per the ARIA in HTML specification"
* [x] Ruleset mapping: 4.1.2 Role, Name, Value
* [x] Toolkit mapping: Level 1
* [x] Help file