### PR TITLE
Add aceconfig.js as a potential config file

### DIFF
--- a/accessibility-checker/src-ts/bin/achecker.js
+++ b/accessibility-checker/src-ts/bin/achecker.js
@@ -86,7 +86,7 @@ Commands:
     archives                : Display valid archive ids and policy ids
 
 Flags:
-    Flags can be set via .achecker.yml or achecker.js files. Specifying the flags here
+    Flags can be set via .achecker.yml or aceconfig.js files. Specifying the flags here
     will override those options.
 
     --ruleArchive           : Archive id to use. Run "achecker archives" for valid ids

--- a/accessibility-checker/src-ts/lib/ACConstants.ts
+++ b/accessibility-checker/src-ts/lib/ACConstants.ts
@@ -72,7 +72,7 @@ export const ACConstants : IConfigUnsupported = {
     //  ./.config/achecker.json
     // The node module, require will load js or json depending on which one is present, in the case
     // both json and js are present it loads js first.
-    configFiles: [".achecker.yml", ".achecker.yaml", "achecker", "aceconfig", pathLib.join(".config", ".achecker.yml"), pathLib.join(".config", ".achecker.yaml"), pathLib.join(".config", "achecker"), , pathLib.join(".config", "aceconfig")],
+    configFiles: [".achecker.yml", ".achecker.yaml", "achecker", "aceconfig", pathLib.join(".config", ".achecker.yml"), pathLib.join(".config", ".achecker.yaml"), pathLib.join(".config", "achecker"), pathLib.join(".config", "aceconfig")],
 
     ignoreHTTPSErrors: false
 };

--- a/accessibility-checker/src-ts/lib/ACConstants.ts
+++ b/accessibility-checker/src-ts/lib/ACConstants.ts
@@ -72,7 +72,7 @@ export const ACConstants : IConfigUnsupported = {
     //  ./.config/achecker.json
     // The node module, require will load js or json depending on which one is present, in the case
     // both json and js are present it loads js first.
-    configFiles: [".achecker.yml", ".achecker.yaml", "achecker", pathLib.join(".config", ".achecker.yml"), pathLib.join(".config", ".achecker.yaml"), pathLib.join(".config", "achecker")],
+    configFiles: [".achecker.yml", ".achecker.yaml", "achecker", "aceconfig", pathLib.join(".config", ".achecker.yml"), pathLib.join(".config", ".achecker.yaml"), pathLib.join(".config", "achecker"), , pathLib.join(".config", "aceconfig")],
 
     ignoreHTTPSErrors: false
 };

--- a/accessibility-checker/src/README.md
+++ b/accessibility-checker/src/README.md
@@ -121,7 +121,7 @@ outputFolder: results
 baselineFolder: test/baselines
 ```
 
-A similar `achecker.js` file can also be used:
+A similar `aceconfig.js` file can also be used:
 
 ```js
 module.exports = {
@@ -356,7 +356,7 @@ Returns `String` representation of the scan results which can be logged to conso
 
 ### async aChecker.getConfig()
 
-Retrieve the configuration object used by accessibility-checker. See achecker.js / .achecker.yml above for details
+Retrieve the configuration object used by accessibility-checker. See aceconfig.js / .achecker.yml above for details
 
 ### async aChecker.close()
 

--- a/cypress-accessibility-checker/src/lib/ACConstants.js
+++ b/cypress-accessibility-checker/src/lib/ACConstants.js
@@ -79,7 +79,7 @@ var constants = {
     //  ./.config/achecker.json
     // The node module, require will load js or json depending on which one is present, in the case
     // both json and js are present it loads js first.
-    configFiles: [".achecker.yml", ".achecker.yaml", "achecker", pathLib.join(".config", ".achecker.yml"), pathLib.join(".config", ".achecker.yaml"), pathLib.join(".config", "achecker")],
+    configFiles: [".achecker.yml", ".achecker.yaml", "achecker", "aceconfig", pathLib.join(".config", ".achecker.yml"), pathLib.join(".config", ".achecker.yaml"), pathLib.join(".config", "achecker"), pathLib.join(".config", "aceconfig")],
 
     // Specify the Base Accessibility Server URL
     baseA11yServerURL: "https://able.ibm.com/rules",

--- a/karma-accessibility-checker/src/lib/ACConstants.js
+++ b/karma-accessibility-checker/src/lib/ACConstants.js
@@ -82,7 +82,7 @@ var constants = {
     //  ./.config/achecker.json
     // The node module, require will load js or json depending on which one is present, in the case
     // both json and js are present it loads js first.
-    configFiles: [".achecker.yml", ".achecker.yaml", "achecker", pathLib.join(".config", ".achecker.yml"), pathLib.join(".config", ".achecker.yaml"), pathLib.join(".config", "achecker")],
+    configFiles: [".achecker.yml", ".achecker.yaml", "achecker", "aceconfig", pathLib.join(".config", ".achecker.yml"), pathLib.join(".config", ".achecker.yaml"), pathLib.join(".config", "achecker"), pathLib.join(".config", "aceconfig")],
 
     // Specify the travis CI server to be used to build the slack notification links based of
     travisServer: "https://travis-ci.org/",


### PR DESCRIPTION
Add aceconfig.js as a potential configuration filename since achecker.js can be confused on Windows as the commandline argument name