### PR TITLE
Color contrast corner case

### DIFF
--- a/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-color-rules.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-color-rules.ts
@@ -52,7 +52,10 @@ let a11yRulesColor: Rule[] = [
                 return null;
             }
             let style = win.getComputedStyle(ruleContext);
-
+            if (style.position === "absolute" && style.clip === "rect(0px, 0px, 0px, 0px)" && style.overflow !== "visible") {
+                // Corner case where item is hidden (accessibility hiding technique)
+                return null;
+            }
             // First determine the color contrast ratio
             let colorCombo = RPTUtil.ColorCombo(ruleContext);
             let fg = colorCombo.fg;

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/Color-usingInline.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/Color-usingInline.html
@@ -99,6 +99,8 @@
     <div style="color:black; background-color: rgba(0,0,0,.6); font-size: 18pt; font-weight: bold ">This text is pass - div[52].</div>
     <div style="color:black; background-color: rgba(0,0,0,.6); font-size: 1.5em; font-weight: bold">This text is pass - div[53].</div>
     <div style="color:black; background-color: rgba(0,0,0,.6); font-size: 150%; font-weight: bold">This text is pass - div[54].</div>
+
+    <div style="color: black; background-color: rgb(51, 51, 51); position:absolute; clip: rect(0,0,0,0); overflow:hidden">This text is pass - div[55].</div>
 <a name="navskip"></a>
 
 


### PR DESCRIPTION
Some usage of accessibility text uses a clip rect of 0,0,0,0. Do not flag color contrast since the text won't be visible