### PR TITLE
fix(cypress-accessibility-checker): update peer dependencies

### DIFF
--- a/cypress-accessibility-checker/package.json
+++ b/cypress-accessibility-checker/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "SEE LICENSE IN LICENSE from the 'equal-access' repository",
   "peerDependencies": {
-    "cypress": "^3 || ^4"
+    "cypress": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
   },
   "devDependencies": {
     "cypress": "^5.2.0",


### PR DESCRIPTION
update peer dependencies for use in NPM7

Fixes #483 

Alternative approach could be
```
  "peerDependencies": {
    "cypress": ">= 3.0.0"
  },
```

The benefit of this would be that nobody will need to explicitly add 9, 10, etc.

The down side is that those versions may or may not be compatible.