### PR TITLE
updating formatting and wording for help and messages

### DIFF
--- a/accessibility-checker-engine/help/Rpt_Aria_RequiredParent_Native_Host_Sematics.mdx
+++ b/accessibility-checker-engine/help/Rpt_Aria_RequiredParent_Native_Host_Sematics.mdx
@@ -8,11 +8,11 @@ import { CodeSnippet, Tag } from "carbon-components-react";
 <Row>
 <Column colLg={16} colMd={8} colSm={4} className="toolHead">
 
-### An element with ARIA role `{0}` is not contained in or owned by an element with one of the following ARIA roles: `{1}`
+### The element with role `"{0}"` is not contained in or owned by an element with one of the following roles: `"{1}"`
 
 <div id="locLevel"></div>
 
-An element with ARIA role must be contained within a valid element
+An element with an implicit or explicit role must be contained within a valid element
 
 </Column>
 </Row>
@@ -21,7 +21,7 @@ An element with ARIA role must be contained within a valid element
 
 ### Why is this important?
 
-If a ARIA `role` attribute is specified for an element, any ARIA parent element that is required for that role must also be set for the element. If the parent element's native ARIA role satisfies the requirement this role does not have to be explicitly set. Without the required parent element, assistive technologies may not be able to accurately represent or interact with the element.
+If an ARIA `'role'` attribute is specified for an element, any parent element that is required for that role must also be present, either in a parent-child relationship between DOM elements or by using `'aria-owns'`. If the parent element's implicit role satisfies the requirement (e.g., `<button>`), this role does not have to be explicitly set with ARIA. Without the required parent element, assistive technologies may not be able to accurately represent or interact with the element.
 
 <div id="locSnippet"></div>
 

--- a/accessibility-checker-engine/src/v2/checker/accessibility/nls/index.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/nls/index.ts
@@ -755,13 +755,13 @@ let a11yNls = {
     "Rpt_Aria_RequiredChildren_Native_Host_Sematics": {
         0: "An element with a ARIA role must contain required children",
         "Pass_0": "Rule Passed",
-        "Potential_1": "The element with ARIA role of \"{0}\" does not contain or own at least one child element with each of the following ARIA roles: \"{1}\""
+        "Potential_1": "The element with role \"{0}\" does not contain or own at least one child element with each of the following roles: \"{1}\""
     },
     // JCH - DONE
     "Rpt_Aria_RequiredParent_Native_Host_Sematics": {
-        0: "An element with a ARIA role must be contained within a valid element",
+        0: "An element with an implicit or explicit role must be contained within a valid element",
         "Pass_0": "Rule Passed",
-        "Fail_1": "The element with \"{0}\" role is not contained in or owned by an element with one of the following ARIA roles: \"{1}\""
+        "Fail_1": "The element with \"{0}\" role is not contained in or owned by an element with one of the following roles: \"{1}\""
     },
     // JCH - DONE
     "Rpt_Aria_EventHandlerMissingRole_Native_Host_Sematics": {


### PR DESCRIPTION
Modified use of "role" for when it is an attribute in regard to a11y hierarchy
Rephrased to try to make things clearer in regard to implicit and explicit roles.
Removed ARIA in many places to reduce the implicit/explicit 'confusion'