### PR TITLE
now checkboxes retain their values when a new scan occurs

### DIFF
--- a/accessibility-checker-extension/src/ts/devtools/DevToolsPanelApp.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/DevToolsPanelApp.tsx
@@ -109,7 +109,7 @@ export default class DevToolsPanelApp extends React.Component<IPanelProps, IPane
         rulesets: null,
         learnMore: false,
         learnItem: null,
-        showIssueTypeFilter: [true, false, false, false],
+        showIssueTypeFilter: [true, true, true, true],
         scanning: false,
         storedScans: [],
         storedScanCount: 0,
@@ -269,8 +269,8 @@ export default class DevToolsPanelApp extends React.Component<IPanelProps, IPane
                     self.selectElementInElements();
                 }
                 self.setState({ rulesets: rulesets, listenerRegistered: true, tabURL: tab.url, 
-                    tabId: tab.id, tabTitle: tab.title, showIssueTypeFilter: [true, true, true, true], 
-                    error: null, archives, selectedArchive: archiveId, selectedPolicy: policyName });
+                    tabId: tab.id, tabTitle: tab.title, error: null, archives, selectedArchive: archiveId, 
+                    selectedPolicy: policyName });
             }
         });
     }

--- a/accessibility-checker-extension/src/ts/devtools/Header.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/Header.tsx
@@ -474,12 +474,13 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
             <div className={this.props.layout === "main"?"countRow summary mainPanel":"countRow summary subPanel"} role="region" aria-label='Issue count' style={{ marginTop: "14px" }}>
                 <div className="countItem" style={{ paddingTop: "0", paddingLeft: "0", paddingBottom: "0", height: "34px", textAlign: "left", overflow: "visible" }}>
                     <span data-tip data-for="filterViolationsTip" style={{ display: "inline-block", verticalAlign: "middle", paddingTop: "4px", paddingRight: "8px" }}>
+                        {console.log("In Header before <Checkbox>s dataFromParent = ",this.props.dataFromParent)}
                         <Checkbox 
                             className="checkboxLabel"
                             disabled={!this.props.counts}
                             // title="Filter violations" // used react tooltip so all tooltips the same
                             aria-label="Filter by violations"
-                            defaultChecked
+                            checked={this.props.dataFromParent[1]}
                             id="Violations"
                             indeterminate={false}
                             labelText={<React.Fragment><img src={Violation16} style={{ verticalAlign: "middle", paddingTop: "0px", marginRight: "4px" }} alt="Violations" /><span className="summaryBarCounts" >{noScan ? ((bDiff ? counts.filtered["Violation"] + "/" : "") + counts.total["Violation"]) : " "}<span className="summaryBarLabels" style={{ marginLeft: "4px" }}>Violations</span></span></React.Fragment>}
@@ -499,7 +500,7 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
                             disabled={!this.props.counts}
                             // title="Filter needs review"
                             aria-label="Filter by needs review"
-                            defaultChecked
+                            checked={this.props.dataFromParent[2]}
                             id="NeedsReview"
                             indeterminate={false}
                             labelText={<React.Fragment><img src={NeedsReview16} style={{ verticalAlign: "middle", paddingTop: "0px", marginRight: "4px" }} alt="Needs review" /><span className="summaryBarCounts" >{noScan ? ((bDiff ? counts.filtered["Needs review"] + "/" : "") + counts.total["Needs review"]) : " "}<span className="summaryBarLabels" style={{ marginLeft: "4px" }}>Needs review</span></span></React.Fragment>}
@@ -519,7 +520,7 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
                             disabled={!this.props.counts}
                             // title="Filter recommendations"
                             aria-label="Filter by recommendations"
-                            defaultChecked
+                            checked={this.props.dataFromParent[3]}
                             id="Recommendations"
                             indeterminate={false}
                             labelText={<React.Fragment><img src={Recommendation16} style={{ verticalAlign: "middle", paddingTop: "0px", marginRight: "4px" }} alt="Recommendations" /><span className="summaryBarCounts" >{noScan ? ((bDiff ? counts.filtered["Recommendation"] + "/" : "") + counts.total["Recommendation"]) : " "}<span className="summaryBarLabels" style={{ marginLeft: "4px" }}>Recommendations</span></span></React.Fragment>}


### PR DESCRIPTION
Note: this is issue #470 in equal-access, E2E #3731