### PR TITLE
Update implicit role calculations in ARIAMapper

### DIFF
--- a/accessibility-checker-engine/README.md
+++ b/accessibility-checker-engine/README.md
@@ -111,7 +111,7 @@ The accessibility report is in JSON format, and contains information about the i
                     // xpath
                     "dom": "/html[1]",
                     // path of ARIA roles
-                    "aria": ""
+                    "aria": "/document[1]"
                 },
                 "ruleTime": 0,
                 // Generated message

--- a/accessibility-checker-engine/src/v2/aria/ARIAMapper.ts
+++ b/accessibility-checker-engine/src/v2/aria/ARIAMapper.ts
@@ -579,36 +579,33 @@ export class ARIAMapper extends CommonMapper {
         }
         return false;
     }
-
+    
     private static inputToRoleMap = (function() {
-        let menuButtonCheck = function(element) {
-            return ARIAMapper.hasParentRole(element, "menu") ? "menuitem" : "button";
-        };
-        let textSuggestions = function(element) {
+        let hasList = function(element) {
             if (element.hasAttribute("list")) {
                 let id = element.getAttribute("list");
                 let idRef = FragmentUtil.getById(element, id);
                 if (idRef && idRef.nodeName.toLowerCase() === "datalist") {
-                    return "combobox";
+                    return true;
                 }
             }
-            return "textbox";
+            return false;
+        };
+        let textSuggestions = function(element) {
+            return hasList(element) ? "combobox" : "textbox";
         }
         return {
-            "button": menuButtonCheck,
-            "image": menuButtonCheck,
-            "checkbox": function(element) {
-                return ARIAMapper.hasParentRole(element, "menu") ? "menuitemcheckbox" : "checkbox";
-            },
-            "radio": function(element) {
-                return ARIAMapper.hasParentRole(element, "menu") ? "menuitemradio" : "radio";
-            },
+            "button": "button",
+            "image": "button",
+            "checkbox": "checkbox",
+            "radio": "radio",
             "email": textSuggestions,
-            "search": textSuggestions,
+            "search": function(element) {
+                return hasList(element) ? "combobox" : "searchbox";
+            },
             "tel": textSuggestions,
             "text": textSuggestions,
             "url": textSuggestions,
-            "password": "textbox",
             "number": "spinbutton",
             "range": "slider",
             "reset": "button",
@@ -662,8 +659,7 @@ export class ARIAMapper extends CommonMapper {
             "a": function(element) {
                 // If it doesn't represent a hyperlink, no corresponding role
                 if (!element.hasAttribute("href")) return null;
-                // If link is in a menu, it's a menuitem, otherwise it's a link
-                return ARIAMapper.hasParentRole(element, "menu") ? "menuitem" : "link";
+                return "link";
             },
             "area": function(element) {
                 // If it doesn't represent a hyperlink, no corresponding role
@@ -672,26 +668,32 @@ export class ARIAMapper extends CommonMapper {
             },
             "article": "article",
             "aside": "complementary",
-            "body": "document",
             "button": "button",
             "datalist": "listbox",
             "dd": "definition",
             "details": "group",
+            "dfn": "term",
             "dialog": "dialog",
+            "dt": "term",
+            "fieldset": "group",
+            "figure": "figure",
             "footer": function(element) {
                 let parent = DOMUtil.parentNode(element);
-                let nodeName = parent.nodeName.toLowerCase();
                 // If nearest sectioningRoot or sectioningContent is body
-                while (parent) {
+                while (parent && parent.nodeType === 1) {
+                    let nodeName = parent.nodeName.toLowerCase();
                     if (sectioningRoots[nodeName] || sectioningContent[nodeName]) {
                         return (nodeName === "body") ? "contentinfo" : null;
                     }
                     parent = DOMUtil.parentNode(parent);
-                    nodeName = parent.nodeName.toLowerCase();
                 }
                 return null;
             },
-            "form": "form",
+            "form": function(element) {
+                let name = ARIAMapper.computeName(element);
+                return (name && name.trim().length > 0) ? "form" : null;
+            },
+            // TODO "form-associated custom element"
             "h1": "heading",
             "h2": "heading",
             "h3": "heading",
@@ -711,6 +713,7 @@ export class ARIAMapper extends CommonMapper {
                 return null;
             },
             "hr": "separator",
+            "html": "document",
             "img": function(element) {
                 if (element.hasAttribute("alt") && element.getAttribute("alt").length === 0) {
                     return "presentation";
@@ -719,53 +722,39 @@ export class ARIAMapper extends CommonMapper {
                 }
             },
             "input": inputToRole,
-            "keygen": "listbox",
+            "keygen": "listbox", // deprecated, but keep for backward compat
             "li": "listitem",
             "main": "main",
             "math": "math",
-            "menu": function(element) {
-                if (!element.hasAttribute("type")) return null;
-                let eType = element.getAttribute("type").toLowerCase();
-                if (eType === "context") return "menu";
-                if (eType === "toolbar") return "toolbar";
-                return null;
-            },
-            "menuitem": function(element) {
-                // Default type is command
-                if (!element.hasAttribute("type")) return "menuitem";
-                let eType = element.getAttribute("type").toLowerCase();
-                if (eType.trim().length === 0) return "menuitem";
-
-                if (eType === "command") return "menuitem";
-                if (eType === "checkbox") return "menuitemcheckbox";
-                if (eType === "radio") return "menuitemradio";
-                return null;
-            },
-            "meter": "progressbar",
+            "menu": "list",
             "nav": "navigation",
             "ol": "list",
             "optgroup": "group",
             "option": "option",
             "output": "status",
             "progress": "progressbar",
-            "section": "region",
+            "section": function(element) {
+                let name = ARIAMapper.computeName(element);
+                return (name && name.trim().length > 0) ? "region" : null;
+            },
             "select": function(element) {
-                if (element.hasAttribute("multiple") || (element.hasAttribute("size") && parseInt(element.getAttribute("size")) > 1)) {
+                if (element.hasAttribute("multiple") || (RPTUtil.attributeNonEmpty(element, "size") && parseInt(element.getAttribute("size")) > 1)) {
                     return "listbox";
                 } else {
                     return "combobox";
                 }
             },
+            "summary": "button",
+            "svg": "graphics-document",
             "table": "table",
-            "textarea": "textbox",
             "tbody": "rowgroup",
+            "textarea": "textbox",
             "td": function(element) {
                 let parent = DOMUtil.parentNode(element);
                 while (parent) {
                     let role = ARIAMapper.nodeToRole(parent);
                     if (role === "table") return "cell";
-                    if (role === "grid") return "gridcell";
-
+                    if (role === "grid" || role === "treegrid") return "gridcell";
                     parent = DOMUtil.parentNode(parent);
                 }
                 return null;
@@ -802,8 +791,8 @@ export class ARIAMapper extends CommonMapper {
                     
                     // scope is auto, default (without a scope) or invalid value.
                     // if all the sibling elements are th, then return "columnheader" 
-                    var siblings = element => [...element.parentElement.children].filter(node=>node.nodeType == 1 && node.tagName != "TH");
-                    if (siblings == null || siblings.length == 0)
+                    var siblings = element => [...element.parentElement.children].filter(node=>node.nodeType === 1 && node.tagName != "TH");
+                    if (siblings === null || siblings.length === 0)
                         return "columnheader"; 
                     else return "rowheader";
                     

--- a/accessibility-checker-engine/src/v2/aria/ARIAMapper.ts
+++ b/accessibility-checker-engine/src/v2/aria/ARIAMapper.ts
@@ -372,6 +372,21 @@ export class ARIAMapper extends CommonMapper {
                 return accumulated.trim();
             }
         }
+
+        // Since nodeToRole calls back here for form and section, we need special casing here to handle those two cases
+        if (["section", "form"].includes(cur.nodeName.toLowerCase())) {
+            if (elem.hasAttribute("aria-label") && elem.getAttribute("aria-label").trim().length > 0) {
+                // If I'm not an embedded control or I'm not recursing, return the aria-label
+                if (!labelledbyTraverse && !walkTraverse) {
+                    return elem.getAttribute("aria-label").trim();
+                }
+            }
+            if (elem.hasAttribute("title")) {
+                return elem.getAttribute("title");
+            }
+            return "";
+        }
+
         // 2c. If label or walk, and this is a control, skip to the value, otherwise provide the label
         const role = ARIAMapper.nodeToRole(cur);
         let isEmbeddedControl = [

--- a/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-img-rules.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-img-rules.ts
@@ -437,6 +437,7 @@ let a11yRulesImg: Rule[] = [
         context: "aria:graphics-document,aria:graphics-symbol",
         run: (context: RuleContext, options?: {}): RuleResult | RuleResult[] => {
             const ruleContext = context["dom"].node as Element;
+            if (!ruleContext.hasAttribute("role") || !ruleContext.getAttribute("role").includes("graphics-")) return null;
             /* removed the role check role= presentation since if an element has role=img, then there needs to be a check for alt attribute regardless of the presecne of role=presentation
             if (RPTUtil.hasRole(ruleContext, "presentation") || RPTUtil.hasRole(ruleContext, "none")){
                     return RulePass(1);

--- a/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-input-rules.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-input-rules.ts
@@ -30,7 +30,7 @@ let a11yRulesInput: Rule[] = [
         id: "WCAG20_Input_ExplicitLabel",
         context: "aria:button,aria:checkbox,aria:combobox,aria:listbox,aria:menuitemcheckbox"
             +",aria:menuitemradio,aria:radio,aria:searchbox,aria:slider,aria:spinbutton"
-            +",aria:switch,aria:textbox,aria:progressbar,dom:input[type=file],dom:output", 
+            +",aria:switch,aria:textbox,aria:progressbar,dom:input[type=file],dom:output,dom:meter,dom:input[type=password]", 
         // the datalist element do not require any explicit or implicit label, might need to exclude it from the scope of the rules
         run: (context: RuleContext, options?: {}): RuleResult | RuleResult[] => {
             const ruleContext = context["dom"].node as Element;

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_ImgAlt_ruleunit/ACT_76d734_pass_2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_ImgAlt_ruleunit/ACT_76d734_pass_2.html
@@ -25,40 +25,32 @@
 </head>
 
 <body id="id-9" aria-atomic="true">
-  <p>How many circles are there?</p>
-<svg xmlns="https://www.w3.org/2000/svg">
-	<circle
-		role="graphics-symbol"
-		cx="50"
-		cy="50"
-		r="40"
-		stroke="green"
-		stroke-width="4"
-		fill="yellow"
-		aria-label="1 circle"
-	></circle>
-</svg>
+    <p>How many circles are there?</p>
+    <svg xmlns="https://www.w3.org/2000/svg">
+        <circle role="graphics-symbol" cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow"
+            aria-label="1 circle"></circle>
+    </svg>
 
     <script type="text/javascript">
         UnitTest = {
             ruleIds: ["HAAC_Aria_SvgAlt"],
             results: [
-            {
-            "ruleId": "HAAC_Aria_SvgAlt",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/svg[1]/circle[1]",
-              "aria": "/document[1]/graphics-symbol[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
+                {
+                    "ruleId": "HAAC_Aria_SvgAlt",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/svg[1]/circle[1]",
+                        "aria": "/document[1]/graphics-document[1]/graphics-symbol[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                }
             ]
         }
     </script>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_ImgAlt_ruleunit/D3494_svg_title_subtext.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_ImgAlt_ruleunit/D3494_svg_title_subtext.html
@@ -25,13 +25,15 @@
 </head>
 
 <body id="id-9" aria-atomic="true">
-  <svg id="target"><title><g>Time II: Party</g></title></svg>
+    <svg id="target">
+        <title>
+            <g>Time II: Party</g>
+        </title>
+    </svg>
     <script type="text/javascript">
         UnitTest = {
             ruleIds: ["HAAC_Aria_SvgAlt"],
-            results: [
-            
-            ]
+            results: []
         }
     </script>
 </body>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/D1027.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/D1027.html
@@ -113,1246 +113,1246 @@
         UnitTest = {
             ruleIds: ["aria_semantics_role", "aria_semantics_attribute"],
             results: [
-            {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[1]",
-              "aria": "/document[1]/main[1]/region[1]/separator[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "separator",
-              "div"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_attribute",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[1]",
-              "aria": "/document[1]/main[1]/region[1]/separator[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "aria-labelledby, aria-label",
-              "div",
-              "separator"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/div[1]/input[1]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "combobox",
-              "input"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_attribute",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/div[1]/input[1]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "aria-autocomplete, aria-expanded, aria-haspopup, aria-owns",
-              "input",
-              "combobox"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_attribute",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/div[1]/button[1]",
-              "aria": "/document[1]/main[1]/region[1]/button[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "aria-label",
-              "button",
-              "button"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "listbox",
-              "ul"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_attribute",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "aria-label",
-              "ul",
-              "listbox"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[1]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[2]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[2]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[3]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[3]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[4]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[4]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[5]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[5]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[6]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[6]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[7]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[7]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[8]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[8]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[9]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[9]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[10]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[10]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[11]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[11]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[12]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[12]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[13]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[13]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[14]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[14]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[15]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[15]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[16]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[16]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[17]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[17]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[18]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[18]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[19]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[19]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[20]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[20]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[21]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[21]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[22]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[22]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[23]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[23]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[24]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[24]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[25]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[25]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[26]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[26]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[27]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[27]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[28]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[28]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[29]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[29]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[30]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[30]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[31]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[31]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[32]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[32]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[33]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[33]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[34]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[34]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[35]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[35]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[36]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[36]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[37]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[37]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[38]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[38]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[39]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[39]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[40]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[40]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[41]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[41]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[42]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[42]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[43]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[43]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[44]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[44]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[45]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[45]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[46]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[46]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[47]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[47]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[48]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[48]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[49]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[49]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[50]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[50]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[51]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[51]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[52]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[52]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[53]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[53]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[54]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[54]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[55]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[55]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[56]",
-              "aria": "/document[1]/main[1]/region[1]/combobox[1]/listbox[1]/option[56]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "option",
-              "li"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_role",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[3]",
-              "aria": "/document[1]/main[1]/region[1]/separator[2]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "separator",
-              "div"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_semantics_attribute",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/section[1]/div[3]",
-              "aria": "/document[1]/main[1]/region[1]/separator[2]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "aria-labelledby, aria-label",
-              "div",
-              "separator"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[1]",
+                        "aria": "/document[1]/main[1]/separator[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "separator",
+                        "div"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_attribute",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[1]",
+                        "aria": "/document[1]/main[1]/separator[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "aria-labelledby, aria-label",
+                        "div",
+                        "separator"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/div[1]/input[1]",
+                        "aria": "/document[1]/main[1]/combobox[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "combobox",
+                        "input"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_attribute",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/div[1]/input[1]",
+                        "aria": "/document[1]/main[1]/combobox[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "aria-autocomplete, aria-expanded, aria-haspopup, aria-owns",
+                        "input",
+                        "combobox"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_attribute",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/div[1]/button[1]",
+                        "aria": "/document[1]/main[1]/button[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "aria-label",
+                        "button",
+                        "button"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "listbox",
+                        "ul"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_attribute",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "aria-label",
+                        "ul",
+                        "listbox"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[1]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[2]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[2]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[3]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[3]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[4]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[4]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[5]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[5]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[6]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[6]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[7]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[7]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[8]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[8]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[9]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[9]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[10]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[10]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[11]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[11]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[12]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[12]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[13]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[13]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[14]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[14]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[15]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[15]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[16]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[16]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[17]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[17]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[18]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[18]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[19]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[19]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[20]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[20]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[21]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[21]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[22]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[22]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[23]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[23]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[24]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[24]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[25]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[25]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[26]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[26]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[27]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[27]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[28]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[28]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[29]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[29]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[30]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[30]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[31]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[31]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[32]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[32]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[33]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[33]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[34]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[34]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[35]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[35]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[36]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[36]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[37]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[37]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[38]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[38]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[39]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[39]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[40]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[40]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[41]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[41]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[42]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[42]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[43]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[43]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[44]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[44]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[45]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[45]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[46]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[46]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[47]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[47]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[48]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[48]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[49]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[49]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[50]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[50]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[51]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[51]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[52]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[52]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[53]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[53]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[54]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[54]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[55]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[55]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[2]/div[1]/ul[1]/li[56]",
+                        "aria": "/document[1]/main[1]/combobox[1]/listbox[1]/option[56]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "option",
+                        "li"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_role",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[3]",
+                        "aria": "/document[1]/main[1]/separator[2]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "separator",
+                        "div"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_semantics_attribute",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/section[1]/div[3]",
+                        "aria": "/document[1]/main[1]/separator[2]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [
+                        "aria-labelledby, aria-label",
+                        "div",
+                        "separator"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                }
             ]
         }
     </script>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/InValidRoleInvalidAttribute.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/InValidRoleInvalidAttribute.html
@@ -215,7 +215,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]",
-                        "aria": "/status[1]/document[2]"
+                        "aria": "/status[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'test' is not valid for the element <body>",
@@ -234,7 +234,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]",
-                        "aria": "/status[1]/document[2]"
+                        "aria": "/status[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -253,7 +253,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[2]",
-                        "aria": "/status[1]/document[2]/contentinfo[1]"
+                        "aria": "/status[1]/contentinfo[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'contentinfo' is not valid for the element <a>",
@@ -272,7 +272,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[3]",
-                        "aria": "/status[1]/document[2]"
+                        "aria": "/status[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -291,7 +291,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[3]",
-                        "aria": "/status[1]/document[2]"
+                        "aria": "/status[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA attribute 'aria-activedescendant' is not valid for the element <a> with ARIA role 'none'",
@@ -311,7 +311,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/address[1]",
-                        "aria": "/status[1]/document[2]/link[2]"
+                        "aria": "/status[1]/link[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -330,7 +330,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/map[1]/area[1]",
-                        "aria": "/status[1]/document[2]/link[3]"
+                        "aria": "/status[1]/link[3]"
                     },
                     "reasonId": "Fail_2",
                     "message": "The ARIA role 'presentation' is not valid for the element <area> and may be ignored by the browser since the element is focusable",
@@ -349,7 +349,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]",
-                        "aria": "/status[1]/document[2]/note[1]"
+                        "aria": "/status[1]/note[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'note' is not valid for the element <article>",
@@ -368,7 +368,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]",
-                        "aria": "/status[1]/document[2]/note[1]/article[1]"
+                        "aria": "/status[1]/note[1]/article[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'article' is not valid for the element <header>",
@@ -387,7 +387,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/h1[1]",
-                        "aria": "/status[1]/document[2]/note[1]/article[1]/heading[1]"
+                        "aria": "/status[1]/note[1]/article[1]/heading[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'section' is not valid for the element <h1>",
@@ -406,7 +406,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]",
-                        "aria": "/status[1]/document[2]/note[1]/article[1]"
+                        "aria": "/status[1]/note[1]/article[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -425,7 +425,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]/strong[1]",
-                        "aria": "/status[1]/document[2]/note[1]/article[1]"
+                        "aria": "/status[1]/note[1]/article[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -444,7 +444,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/aside[1]",
-                        "aria": "/status[1]/document[2]/main[1]"
+                        "aria": "/status[1]/main[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'main' is not valid for the element <aside>",
@@ -463,7 +463,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/audio[1]",
-                        "aria": "/status[1]/document[2]/checkbox[1]"
+                        "aria": "/status[1]/checkbox[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'checkbox' is not valid for the element <audio>",
@@ -482,7 +482,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[1]",
-                        "aria": "/status[1]/document[2]/img[1]"
+                        "aria": "/status[1]/img[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'img' is not valid for the element <button>",
@@ -501,7 +501,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[2]",
-                        "aria": "/status[1]/document[2]/radio[1]"
+                        "aria": "/status[1]/radio[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -520,7 +520,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]"
+                        "aria": "/status[1]/textbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -539,7 +539,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/caption[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]/textbox[1]"
+                        "aria": "/status[1]/textbox[1]/textbox[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'textbox' is not valid for the element <caption>",
@@ -558,7 +558,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/colgroup[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]/option[1]"
+                        "aria": "/status[1]/textbox[1]/option[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'option' is not valid for the element <colgroup>",
@@ -577,7 +577,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/colgroup[1]/col[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]/option[1]"
+                        "aria": "/status[1]/textbox[1]/option[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'alertdialog' is not valid for the element <col>",
@@ -596,7 +596,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/tbody[1]/tr[1]/th[1]/dialog[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]/rowgroup[1]/row[1]/list[1]"
+                        "aria": "/status[1]/textbox[1]/rowgroup[1]/row[1]/list[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'list' is not valid for the element <dialog>",
@@ -615,7 +615,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/status[1]/document[2]/form[1]/menuitem[1]"
+                        "aria": "/status[1]/menuitem[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'menuitem' is not valid for the element <datalist>",
@@ -634,7 +634,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]",
-                        "aria": "/status[1]/document[2]/alertdialog[1]"
+                        "aria": "/status[1]/alertdialog[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'alertdialog' is not valid for the element <dl>",
@@ -653,7 +653,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dt[1]",
-                        "aria": "/status[1]/document[2]/alertdialog[1]/img[1]"
+                        "aria": "/status[1]/alertdialog[1]/img[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'img' is not valid for the element <dt>",
@@ -672,7 +672,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dd[1]",
-                        "aria": "/status[1]/document[2]/alertdialog[1]"
+                        "aria": "/status[1]/alertdialog[1]"
                     },
                     "reasonId": "Fail_2",
                     "message": "The ARIA role 'presentation' is not valid for the element <dd> and may be ignored by the browser since the element is focusable",
@@ -691,7 +691,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]",
-                        "aria": "/status[1]/document[2]/dialog[1]"
+                        "aria": "/status[1]/dialog[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'dialog' is not valid for the element <details>",
@@ -710,7 +710,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/p[1]",
-                        "aria": "/status[1]/document[2]/dialog[1]"
+                        "aria": "/status[1]/dialog[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -729,7 +729,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/hr[1]",
-                        "aria": "/status[1]/document[2]/dialog[1]/document[1]"
+                        "aria": "/status[1]/dialog[1]/document[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'document' is not valid for the element <hr>",
@@ -748,7 +748,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/embed[1]",
-                        "aria": "/status[1]/document[2]/list[1]"
+                        "aria": "/status[1]/list[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'list' is not valid for the element <embed>",
@@ -767,7 +767,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]",
-                        "aria": "/status[1]/document[2]/tab[1]"
+                        "aria": "/status[1]/tab[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'tab' is not valid for the element <form>",
@@ -786,7 +786,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/status[1]/document[2]/tab[1]"
+                        "aria": "/status[1]/tab[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'section' is not valid for the element <fieldset>",
@@ -805,7 +805,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/status[1]/document[2]"
+                        "aria": "/status[1]/figure[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -824,7 +824,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/footer[1]",
-                        "aria": "/status[1]/document[2]/search[1]"
+                        "aria": "/status[1]/search[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'search' is not valid for the element <footer>",
@@ -843,7 +843,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/status[1]/document[2]/document[1]"
+                        "aria": "/status[1]/document[2]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'document' is not valid for the element <input>",
@@ -862,7 +862,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[2]",
-                        "aria": "/status[1]/document[2]/application[1]"
+                        "aria": "/status[1]/application[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'application' is not valid for the element <input>",
@@ -881,7 +881,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/ol[1]/li[1]",
-                        "aria": "/status[1]/document[2]/list[2]/status[1]"
+                        "aria": "/status[1]/list[2]/status[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'status' is not valid for the element <li>",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/InValidRoleSpecified.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/InValidRoleSpecified.html
@@ -215,7 +215,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]",
-                        "aria": "/status[1]/document[2]"
+                        "aria": "/status[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'test' is not valid for the element <body>",
@@ -234,7 +234,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]",
-                        "aria": "/status[1]/document[2]"
+                        "aria": "/status[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -253,7 +253,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[2]",
-                        "aria": "/status[1]/document[2]/contentinfo[1]"
+                        "aria": "/status[1]/contentinfo[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'contentinfo' is not valid for the element <a>",
@@ -272,7 +272,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[3]",
-                        "aria": "/status[1]/document[2]"
+                        "aria": "/status[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -291,7 +291,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/address[1]",
-                        "aria": "/status[1]/document[2]/link[2]"
+                        "aria": "/status[1]/link[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -310,7 +310,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/map[1]/area[1]",
-                        "aria": "/status[1]/document[2]/link[3]"
+                        "aria": "/status[1]/link[3]"
                     },
                     "reasonId": "Fail_2",
                     "message": "The ARIA role 'presentation' is not valid for the element <area> and may be ignored by the browser since the element is focusable",
@@ -329,7 +329,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]",
-                        "aria": "/status[1]/document[2]/note[1]"
+                        "aria": "/status[1]/note[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'note' is not valid for the element <article>",
@@ -348,7 +348,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]",
-                        "aria": "/status[1]/document[2]/note[1]/article[1]"
+                        "aria": "/status[1]/note[1]/article[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'article' is not valid for the element <header>",
@@ -367,7 +367,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/h1[1]",
-                        "aria": "/status[1]/document[2]/note[1]/article[1]/heading[1]"
+                        "aria": "/status[1]/note[1]/article[1]/heading[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'section' is not valid for the element <h1>",
@@ -386,7 +386,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]",
-                        "aria": "/status[1]/document[2]/note[1]/article[1]"
+                        "aria": "/status[1]/note[1]/article[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -405,7 +405,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]/strong[1]",
-                        "aria": "/status[1]/document[2]/note[1]/article[1]"
+                        "aria": "/status[1]/note[1]/article[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -424,7 +424,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/aside[1]",
-                        "aria": "/status[1]/document[2]/main[1]"
+                        "aria": "/status[1]/main[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'main' is not valid for the element <aside>",
@@ -443,7 +443,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/audio[1]",
-                        "aria": "/status[1]/document[2]/checkbox[1]"
+                        "aria": "/status[1]/checkbox[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'checkbox' is not valid for the element <audio>",
@@ -462,7 +462,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[1]",
-                        "aria": "/status[1]/document[2]/img[1]"
+                        "aria": "/status[1]/img[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'img' is not valid for the element <button>",
@@ -481,7 +481,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[2]",
-                        "aria": "/status[1]/document[2]/menu[1]"
+                        "aria": "/status[1]/menu[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'menu' is not valid for the element <button>",
@@ -500,7 +500,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]"
+                        "aria": "/status[1]/textbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -519,7 +519,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/caption[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]/textbox[1]"
+                        "aria": "/status[1]/textbox[1]/textbox[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'textbox' is not valid for the element <caption>",
@@ -538,7 +538,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/colgroup[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]/option[1]"
+                        "aria": "/status[1]/textbox[1]/option[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'option' is not valid for the element <colgroup>",
@@ -557,7 +557,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/colgroup[1]/col[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]/option[1]"
+                        "aria": "/status[1]/textbox[1]/option[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'alertdialog' is not valid for the element <col>",
@@ -576,7 +576,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/tbody[1]/tr[1]/th[1]/dialog[1]",
-                        "aria": "/status[1]/document[2]/textbox[1]/rowgroup[1]/row[1]/list[1]"
+                        "aria": "/status[1]/textbox[1]/rowgroup[1]/row[1]/list[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'list' is not valid for the element <dialog>",
@@ -595,7 +595,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/status[1]/document[2]/form[1]/menuitem[1]"
+                        "aria": "/status[1]/menuitem[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'menuitem' is not valid for the element <datalist>",
@@ -614,7 +614,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]",
-                        "aria": "/status[1]/document[2]/alertdialog[1]"
+                        "aria": "/status[1]/alertdialog[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'alertdialog' is not valid for the element <dl>",
@@ -633,7 +633,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dt[1]",
-                        "aria": "/status[1]/document[2]/alertdialog[1]/img[1]"
+                        "aria": "/status[1]/alertdialog[1]/img[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'img' is not valid for the element <dt>",
@@ -652,7 +652,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dd[1]",
-                        "aria": "/status[1]/document[2]/alertdialog[1]"
+                        "aria": "/status[1]/alertdialog[1]"
                     },
                     "reasonId": "Fail_2",
                     "message": "The ARIA role 'presentation' is not valid for the element <dd> and may be ignored by the browser since the element is focusable",
@@ -671,7 +671,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]",
-                        "aria": "/status[1]/document[2]/dialog[1]"
+                        "aria": "/status[1]/dialog[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'dialog' is not valid for the element <details>",
@@ -690,7 +690,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/p[1]",
-                        "aria": "/status[1]/document[2]/dialog[1]"
+                        "aria": "/status[1]/dialog[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -709,7 +709,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/hr[1]",
-                        "aria": "/status[1]/document[2]/dialog[1]/document[1]"
+                        "aria": "/status[1]/dialog[1]/document[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'document' is not valid for the element <hr>",
@@ -728,7 +728,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/embed[1]",
-                        "aria": "/status[1]/document[2]/list[1]"
+                        "aria": "/status[1]/list[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'list' is not valid for the element <embed>",
@@ -747,7 +747,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]",
-                        "aria": "/status[1]/document[2]/tab[1]"
+                        "aria": "/status[1]/tab[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'tab' is not valid for the element <form>",
@@ -766,7 +766,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/status[1]/document[2]/tab[1]"
+                        "aria": "/status[1]/tab[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'section' is not valid for the element <fieldset>",
@@ -785,7 +785,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/status[1]/document[2]"
+                        "aria": "/status[1]/figure[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -804,7 +804,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/footer[1]",
-                        "aria": "/status[1]/document[2]/search[1]"
+                        "aria": "/status[1]/search[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'search' is not valid for the element <footer>",
@@ -823,7 +823,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/status[1]/document[2]/document[1]"
+                        "aria": "/status[1]/document[2]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'document' is not valid for the element <input>",
@@ -842,7 +842,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[2]",
-                        "aria": "/status[1]/document[2]/application[1]"
+                        "aria": "/status[1]/application[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'application' is not valid for the element <input>",
@@ -861,7 +861,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/ol[1]/li[1]",
-                        "aria": "/status[1]/document[2]/list[2]/status[1]"
+                        "aria": "/status[1]/list[2]/status[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'status' is not valid for the element <li>",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/InvalidAttribute.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/InvalidAttribute.html
@@ -146,7 +146,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -359,7 +359,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/document[1]/form[1]/listbox[1]"
+                        "aria": "/document[1]/listbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -399,14 +399,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dt[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/term[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-busy",
                         "dt",
-                        "none"
+                        "term"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -479,14 +479,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]",
-                        "aria": "/document[1]/form[2]"
+                        "aria": "/document[1]"
                     },
                     "reasonId": "Fail_1",
-                    "message": "The ARIA attribute 'aria-orientation' is not valid for the element <form> with ARIA role 'form'",
+                    "message": "The ARIA attribute 'aria-orientation' is not valid for the element <form> with ARIA role 'none'",
                     "messageArgs": [
                         "aria-orientation",
                         "form",
-                        "form"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -499,14 +499,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/document[1]/form[2]"
+                        "aria": "/document[1]/group[2]"
                     },
                     "reasonId": "Fail_1",
-                    "message": "The ARIA attribute 'aria-expanded' is not valid for the element <fieldset> with ARIA role 'none'",
+                    "message": "The ARIA attribute 'aria-expanded' is not valid for the element <fieldset> with ARIA role 'group'",
                     "messageArgs": [
                         "aria-expanded",
                         "fieldset",
-                        "none"
+                        "group"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -519,14 +519,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/figure[1]"
                     },
                     "reasonId": "Fail_1",
-                    "message": "The ARIA attribute 'aria-colindex' is not valid for the element <figure> with ARIA role 'none'",
+                    "message": "The ARIA attribute 'aria-colindex' is not valid for the element <figure> with ARIA role 'figure'",
                     "messageArgs": [
                         "aria-colindex",
                         "figure",
-                        "none"
+                        "figure"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -559,7 +559,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/document[1]/button[3]"
+                        "aria": "/document[1]/button[4]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidAttribute.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidAttribute.html
@@ -150,7 +150,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -363,7 +363,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/document[1]/form[1]/listbox[1]"
+                        "aria": "/document[1]/listbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -403,14 +403,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dt[1]",
-                        "aria": "/document[1]/list[1]"
+                        "aria": "/document[1]/list[1]/term[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-busy",
                         "dt",
-                        "none"
+                        "term"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -483,14 +483,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]",
-                        "aria": "/document[1]/form[2]"
+                        "aria": "/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-describedby",
                         "form",
-                        "form"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -503,14 +503,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/document[1]/form[2]"
+                        "aria": "/document[1]/group[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-busy",
                         "fieldset",
-                        "none"
+                        "group"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -523,14 +523,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/figure[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-atomic",
                         "figure",
-                        "none"
+                        "figure"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -563,7 +563,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/document[1]/button[3]"
+                        "aria": "/document[1]/button[4]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecified.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecified.html
@@ -148,7 +148,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -167,7 +167,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -186,7 +186,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[2]",
-                        "aria": "/document[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -205,7 +205,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[3]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -224,7 +224,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/address[1]",
-                        "aria": "/document[1]/contentinfo[1]"
+                        "aria": "/document[1]/document[1]/contentinfo[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -243,7 +243,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/map[1]/area[1]",
-                        "aria": "/document[1]/link[2]"
+                        "aria": "/document[1]/document[1]/link[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -262,7 +262,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -281,7 +281,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -300,7 +300,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/h1[1]",
-                        "aria": "/document[1]/main[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/main[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -319,7 +319,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -338,7 +338,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]/strong[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -357,7 +357,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[2]",
-                        "aria": "/document[1]/feed[1]"
+                        "aria": "/document[1]/document[1]/feed[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -376,7 +376,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/aside[1]",
-                        "aria": "/document[1]/complementary[1]"
+                        "aria": "/document[1]/document[1]/complementary[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -395,7 +395,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/aside[2]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -414,7 +414,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/audio[1]",
-                        "aria": "/document[1]/application[1]"
+                        "aria": "/document[1]/document[1]/application[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -433,7 +433,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[1]",
-                        "aria": "/document[1]/menuitemradio[1]"
+                        "aria": "/document[1]/document[1]/menuitemradio[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -452,7 +452,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[2]",
-                        "aria": "/document[1]/link[3]"
+                        "aria": "/document[1]/document[1]/link[3]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -471,7 +471,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]",
-                        "aria": "/document[1]/table[1]"
+                        "aria": "/document[1]/document[1]/table[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -490,7 +490,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/tbody[1]/tr[1]/th[1]/dialog[1]",
-                        "aria": "/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
+                        "aria": "/document[1]/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -509,7 +509,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/document[1]/form[1]/listbox[1]"
+                        "aria": "/document[1]/document[1]/listbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -528,7 +528,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]",
-                        "aria": "/document[1]/list[1]"
+                        "aria": "/document[1]/document[1]/list[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -547,7 +547,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -566,7 +566,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/p[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -585,7 +585,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/hr[1]",
-                        "aria": "/document[1]/group[1]/separator[1]"
+                        "aria": "/document[1]/document[1]/group[1]/separator[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -604,7 +604,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/embed[1]",
-                        "aria": "/document[1]/img[1]"
+                        "aria": "/document[1]/document[1]/img[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -623,7 +623,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]",
-                        "aria": "/document[1]/search[1]"
+                        "aria": "/document[1]/document[1]/search[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -642,7 +642,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/document[1]/search[1]/group[1]"
+                        "aria": "/document[1]/document[1]/search[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -661,7 +661,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/document[1]/group[2]"
+                        "aria": "/document[1]/document[1]/group[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -680,7 +680,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/footer[1]",
-                        "aria": "/document[1]/contentinfo[2]"
+                        "aria": "/document[1]/document[1]/contentinfo[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -699,7 +699,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/document[1]/menuitem[1]"
+                        "aria": "/document[1]/document[1]/menuitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -718,7 +718,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[2]",
-                        "aria": "/document[1]/switch[1]"
+                        "aria": "/document[1]/document[1]/switch[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -737,7 +737,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/ol[1]/li[1]",
-                        "aria": "/document[1]/list[2]/listitem[1]"
+                        "aria": "/document[1]/document[1]/list[2]/listitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecifiedInvalidAttribute.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecifiedInvalidAttribute.html
@@ -142,7 +142,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -161,14 +161,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "none"
+                        "document"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -181,7 +181,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]",
-                        "aria": "/document[1]/document[1]"
+                        "aria": "/document[1]/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -200,7 +200,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]",
-                        "aria": "/document[1]/document[1]"
+                        "aria": "/document[1]/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -220,7 +220,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[2]",
-                        "aria": "/document[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -239,7 +239,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[2]",
-                        "aria": "/document[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -259,7 +259,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[3]",
-                        "aria": "/document[1]/option[1]"
+                        "aria": "/document[1]/document[1]/option[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -278,7 +278,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[3]",
-                        "aria": "/document[1]/option[1]"
+                        "aria": "/document[1]/document[1]/option[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -298,7 +298,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/address[1]",
-                        "aria": "/document[1]/contentinfo[1]"
+                        "aria": "/document[1]/document[1]/contentinfo[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -317,7 +317,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/address[1]",
-                        "aria": "/document[1]/contentinfo[1]"
+                        "aria": "/document[1]/document[1]/contentinfo[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA attribute 'aria-pressed' is not valid for the element <address> with ARIA role 'contentinfo'",
@@ -337,7 +337,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/map[1]/area[1]",
-                        "aria": "/document[1]/link[2]"
+                        "aria": "/document[1]/document[1]/link[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -356,7 +356,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/map[1]/area[1]",
-                        "aria": "/document[1]/link[2]"
+                        "aria": "/document[1]/document[1]/link[2]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA attribute 'aria-selected' is not valid for the element <area> with ARIA role 'link'",
@@ -376,7 +376,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -395,7 +395,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -415,7 +415,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -434,7 +434,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -454,7 +454,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/h1[1]",
-                        "aria": "/document[1]/main[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/main[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -473,7 +473,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/h1[1]",
-                        "aria": "/document[1]/main[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/main[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -493,7 +493,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -512,7 +512,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]/strong[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -531,7 +531,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/aside[1]",
-                        "aria": "/document[1]/complementary[1]"
+                        "aria": "/document[1]/document[1]/complementary[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -550,7 +550,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/aside[1]",
-                        "aria": "/document[1]/complementary[1]"
+                        "aria": "/document[1]/document[1]/complementary[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA attribute 'aria-pressed' is not valid for the element <aside> with ARIA role 'complementary'",
@@ -570,7 +570,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/audio[1]",
-                        "aria": "/document[1]/application[1]"
+                        "aria": "/document[1]/document[1]/application[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -589,7 +589,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[1]",
-                        "aria": "/document[1]/menuitemradio[1]"
+                        "aria": "/document[1]/document[1]/menuitemradio[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -608,7 +608,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[2]",
-                        "aria": "/document[1]/link[3]"
+                        "aria": "/document[1]/document[1]/link[3]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -627,7 +627,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]",
-                        "aria": "/document[1]/table[1]"
+                        "aria": "/document[1]/document[1]/table[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -646,7 +646,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/tbody[1]/tr[1]/th[1]/dialog[1]",
-                        "aria": "/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
+                        "aria": "/document[1]/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -665,7 +665,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/tbody[1]/tr[1]/th[1]/dialog[1]",
-                        "aria": "/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
+                        "aria": "/document[1]/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -685,7 +685,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/document[1]/form[1]/listbox[1]"
+                        "aria": "/document[1]/document[1]/listbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -704,7 +704,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/document[1]/form[1]/listbox[1]"
+                        "aria": "/document[1]/document[1]/listbox[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA attribute 'aria-pressed' is not valid for the element <datalist> with ARIA role 'listbox'",
@@ -724,7 +724,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]",
-                        "aria": "/document[1]/list[1]"
+                        "aria": "/document[1]/document[1]/list[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -743,7 +743,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]",
-                        "aria": "/document[1]/list[1]"
+                        "aria": "/document[1]/document[1]/list[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -763,14 +763,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dt[1]",
-                        "aria": "/document[1]/list[1]"
+                        "aria": "/document[1]/document[1]/list[1]/term[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-busy",
                         "dt",
-                        "none"
+                        "term"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -783,7 +783,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dd[1]",
-                        "aria": "/document[1]/list[1]/definition[1]"
+                        "aria": "/document[1]/document[1]/list[1]/definition[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA attribute 'aria-activedescendant' is not valid for the element <dd> with ARIA role 'definition'",
@@ -803,7 +803,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -822,7 +822,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -842,7 +842,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/p[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -861,7 +861,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/hr[1]",
-                        "aria": "/document[1]/group[1]/separator[1]"
+                        "aria": "/document[1]/document[1]/group[1]/separator[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -880,7 +880,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/hr[1]",
-                        "aria": "/document[1]/group[1]/separator[1]"
+                        "aria": "/document[1]/document[1]/group[1]/separator[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -900,7 +900,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/embed[1]",
-                        "aria": "/document[1]/img[1]"
+                        "aria": "/document[1]/document[1]/img[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -919,7 +919,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/embed[1]",
-                        "aria": "/document[1]/img[1]"
+                        "aria": "/document[1]/document[1]/img[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -939,7 +939,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]",
-                        "aria": "/document[1]/search[1]"
+                        "aria": "/document[1]/document[1]/search[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -958,7 +958,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]",
-                        "aria": "/document[1]/search[1]"
+                        "aria": "/document[1]/document[1]/search[1]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA attribute 'aria-orientation' is not valid for the element <form> with ARIA role 'search'",
@@ -978,7 +978,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/document[1]/search[1]/group[1]"
+                        "aria": "/document[1]/document[1]/search[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -997,7 +997,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/document[1]/search[1]/group[1]"
+                        "aria": "/document[1]/document[1]/search[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1017,7 +1017,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/document[1]/group[2]"
+                        "aria": "/document[1]/document[1]/group[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1036,7 +1036,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/document[1]/group[2]"
+                        "aria": "/document[1]/document[1]/group[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1056,7 +1056,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/footer[1]",
-                        "aria": "/document[1]/contentinfo[2]"
+                        "aria": "/document[1]/document[1]/contentinfo[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1075,7 +1075,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/footer[1]",
-                        "aria": "/document[1]/contentinfo[2]"
+                        "aria": "/document[1]/document[1]/contentinfo[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1095,7 +1095,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/document[1]/menuitem[1]"
+                        "aria": "/document[1]/document[1]/menuitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1114,7 +1114,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/document[1]/menuitem[1]"
+                        "aria": "/document[1]/document[1]/menuitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1134,7 +1134,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[2]",
-                        "aria": "/document[1]/switch[1]"
+                        "aria": "/document[1]/document[1]/switch[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1153,7 +1153,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[2]",
-                        "aria": "/document[1]/switch[1]"
+                        "aria": "/document[1]/document[1]/switch[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1173,7 +1173,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/ol[1]/li[1]",
-                        "aria": "/document[1]/list[2]/listitem[1]"
+                        "aria": "/document[1]/document[1]/list[2]/listitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1192,7 +1192,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/ol[1]/li[1]",
-                        "aria": "/document[1]/list[2]/listitem[1]"
+                        "aria": "/document[1]/document[1]/list[2]/listitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1212,7 +1212,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/h6[1]",
-                        "aria": "/document[1]/heading[2]"
+                        "aria": "/document[1]/document[1]/heading[2]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA attribute 'aria-expanded, aria-colcount' is not valid for the element <h6> with ARIA role 'heading'",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecifiedInvalidAttribute.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecifiedInvalidAttribute.html
@@ -168,7 +168,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecifiedMultiple.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecifiedMultiple.html
@@ -139,7 +139,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -158,7 +158,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]",
-                        "aria": "/document[1]/document[1]"
+                        "aria": "/document[1]/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -177,7 +177,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[2]",
-                        "aria": "/document[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -196,7 +196,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[3]",
-                        "aria": "/document[1]/tab[2]"
+                        "aria": "/document[1]/document[1]/tab[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -215,7 +215,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/address[1]",
-                        "aria": "/document[1]/contentinfo[1]"
+                        "aria": "/document[1]/document[1]/contentinfo[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -234,7 +234,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/map[1]/area[1]",
-                        "aria": "/document[1]/link[2]"
+                        "aria": "/document[1]/document[1]/link[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -253,7 +253,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -272,7 +272,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -291,7 +291,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/h1[1]",
-                        "aria": "/document[1]/main[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/main[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -310,7 +310,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -329,7 +329,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]/strong[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -348,7 +348,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/aside[1]",
-                        "aria": "/document[1]/complementary[1]"
+                        "aria": "/document[1]/document[1]/complementary[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -367,7 +367,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/audio[1]",
-                        "aria": "/document[1]/application[1]"
+                        "aria": "/document[1]/document[1]/application[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -386,7 +386,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[1]",
-                        "aria": "/document[1]/menuitemradio[1]"
+                        "aria": "/document[1]/document[1]/menuitemradio[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -405,7 +405,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[2]",
-                        "aria": "/document[1]/link[3]"
+                        "aria": "/document[1]/document[1]/link[3]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -424,7 +424,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]",
-                        "aria": "/document[1]/table[1]"
+                        "aria": "/document[1]/document[1]/table[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -443,7 +443,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/tbody[1]/tr[1]/th[1]/dialog[1]",
-                        "aria": "/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
+                        "aria": "/document[1]/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -462,7 +462,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/document[1]/form[1]/listbox[1]"
+                        "aria": "/document[1]/document[1]/listbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -481,7 +481,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]",
-                        "aria": "/document[1]/list[1]"
+                        "aria": "/document[1]/document[1]/list[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -500,7 +500,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -519,7 +519,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/p[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -538,7 +538,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/hr[1]",
-                        "aria": "/document[1]/group[1]/separator[1]"
+                        "aria": "/document[1]/document[1]/group[1]/separator[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -557,7 +557,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/embed[1]",
-                        "aria": "/document[1]/img[1]"
+                        "aria": "/document[1]/document[1]/img[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -576,7 +576,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]",
-                        "aria": "/document[1]/search[1]"
+                        "aria": "/document[1]/document[1]/search[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -595,7 +595,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/document[1]/search[1]/group[1]"
+                        "aria": "/document[1]/document[1]/search[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -614,7 +614,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -633,7 +633,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/footer[1]",
-                        "aria": "/document[1]/contentinfo[2]"
+                        "aria": "/document[1]/document[1]/contentinfo[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -652,7 +652,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/document[1]/menuitem[1]"
+                        "aria": "/document[1]/document[1]/menuitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -671,7 +671,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[2]",
-                        "aria": "/document[1]/switch[1]"
+                        "aria": "/document[1]/document[1]/switch[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -690,7 +690,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/ol[1]/li[1]",
-                        "aria": "/document[1]/list[2]/listitem[1]"
+                        "aria": "/document[1]/document[1]/list[2]/listitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecifiedValidAttribute.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/ValidRoleSpecifiedValidAttribute.html
@@ -138,7 +138,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -157,7 +157,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]",
-                        "aria": "/document[1]"
+                        "aria": "/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -177,7 +177,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]",
-                        "aria": "/document[1]/document[1]"
+                        "aria": "/document[1]/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -196,7 +196,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]",
-                        "aria": "/document[1]/document[1]"
+                        "aria": "/document[1]/document[1]/document[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -216,7 +216,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[2]",
-                        "aria": "/document[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -235,7 +235,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[2]",
-                        "aria": "/document[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -255,7 +255,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[3]",
-                        "aria": "/document[1]/option[1]"
+                        "aria": "/document[1]/document[1]/option[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -274,7 +274,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/a[3]",
-                        "aria": "/document[1]/option[1]"
+                        "aria": "/document[1]/document[1]/option[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -294,7 +294,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/address[1]",
-                        "aria": "/document[1]/contentinfo[1]"
+                        "aria": "/document[1]/document[1]/contentinfo[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -313,7 +313,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/address[1]",
-                        "aria": "/document[1]/contentinfo[1]"
+                        "aria": "/document[1]/document[1]/contentinfo[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -333,7 +333,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/map[1]/area[1]",
-                        "aria": "/document[1]/link[2]"
+                        "aria": "/document[1]/document[1]/link[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -352,7 +352,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/map[1]/area[1]",
-                        "aria": "/document[1]/link[2]"
+                        "aria": "/document[1]/document[1]/link[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -372,7 +372,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -391,7 +391,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -411,7 +411,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -430,7 +430,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -450,7 +450,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/h1[1]",
-                        "aria": "/document[1]/main[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/main[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -469,7 +469,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/h1[1]",
-                        "aria": "/document[1]/main[1]/tab[1]"
+                        "aria": "/document[1]/document[1]/main[1]/tab[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -489,7 +489,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -508,7 +508,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/article[1]/header[1]/p[1]/strong[1]",
-                        "aria": "/document[1]/main[1]"
+                        "aria": "/document[1]/document[1]/main[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -527,7 +527,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/aside[1]",
-                        "aria": "/document[1]/complementary[1]"
+                        "aria": "/document[1]/document[1]/complementary[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -546,7 +546,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/aside[1]",
-                        "aria": "/document[1]/complementary[1]"
+                        "aria": "/document[1]/document[1]/complementary[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -566,7 +566,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/audio[1]",
-                        "aria": "/document[1]/application[1]"
+                        "aria": "/document[1]/document[1]/application[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -585,7 +585,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[1]",
-                        "aria": "/document[1]/menuitemradio[1]"
+                        "aria": "/document[1]/document[1]/menuitemradio[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -604,7 +604,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/button[2]",
-                        "aria": "/document[1]/link[3]"
+                        "aria": "/document[1]/document[1]/link[3]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -623,7 +623,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]",
-                        "aria": "/document[1]/table[1]"
+                        "aria": "/document[1]/document[1]/table[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -642,7 +642,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/tbody[1]/tr[1]/th[1]/dialog[1]",
-                        "aria": "/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
+                        "aria": "/document[1]/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -661,7 +661,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/table[1]/tbody[1]/tr[1]/th[1]/dialog[1]",
-                        "aria": "/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
+                        "aria": "/document[1]/document[1]/table[1]/rowgroup[1]/row[1]/rowheader[1]/alertdialog[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -681,7 +681,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/document[1]/form[1]/listbox[1]"
+                        "aria": "/document[1]/document[1]/listbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -700,7 +700,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[1]/datalist[1]",
-                        "aria": "/document[1]/form[1]/listbox[1]"
+                        "aria": "/document[1]/document[1]/listbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -720,7 +720,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]",
-                        "aria": "/document[1]/list[1]"
+                        "aria": "/document[1]/document[1]/list[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -739,7 +739,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]",
-                        "aria": "/document[1]/list[1]"
+                        "aria": "/document[1]/document[1]/list[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -759,14 +759,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dt[1]",
-                        "aria": "/document[1]/list[1]"
+                        "aria": "/document[1]/document[1]/list[1]/term[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-busy",
                         "dt",
-                        "none"
+                        "term"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -779,7 +779,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/dl[1]/dd[1]",
-                        "aria": "/document[1]/list[1]/definition[1]"
+                        "aria": "/document[1]/document[1]/list[1]/definition[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -799,7 +799,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -818,7 +818,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -838,7 +838,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/p[1]",
-                        "aria": "/document[1]/group[1]"
+                        "aria": "/document[1]/document[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -857,7 +857,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/hr[1]",
-                        "aria": "/document[1]/group[1]/separator[1]"
+                        "aria": "/document[1]/document[1]/group[1]/separator[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -876,7 +876,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/details[1]/hr[1]",
-                        "aria": "/document[1]/group[1]/separator[1]"
+                        "aria": "/document[1]/document[1]/group[1]/separator[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -896,7 +896,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/embed[1]",
-                        "aria": "/document[1]/img[1]"
+                        "aria": "/document[1]/document[1]/img[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -915,7 +915,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/embed[1]",
-                        "aria": "/document[1]/img[1]"
+                        "aria": "/document[1]/document[1]/img[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -935,7 +935,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]",
-                        "aria": "/document[1]/search[1]"
+                        "aria": "/document[1]/document[1]/search[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -954,7 +954,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/document[1]/search[1]/group[1]"
+                        "aria": "/document[1]/document[1]/search[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -973,7 +973,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/form[2]/fieldset[1]",
-                        "aria": "/document[1]/search[1]/group[1]"
+                        "aria": "/document[1]/document[1]/search[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -993,7 +993,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/document[1]/group[2]"
+                        "aria": "/document[1]/document[1]/group[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1012,7 +1012,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/figure[1]",
-                        "aria": "/document[1]/group[2]"
+                        "aria": "/document[1]/document[1]/group[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1032,7 +1032,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/footer[1]",
-                        "aria": "/document[1]/contentinfo[2]"
+                        "aria": "/document[1]/document[1]/contentinfo[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1051,7 +1051,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/footer[1]",
-                        "aria": "/document[1]/contentinfo[2]"
+                        "aria": "/document[1]/document[1]/contentinfo[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1071,7 +1071,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/document[1]/menuitem[1]"
+                        "aria": "/document[1]/document[1]/menuitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1090,7 +1090,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[1]",
-                        "aria": "/document[1]/menuitem[1]"
+                        "aria": "/document[1]/document[1]/menuitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1110,7 +1110,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[2]",
-                        "aria": "/document[1]/switch[1]"
+                        "aria": "/document[1]/document[1]/switch[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1129,7 +1129,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/input[2]",
-                        "aria": "/document[1]/switch[1]"
+                        "aria": "/document[1]/document[1]/switch[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1149,7 +1149,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/ol[1]/li[1]",
-                        "aria": "/document[1]/list[2]/listitem[1]"
+                        "aria": "/document[1]/document[1]/list[2]/listitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1168,7 +1168,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/ol[1]/li[1]",
-                        "aria": "/document[1]/list[2]/listitem[1]"
+                        "aria": "/document[1]/document[1]/list[2]/listitem[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/area_element_test.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/area_element_test.html
@@ -60,7 +60,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/canvas_element_test.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/canvas_element_test.html
@@ -61,7 +61,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/cell_role_test.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/cell_role_test.html
@@ -100,7 +100,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/elementsWithSupportingAttributes.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/elementsWithSupportingAttributes.html
@@ -115,7 +115,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/figcaption_element_test.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/figcaption_element_test.html
@@ -57,7 +57,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -109,14 +109,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/figure[1]",
-                        "aria": "/document[1]/region[1]"
+                        "aria": "/document[1]/region[1]/figure[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-label",
                         "figure",
-                        "none"
+                        "figure"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -129,7 +129,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/figure[1]/img[1]",
-                        "aria": "/document[1]/region[1]/img[1]"
+                        "aria": "/document[1]/region[1]/figure[1]/img[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -149,7 +149,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/figure[1]/figcaption[1]",
-                        "aria": "/document[1]/region[1]/group[1]"
+                        "aria": "/document[1]/region[1]/figure[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -168,7 +168,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/figure[1]/figcaption[1]",
-                        "aria": "/document[1]/region[1]/group[1]"
+                        "aria": "/document[1]/region[1]/figure[1]/group[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/hgroup_element_test.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/hgroup_element_test.html
@@ -57,7 +57,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/iframe_test.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/iframe_test.html
@@ -59,7 +59,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/input_type_test.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/HAAC_Aria_Native_Host_Semantics_ruleunit/input_type_test.html
@@ -174,7 +174,7 @@
                     "messageArgs": [
                         "aria-atomic",
                         "body",
-                        "document"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -1084,14 +1084,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[37]",
-                        "aria": "/document[1]/region[1]/textbox[5]"
+                        "aria": "/document[1]/region[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-label",
                         "input",
-                        "textbox"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -1123,7 +1123,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[39]",
-                        "aria": "/document[1]/region[1]/textbox[6]"
+                        "aria": "/document[1]/region[1]/textbox[5]"
                     },
                     "reasonId": "Fail_1",
                     "message": "The ARIA role 'textbox' is not valid for the element <input>",
@@ -1415,14 +1415,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[50]",
-                        "aria": "/document[1]/region[1]/textbox[7]"
+                        "aria": "/document[1]/region[1]/searchbox[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-label",
                         "input",
-                        "textbox"
+                        "searchbox"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -1454,7 +1454,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[52]",
-                        "aria": "/document[1]/region[1]/searchbox[1]"
+                        "aria": "/document[1]/region[1]/searchbox[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1473,7 +1473,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[52]",
-                        "aria": "/document[1]/region[1]/searchbox[1]"
+                        "aria": "/document[1]/region[1]/searchbox[2]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1493,14 +1493,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[53]",
-                        "aria": "/document[1]/region[1]/textbox[8]"
+                        "aria": "/document[1]/region[1]/searchbox[3]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-label",
                         "input",
-                        "textbox"
+                        "searchbox"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"
@@ -1649,7 +1649,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[59]",
-                        "aria": "/document[1]/region[1]/textbox[9]"
+                        "aria": "/document[1]/region[1]/textbox[6]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1688,7 +1688,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[61]",
-                        "aria": "/document[1]/region[1]/textbox[10]"
+                        "aria": "/document[1]/region[1]/textbox[7]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1707,7 +1707,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[61]",
-                        "aria": "/document[1]/region[1]/textbox[10]"
+                        "aria": "/document[1]/region[1]/textbox[7]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1727,7 +1727,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[62]",
-                        "aria": "/document[1]/region[1]/textbox[11]"
+                        "aria": "/document[1]/region[1]/textbox[8]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1805,7 +1805,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[65]",
-                        "aria": "/document[1]/region[1]/textbox[12]"
+                        "aria": "/document[1]/region[1]/textbox[9]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1844,7 +1844,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[67]",
-                        "aria": "/document[1]/region[1]/textbox[13]"
+                        "aria": "/document[1]/region[1]/textbox[10]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1863,7 +1863,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[67]",
-                        "aria": "/document[1]/region[1]/textbox[13]"
+                        "aria": "/document[1]/region[1]/textbox[10]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1883,7 +1883,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[68]",
-                        "aria": "/document[1]/region[1]/textbox[14]"
+                        "aria": "/document[1]/region[1]/textbox[11]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -1961,7 +1961,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[71]",
-                        "aria": "/document[1]/region[1]/textbox[15]"
+                        "aria": "/document[1]/region[1]/textbox[12]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -2000,7 +2000,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[73]",
-                        "aria": "/document[1]/region[1]/textbox[16]"
+                        "aria": "/document[1]/region[1]/textbox[13]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -2019,7 +2019,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[73]",
-                        "aria": "/document[1]/region[1]/textbox[16]"
+                        "aria": "/document[1]/region[1]/textbox[13]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -2039,7 +2039,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[74]",
-                        "aria": "/document[1]/region[1]/textbox[17]"
+                        "aria": "/document[1]/region[1]/textbox[14]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
@@ -2195,14 +2195,14 @@
                     ],
                     "path": {
                         "dom": "/html[1]/body[1]/div[1]/input[81]",
-                        "aria": "/document[1]/region[1]/textbox[18]"
+                        "aria": "/document[1]/region[1]"
                     },
                     "reasonId": "Pass_0",
                     "message": "Rule Passed",
                     "messageArgs": [
                         "aria-label, aria-required",
                         "input",
-                        "textbox"
+                        "none"
                     ],
                     "apiArgs": [],
                     "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/Rpt_Aria_OrphanedContent_Native_Host_Sematics_ruleunit/shadowdom.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/Rpt_Aria_OrphanedContent_Native_Host_Sematics_ruleunit/shadowdom.html
@@ -43,7 +43,7 @@
             ],
             "path": {
               "dom": "/html[1]/head[1]",
-              "aria": ""
+              "aria": "/document[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",
@@ -59,7 +59,7 @@
             ],
             "path": {
               "dom": "/html[1]/head[1]/title[1]",
-              "aria": ""
+              "aria": "/document[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",
@@ -75,7 +75,7 @@
             ],
             "path": {
               "dom": "/html[1]/head[1]/meta[1]",
-              "aria": ""
+              "aria": "/document[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Doc_HasTitle_ruleunit/ACT_2779a5_2d775d11ea501f97cf182fa8091373ebaddc7b9a.html.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Doc_HasTitle_ruleunit/ACT_2779a5_2d775d11ea501f97cf182fa8091373ebaddc7b9a.html.html
@@ -19,7 +19,7 @@
             ],
             "path": {
               "dom": "/html[1]",
-              "aria": ""
+              "aria": "/document[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Elem_Lang_Valid_ruleunit/ACT_bf051a_e806126ba40cc2ee3da9d01afb217bded3b816bc.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Elem_Lang_Valid_ruleunit/ACT_bf051a_e806126ba40cc2ee3da9d01afb217bded3b816bc.html
@@ -22,7 +22,7 @@
             ],
             "path": {
               "dom": "/html[1]",
-              "aria": ""
+              "aria": "/document[1]"
             },
             "reasonId": "Fail_1",
             "message": "Specified 'lang' attribute does not include a valid primary language",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Elem_Lang_Valid_ruleunit/ACT_de46e4_4c655a5da71710e6ca6245186af7f5963e89b332.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Elem_Lang_Valid_ruleunit/ACT_de46e4_4c655a5da71710e6ca6245186af7f5963e89b332.html
@@ -26,7 +26,7 @@
             ],
             "path": {
               "dom": "/html[1]",
-              "aria": ""
+              "aria": "/document[1]"
             },
             "reasonId": "Fail_1",
             "message": "Specified 'lang' attribute does not include a valid primary language",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/ACT_5b7ae0_bd91d04e04dcdbb60ab1f0c88177dcb229fc1102.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/ACT_5b7ae0_bd91d04e04dcdbb60ab1f0c88177dcb229fc1102.html
@@ -21,7 +21,7 @@
             ],
             "path": {
               "dom": "/html[1]",
-              "aria": ""
+              "aria": "/document[1]"
             },
             "reasonId": "Fail_5",
             "message": "Page detected with 'lang' and 'xml:lang' attributes that do not match: \"en-GB\", \"en-US\"",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/Html-invalidEmptyXmlLang.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/Html-invalidEmptyXmlLang.html
@@ -58,7 +58,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]",
-                        "aria": ""
+                        "aria": "/document[1]"
                     },
                     "reasonId": "Fail_3",
                     "message": "Specified 'lang' attribute does not include a valid primary language",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/Html-invalidXmlLang.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/Html-invalidXmlLang.html
@@ -58,7 +58,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]",
-                        "aria": ""
+                        "aria": "/document[1]"
                     },
                     "reasonId": "Fail_3",
                     "message": "Specified 'lang' attribute does not include a valid primary language",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/Html-noXmlLang.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/Html-noXmlLang.html
@@ -56,7 +56,7 @@
                 ],
                 "path": {
                     "dom": "/html[1]",
-                    "aria": ""
+                    "aria": "/document[1]"
                 },
                 "reasonId": "Potential_5",
                 //"message": "Page detected as XHTML 1.0 with only a lang attribute. Confirm that page is only delivered via text/html mime type",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/Html-spacesXmlLang.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Html_HasLang_ruleunit/Html-spacesXmlLang.html
@@ -58,7 +58,7 @@
                     ],
                     "path": {
                         "dom": "/html[1]",
-                        "aria": ""
+                        "aria": "/document[1]"
                     },
                     "reasonId": "Fail_3",
                     "message": "Specified 'lang' attribute does not include a valid primary language",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Input_ExplicitLabel_ruleunit/Button-template-shadow.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Input_ExplicitLabel_ruleunit/Button-template-shadow.html
@@ -49,7 +49,7 @@
             ],
             "path": {
               "dom": "/html[1]/head[1]/template[1]",
-              "aria": ""
+              "aria": "/document[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Input_RadioChkInFieldSet_ruleunit/Lonecheckbox.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Input_RadioChkInFieldSet_ruleunit/Lonecheckbox.html
@@ -1,143 +1,189 @@
-
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-  <meta charset="utf-8">
-  <title>checkbox group issue</title>
+    <meta charset="utf-8">
+    <title>checkbox group issue</title>
 </head>
+
 <body>
-<main>
-    <h1>checkbox group issue</h1>
-<form aria-label="GitHub Enterprise Whitewater for " autocomplete="off">
-	<div class="form-content-div">
-		<div class="bx--form-item" data-type="label">
-			<div class="detailsFormInputDiv">
-				<div class="markdown labelInfo" id="undefined-undefined">
-					<p><strong><span>Note:</span></strong><span> All users with </span><a class="bx--link" href="https://cloud.ibm.com/docs/services/ContinuousDelivery?topic=ContinuousDelivery-toolchains-using#managing_access" target="_blank"><span>access to this toolchain</span></a><span> will be able to access artifacts derived from this repository, such as build artifacts in the Delivery Pipeline.</span></p>
-				</div>
-			</div>
-		</div>
-		<div class="bx--form-item" data-type="boolean">
-			<div class="detailsFormLabelDiv"><span class="checkBoxSpan"><div class="bx--form-item bx--checkbox-wrapper"><input name="undefined_legal" data-paramdef-type="boolean" type="checkbox" class="bx--checkbox" id="undefined_legal"><label for="undefined_legal" class="bx--checkbox-label"><span class="bx--checkbox-label-text">I understand</span></label>
-			</div><span class="checkbox-error"><svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" aria-hidden="true" class="checkbox-error-icon" style="will-change: transform;"><path d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L4.5,5.3l0.8-0.8l6.2,6.2L10.7,11.5z"></path><path fill="none" d="M10.7,11.5L4.5,5.3l0.8-0.8l6.2,6.2L10.7,11.5z" data-icon-path="inner-path" opacity="0"></path></svg></span>
-			<span
-				class="checkbox-text">You must confirm that you understand the note before proceeding.</span>
-				</span>
-		</div>
-	</div>
-	<div class="bx--form-item" data-type="selectfieldset">
-		<div class="detailsFormInputDiv">
-			<fieldset>
-				<legend>Repository options</legend>
-				<div class="bx--form-item" data-type="selectfieldset">
-					<div class="bx--select">
-						<div class="bx--select-input__wrapper"><select name="type" aria-label="Repository type" class="bx--select-input"><option class="bx--select-option" value="new">New</option><option class="bx--select-option" value="fork">Fork</option><option class="bx--select-option" value="clone">Clone</option><option class="bx--select-option" value="link">Existing</option></select></div>
-					</div>
-				</div>
-				<div>
-					<div class="bx--form-item" data-type="boolean">
-						<div class="detailsFormLabelDiv"><span class="checkBoxSpan"><div class="bx--form-item bx--checkbox-wrapper"><input name="undefined_private_repo" data-paramdef-type="boolean" type="checkbox" class="bx--checkbox" id="undefined_private_repo"><label for="undefined_private_repo" class="bx--checkbox-label"><span class="bx--checkbox-label-text">Make this repository private</span></label>
-						</div>
-						</span>
-					</div>
-				</div>
-				<div class="bx--form-item" data-type="boolean">
-					<div class="detailsFormLabelDiv"><span class="checkBoxSpan"><div class="bx--form-item bx--checkbox-wrapper"><input name="undefined_has_issues" data-paramdef-type="boolean" type="checkbox" class="bx--checkbox" id="undefined_has_issues"><label for="undefined_has_issues" class="bx--checkbox-label"><span class="bx--checkbox-label-text">Enable GitHub Issues</span></label>
-					</div>
-					</span>
-				</div>
-		</div>
-		<div class="bx--form-item" data-type="boolean">
-			<div class="detailsFormLabelDiv"><span class="checkBoxSpan"><div class="bx--form-item bx--checkbox-wrapper"><input name="undefined_enable_traceability" data-paramdef-type="boolean" type="checkbox" class="bx--checkbox" id="undefined_enable_traceability"><label for="undefined_enable_traceability" class="bx--checkbox-label"><span class="bx--checkbox-label-text">Track deployment of code changes</span></label>
-			</div>
-			</span>
-		</div>
-	</div>
-	</div>
-	</fieldset>
-	</div>
-	</div>
-	</div>
-</form>
-</main>
-<script type="text/javascript">
-    UnitTest = {
-        ruleIds: ["WCAG20_Input_RadioChkInFieldSet"],
-        results: [
-          {
-            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
-            "value": [
-              "INFORMATION",
-              "POTENTIAL"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[2]/div[1]/span[1]/div[1]/input[1]",
-              "aria": "/document[1]/main[1]/form[1]/checkbox[1]"
-            },
-            "reasonId": "Potential_LoneCheckbox",
-            "message": "Verify that this ungrouped checkbox input is not related to other checkboxes",
-            "messageArgs": [
-              "Checkbox"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[1]/div[1]/span[1]/div[1]/input[1]",
-              "aria": "/document[1]/main[1]/form[1]/checkbox[2]"
-            },
-            "reasonId": "Pass_Grouped",
-            "message": "Checkbox input is grouped with other related controls with the same name",
-            "messageArgs": [
-              "Checkbox"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[2]/div[1]/span[1]/div[1]/input[1]",
-              "aria": "/document[1]/main[1]/form[1]/checkbox[3]"
-            },
-            "reasonId": "Pass_Grouped",
-            "message": "Checkbox input is grouped with other related controls with the same name",
-            "messageArgs": [
-              "Checkbox"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[3]/div[1]/span[1]/div[1]/input[1]",
-              "aria": "/document[1]/main[1]/form[1]/checkbox[4]"
-            },
-            "reasonId": "Pass_Grouped",
-            "message": "Checkbox input is grouped with other related controls with the same name",
-            "messageArgs": [
-              "Checkbox"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
-        ]
-    }
-</script>
+    <main>
+        <h1>checkbox group issue</h1>
+        <form aria-label="GitHub Enterprise Whitewater for " autocomplete="off">
+            <div class="form-content-div">
+                <div class="bx--form-item" data-type="label">
+                    <div class="detailsFormInputDiv">
+                        <div class="markdown labelInfo" id="undefined-undefined">
+                            <p><strong><span>Note:</span></strong><span> All users with </span><a class="bx--link"
+                                    href="https://cloud.ibm.com/docs/services/ContinuousDelivery?topic=ContinuousDelivery-toolchains-using#managing_access"
+                                    target="_blank"><span>access to this toolchain</span></a><span> will be able to
+                                    access artifacts derived from this repository, such as build artifacts in the
+                                    Delivery Pipeline.</span></p>
+                        </div>
+                    </div>
+                </div>
+                <div class="bx--form-item" data-type="boolean">
+                    <div class="detailsFormLabelDiv"><span class="checkBoxSpan">
+                            <div class="bx--form-item bx--checkbox-wrapper"><input name="undefined_legal"
+                                    data-paramdef-type="boolean" type="checkbox" class="bx--checkbox"
+                                    id="undefined_legal"><label for="undefined_legal" class="bx--checkbox-label"><span
+                                        class="bx--checkbox-label-text">I understand</span></label>
+                            </div><span class="checkbox-error"><svg focusable="false"
+                                    preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="16"
+                                    height="16" viewBox="0 0 16 16" aria-hidden="true" class="checkbox-error-icon"
+                                    style="will-change: transform;">
+                                    <path
+                                        d="M8,1C4.1,1,1,4.1,1,8s3.1,7,7,7s7-3.1,7-7S11.9,1,8,1z M10.7,11.5L4.5,5.3l0.8-0.8l6.2,6.2L10.7,11.5z">
+                                    </path>
+                                    <path fill="none" d="M10.7,11.5L4.5,5.3l0.8-0.8l6.2,6.2L10.7,11.5z"
+                                        data-icon-path="inner-path" opacity="0"></path>
+                                </svg></span>
+                            <span class="checkbox-text">You must confirm that you understand the note before
+                                proceeding.</span>
+                        </span>
+                    </div>
+                </div>
+                <div class="bx--form-item" data-type="selectfieldset">
+                    <div class="detailsFormInputDiv">
+                        <fieldset>
+                            <legend>Repository options</legend>
+                            <div class="bx--form-item" data-type="selectfieldset">
+                                <div class="bx--select">
+                                    <div class="bx--select-input__wrapper"><select name="type"
+                                            aria-label="Repository type" class="bx--select-input">
+                                            <option class="bx--select-option" value="new">New</option>
+                                            <option class="bx--select-option" value="fork">Fork</option>
+                                            <option class="bx--select-option" value="clone">Clone</option>
+                                            <option class="bx--select-option" value="link">Existing</option>
+                                        </select></div>
+                                </div>
+                            </div>
+                            <div>
+                                <div class="bx--form-item" data-type="boolean">
+                                    <div class="detailsFormLabelDiv"><span class="checkBoxSpan">
+                                            <div class="bx--form-item bx--checkbox-wrapper"><input
+                                                    name="undefined_private_repo" data-paramdef-type="boolean"
+                                                    type="checkbox" class="bx--checkbox"
+                                                    id="undefined_private_repo"><label for="undefined_private_repo"
+                                                    class="bx--checkbox-label"><span
+                                                        class="bx--checkbox-label-text">Make this repository
+                                                        private</span></label>
+                                            </div>
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="bx--form-item" data-type="boolean">
+                                    <div class="detailsFormLabelDiv"><span class="checkBoxSpan">
+                                            <div class="bx--form-item bx--checkbox-wrapper"><input
+                                                    name="undefined_has_issues" data-paramdef-type="boolean"
+                                                    type="checkbox" class="bx--checkbox"
+                                                    id="undefined_has_issues"><label for="undefined_has_issues"
+                                                    class="bx--checkbox-label"><span
+                                                        class="bx--checkbox-label-text">Enable GitHub
+                                                        Issues</span></label>
+                                            </div>
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="bx--form-item" data-type="boolean">
+                                    <div class="detailsFormLabelDiv"><span class="checkBoxSpan">
+                                            <div class="bx--form-item bx--checkbox-wrapper"><input
+                                                    name="undefined_enable_traceability" data-paramdef-type="boolean"
+                                                    type="checkbox" class="bx--checkbox"
+                                                    id="undefined_enable_traceability"><label
+                                                    for="undefined_enable_traceability" class="bx--checkbox-label"><span
+                                                        class="bx--checkbox-label-text">Track deployment of code
+                                                        changes</span></label>
+                                            </div>
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </fieldset>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </main>
+    <script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["WCAG20_Input_RadioChkInFieldSet"],
+            results: [
+                {
+                    "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+                    "value": [
+                        "INFORMATION",
+                        "POTENTIAL"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[2]/div[1]/span[1]/div[1]/input[1]",
+                        "aria": "/document[1]/main[1]/form[1]/checkbox[1]"
+                    },
+                    "reasonId": "Potential_LoneCheckbox",
+                    "message": "Verify that this ungrouped checkbox input is not related to other checkboxes",
+                    "messageArgs": [
+                        "Checkbox"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[1]/div[1]/span[1]/div[1]/input[1]",
+                        "aria": "/document[1]/main[1]/form[1]/group[1]/checkbox[1]"
+                    },
+                    "reasonId": "Pass_Grouped",
+                    "message": "Checkbox input is grouped with other related controls with the same name",
+                    "messageArgs": [
+                        "Checkbox"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[2]/div[1]/span[1]/div[1]/input[1]",
+                        "aria": "/document[1]/main[1]/form[1]/group[1]/checkbox[2]"
+                    },
+                    "reasonId": "Pass_Grouped",
+                    "message": "Checkbox input is grouped with other related controls with the same name",
+                    "messageArgs": [
+                        "Checkbox"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[3]/div[1]/span[1]/div[1]/input[1]",
+                        "aria": "/document[1]/main[1]/form[1]/group[1]/checkbox[3]"
+                    },
+                    "reasonId": "Pass_Grouped",
+                    "message": "Checkbox input is grouped with other related controls with the same name",
+                    "messageArgs": [
+                        "Checkbox"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                }
+            ]
+        }
+    </script>
 </body>
+
 </html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Input_RadioChkInFieldSet_ruleunit/shadow2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/WCAG20_Input_RadioChkInFieldSet_ruleunit/shadow2.html
@@ -45,43 +45,43 @@
         UnitTest = {
             ruleIds: ["WCAG20_Input_RadioChkInFieldSet"],
             results: [
-          {
-            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/fieldset[1]/my-radio[1]/#document-fragment[1]/input[1]",
-              "aria": "/document[1]/main[1]/radio[1]"
-            },
-            "reasonId": "Pass_Grouped",
-            "message": "Radio input is grouped with other related controls with the same name",
-            "messageArgs": [
-              "Radio"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "WCAG20_Input_RadioChkInFieldSet",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]/fieldset[1]/my-radio[2]/#document-fragment[1]/input[1]",
-              "aria": "/document[1]/main[1]/radio[2]"
-            },
-            "reasonId": "Pass_Grouped",
-            "message": "Radio input is grouped with other related controls with the same name",
-            "messageArgs": [
-              "Radio"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
-        ]
+                {
+                    "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/fieldset[1]/my-radio[1]/#document-fragment[1]/input[1]",
+                        "aria": "/document[1]/main[1]/group[1]/radio[1]"
+                    },
+                    "reasonId": "Pass_Grouped",
+                    "message": "Radio input is grouped with other related controls with the same name",
+                    "messageArgs": [
+                        "Radio"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "WCAG20_Input_RadioChkInFieldSet",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/main[1]/fieldset[1]/my-radio[2]/#document-fragment[1]/input[1]",
+                        "aria": "/document[1]/main[1]/group[1]/radio[2]"
+                    },
+                    "reasonId": "Pass_Grouped",
+                    "message": "Radio input is grouped with other related controls with the same name",
+                    "messageArgs": [
+                        "Radio"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                }
+            ]
         };
     </script>
 </body>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_hidden_focus_misuse_ruleunit/act_6cfa84_aria_hidden_fail_with_summary_element.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_hidden_focus_misuse_ruleunit/act_6cfa84_aria_hidden_fail_with_summary_element.html
@@ -33,56 +33,56 @@
         UnitTest = {
             ruleIds: ["aria_hidden_focus_misuse"],
             results: [
-            {
-            "ruleId": "aria_hidden_focus_misuse",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/details[1]",
-              "aria": "/document[1]/group[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_hidden_focus_misuse",
-            "value": [
-              "INFORMATION",
-              "FAIL"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/details[1]/summary[1]",
-              "aria": "/document[1]/group[1]"
-            },
-            "reasonId": "Fail_1",
-            "message": "Element \"summary\" should not be focusable within the subtree of an element with an 'aria-hidden' attribute with value 'true'",
-            "messageArgs": [
-              "summary"
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          },
-          {
-            "ruleId": "aria_hidden_focus_misuse",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/details[1]/p[1]",
-              "aria": "/document[1]/group[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
+                {
+                    "ruleId": "aria_hidden_focus_misuse",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/details[1]",
+                        "aria": "/document[1]/group[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_hidden_focus_misuse",
+                    "value": [
+                        "INFORMATION",
+                        "FAIL"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/details[1]/summary[1]",
+                        "aria": "/document[1]/group[1]/button[1]"
+                    },
+                    "reasonId": "Fail_1",
+                    "message": "Element \"summary\" should not be focusable within the subtree of an element with an 'aria-hidden' attribute with value 'true'",
+                    "messageArgs": [
+                        "summary"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                },
+                {
+                    "ruleId": "aria_hidden_focus_misuse",
+                    "value": [
+                        "INFORMATION",
+                        "PASS"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/body[1]/details[1]/p[1]",
+                        "aria": "/document[1]/group[1]"
+                    },
+                    "reasonId": "Pass_0",
+                    "message": "Rule Passed",
+                    "messageArgs": [],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                }
             ]
         }
     </script>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_maximum_user_scale_1.0.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_maximum_user_scale_1.0.html
@@ -40,7 +40,7 @@
               ],
               "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
               },
               "reasonId": "Potential_1",
               "message": "Confirm the 'meta[name=viewport]' with \"maximum-scale=1.0\" can be zoomed by user",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_maximum_user_scale_1.5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_maximum_user_scale_1.5.html
@@ -39,7 +39,7 @@
               ],
               "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
               },
               "reasonId": "Potential_1",
               "message": "Confirm the 'meta[name=viewport]' with \" maximum-scale=1.5\" can be zoomed by user",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_unknown_maximum_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_unknown_maximum_user_scale.html
@@ -39,7 +39,7 @@
               ],
               "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
               },
               "reasonId": "Potential_1",
               "message": "Confirm the 'meta[name=viewport]' with \"maximum-scale=ok\" can be zoomed by user",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_user_scale_no.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_user_scale_no.html
@@ -39,7 +39,7 @@
               ],
               "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
               },
               "reasonId": "Potential_1",
               "message": "Confirm the 'meta[name=viewport]' with \"user-scalable=no\" can be zoomed by user",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_yes_maximum_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_fail_yes_maximum_user_scale.html
@@ -25,31 +25,32 @@
 </head>
 
 <body>
-  <p>
-    Lorem ipsum
-  </p>
+    <p>
+        Lorem ipsum
+    </p>
     <script>
         UnitTest = {
             ruleIds: ["meta_viewport_zoom"],
-            results: [{
-              "ruleId": "meta_viewport_zoom",
-              "value": [
-                "INFORMATION",
-                "POTENTIAL"
-              ],
-              "path": {
-                "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
-              },
-              "reasonId": "Potential_1",
-              "message": "Confirm the 'meta[name=viewport]' with \"maximum-scale=yes\" can be zoomed by user",
-              "messageArgs": [
-                "maximum-scale=yes"
-              ],
-              "apiArgs": [],
-              "category": "Accessibility"
-            }
-        ]
+            results: [
+                {
+                    "ruleId": "meta_viewport_zoom",
+                    "value": [
+                        "INFORMATION",
+                        "POTENTIAL"
+                    ],
+                    "path": {
+                        "dom": "/html[1]/head[1]/meta[2]",
+                        "aria": "/document[1]"
+                    },
+                    "reasonId": "Potential_1",
+                    "message": "Confirm the 'meta[name=viewport]' with \"maximum-scale=yes\" can be zoomed by user",
+                    "messageArgs": [
+                        "maximum-scale=yes"
+                    ],
+                    "apiArgs": [],
+                    "category": "Accessibility"
+                }
+            ]
         }
     </script>
 </body>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_pass_allow_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_pass_allow_user_scale.html
@@ -39,7 +39,7 @@
                 ],
                 "path": {
                   "dom": "/html[1]/head[1]/meta[2]",
-                  "aria": ""
+                  "aria": "/document[1]"
                 },
                 "reasonId": "Pass_0",
                 "message": "The 'meta[name=viewport]' does not prevent the browser zooming the content",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_pass_enough_maxium_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_pass_enough_maxium_user_scale.html
@@ -39,7 +39,7 @@
                 ],
                 "path": {
                   "dom": "/html[1]/head[1]/meta[2]",
-                  "aria": ""
+                  "aria": "/document[1]"
                 },
                 "reasonId": "Pass_0",
                 "message": "The 'meta[name=viewport]' does not prevent the browser zooming the content",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_pass_ignored_maximum_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoom_ruleunit/viewport_pass_ignored_maximum_user_scale.html
@@ -39,7 +39,7 @@
               ],
               "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
               },
               "reasonId": "Pass_0",
               "message": "The 'meta[name=viewport]' does not prevent the browser zooming the content",

--- a/accessibility-checker/boilerplates/jest-selenium/baselines/HOME.json
+++ b/accessibility-checker/boilerplates/jest-selenium/baselines/HOME.json
@@ -13,7 +13,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[1]"
             },
             "reasonId": "Potential_1",
@@ -39,7 +39,7 @@
             "message": "Default border or outline keyboard focus indicator is modified by CSS so ensure that indicator is visible.",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[1]"
             },
             "reasonId": "Potential_1",
@@ -65,7 +65,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[2]"
             },
             "reasonId": "Potential_1",
@@ -91,7 +91,7 @@
             "message": "Default border or outline keyboard focus indicator is modified by CSS so ensure that indicator is visible.",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[2]"
             },
             "reasonId": "Potential_1",
@@ -117,7 +117,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[3]"
             },
             "reasonId": "Potential_1",
@@ -143,7 +143,7 @@
             "message": "Default border or outline keyboard focus indicator is modified by CSS so ensure that indicator is visible.",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[3]"
             },
             "reasonId": "Potential_1",
@@ -169,7 +169,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[4]"
             },
             "reasonId": "Potential_1",
@@ -195,7 +195,7 @@
             "message": "Default border or outline keyboard focus indicator is modified by CSS so ensure that indicator is visible.",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[4]"
             },
             "reasonId": "Potential_1",
@@ -221,7 +221,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[5]"
             },
             "reasonId": "Potential_1",
@@ -247,7 +247,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[6]"
             },
             "reasonId": "Potential_1",
@@ -273,7 +273,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[7]"
             },
             "reasonId": "Potential_1",
@@ -299,7 +299,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[8]"
             },
             "reasonId": "Potential_1",
@@ -325,7 +325,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[9]"
             },
             "reasonId": "Potential_1",
@@ -351,7 +351,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[10]"
             },
             "reasonId": "Potential_1",
@@ -377,7 +377,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[11]"
             },
             "reasonId": "Potential_1",
@@ -403,7 +403,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[12]"
             },
             "reasonId": "Potential_1",
@@ -429,7 +429,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[13]"
             },
             "reasonId": "Potential_1",
@@ -455,7 +455,7 @@
             "message": "Default border or outline keyboard focus indicator is modified by CSS so ensure that indicator is visible.",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[13]"
             },
             "reasonId": "Potential_1",
@@ -481,7 +481,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[14]"
             },
             "reasonId": "Potential_1",
@@ -507,7 +507,7 @@
             "message": "Default border or outline keyboard focus indicator is modified by CSS so ensure that indicator is visible.",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[14]"
             },
             "reasonId": "Potential_1",
@@ -533,7 +533,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[15]"
             },
             "reasonId": "Potential_1",
@@ -559,7 +559,7 @@
             "message": "Default border or outline keyboard focus indicator is modified by CSS so ensure that indicator is visible.",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[15]"
             },
             "reasonId": "Potential_1",
@@ -585,7 +585,7 @@
             "message": "Possible use of only color to convey information make sure the color is supported by descriptive markup .",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[16]"
             },
             "reasonId": "Potential_1",
@@ -611,7 +611,7 @@
             "message": "Default border or outline keyboard focus indicator is modified by CSS so ensure that indicator is visible.",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[16]"
             },
             "reasonId": "Potential_1",
@@ -637,7 +637,7 @@
             "message": "Confirm Windows high contrast mode is supported for CSS background images.",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/style[1]"
             },
             "reasonId": "Manual_1",

--- a/accessibility-checker/boilerplates/jest/baselines/IMG_BASELINE.json
+++ b/accessibility-checker/boilerplates/jest/baselines/IMG_BASELINE.json
@@ -8,7 +8,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 1,
             "reasonId": "Fail_3",
@@ -34,7 +34,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 1,
             "reasonId": "Fail_2",
@@ -112,7 +112,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Potential_1",

--- a/accessibility-checker/src/README.md
+++ b/accessibility-checker/src/README.md
@@ -255,7 +255,7 @@ Using a callback mechanism (`callback`) to extract the results and perform asser
                     // xpath
                     "dom": "/html[1]",
                     // path of ARIA roles
-                    "aria": ""
+                    "aria": "/document[1]"
                 },
                 "ruleTime": 0,
                 // Generated message

--- a/accessibility-checker/test/baselines/Baseline_aChecker.Baseline.html.json
+++ b/accessibility-checker/test/baselines/Baseline_aChecker.Baseline.html.json
@@ -34,7 +34,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Fail_3",
@@ -60,7 +60,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Fail_2",
@@ -112,7 +112,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Potential_1",
@@ -138,7 +138,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -216,7 +216,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -242,7 +242,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -320,7 +320,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 2,
             "reasonId": "Pass_0",
@@ -398,7 +398,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -476,7 +476,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -528,7 +528,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -606,7 +606,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -632,7 +632,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -710,7 +710,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 4,
             "reasonId": "Pass_0",
@@ -788,7 +788,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -814,7 +814,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -892,7 +892,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",

--- a/accessibility-checker/test/baselines/Baseline_aChecker.Baseline2.html.json
+++ b/accessibility-checker/test/baselines/Baseline_aChecker.Baseline2.html.json
@@ -8,7 +8,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Fail_2",
@@ -112,7 +112,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Potential_1",
@@ -138,7 +138,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -164,7 +164,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -190,7 +190,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -216,7 +216,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -242,7 +242,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -268,7 +268,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -294,7 +294,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -320,7 +320,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -346,7 +346,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -372,7 +372,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -398,7 +398,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -424,7 +424,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -450,7 +450,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -476,7 +476,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -502,7 +502,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -528,7 +528,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -554,7 +554,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
@@ -37,7 +37,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -63,7 +63,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -89,7 +89,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -115,7 +115,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -349,7 +349,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -375,7 +375,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 1,
             "reasonId": "Pass_0",
@@ -401,7 +401,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -427,7 +427,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -453,7 +453,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -687,7 +687,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -713,7 +713,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -741,7 +741,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -767,7 +767,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -871,7 +871,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1107,7 +1107,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1133,7 +1133,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1159,7 +1159,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1185,7 +1185,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1419,7 +1419,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1445,7 +1445,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1549,7 +1549,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1575,7 +1575,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1601,7 +1601,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1627,7 +1627,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1861,7 +1861,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -2095,7 +2095,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -2121,7 +2121,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -2147,7 +2147,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -2173,7 +2173,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -2649,7 +2649,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 1,
             "reasonId": "Pass_0",
@@ -2743,7 +2743,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -2769,7 +2769,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -2795,7 +2795,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -2821,7 +2821,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -3055,7 +3055,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
@@ -157,7 +157,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/title[1]"
             },
             "reasonId": "Pass_0",
@@ -183,7 +183,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[2]"
             },
             "reasonId": "Pass_0",
@@ -209,7 +209,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[1]"
             },
             "reasonId": "Pass_0",
@@ -235,7 +235,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]"
             },
             "reasonId": "Pass_0",
@@ -469,7 +469,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",
@@ -495,7 +495,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/title[1]"
             },
             "reasonId": "Pass_0",
@@ -521,7 +521,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[2]"
             },
             "reasonId": "Pass_0",
@@ -547,7 +547,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[1]"
             },
             "reasonId": "Pass_0",
@@ -573,7 +573,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]"
             },
             "reasonId": "Pass_0",
@@ -807,7 +807,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",
@@ -835,7 +835,7 @@
                 "en"
             ],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",
@@ -861,7 +861,7 @@
             "message": "Lang has a valid primary lang and conforms to BCP 47",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",
@@ -887,7 +887,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",
@@ -993,7 +993,7 @@
                 "Helo World"
             ],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/title[1]"
             },
             "reasonId": "Pass_0",
@@ -1227,7 +1227,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/title[1]"
             },
             "reasonId": "Pass_0",
@@ -1253,7 +1253,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[2]"
             },
             "reasonId": "Pass_0",
@@ -1279,7 +1279,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[1]"
             },
             "reasonId": "Pass_0",
@@ -1305,7 +1305,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]"
             },
             "reasonId": "Pass_0",
@@ -1539,7 +1539,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",
@@ -1565,7 +1565,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",
@@ -1669,7 +1669,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/title[1]"
             },
             "reasonId": "Pass_0",
@@ -1695,7 +1695,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[2]"
             },
             "reasonId": "Pass_0",
@@ -1721,7 +1721,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[1]"
             },
             "reasonId": "Pass_0",
@@ -1747,7 +1747,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]"
             },
             "reasonId": "Pass_0",
@@ -1981,7 +1981,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",
@@ -2215,7 +2215,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/title[1]"
             },
             "reasonId": "Pass_0",
@@ -2241,7 +2241,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[2]"
             },
             "reasonId": "Pass_0",
@@ -2267,7 +2267,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[1]"
             },
             "reasonId": "Pass_0",
@@ -2293,7 +2293,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]"
             },
             "reasonId": "Pass_0",
@@ -2769,7 +2769,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",
@@ -2863,7 +2863,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/title[1]"
             },
             "reasonId": "Pass_0",
@@ -2889,7 +2889,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[2]"
             },
             "reasonId": "Pass_0",
@@ -2915,7 +2915,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]/meta[1]"
             },
             "reasonId": "Pass_0",
@@ -2941,7 +2941,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]/head[1]"
             },
             "reasonId": "Pass_0",
@@ -3175,7 +3175,7 @@
             "message": "Rule Passed",
             "messageArgs": [],
             "path": {
-                "aria": "",
+                "aria": "/document[1]",
                 "dom": "/html[1]"
             },
             "reasonId": "Pass_0",

--- a/cypress-accessibility-checker/test/baselines/getBaseline test.json
+++ b/cypress-accessibility-checker/test/baselines/getBaseline test.json
@@ -8,7 +8,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Fail_3",

--- a/cypress-accessibility-checker/test/baselines/violations-no-match.json
+++ b/cypress-accessibility-checker/test/baselines/violations-no-match.json
@@ -8,7 +8,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Fail_3",
@@ -34,7 +34,7 @@
             ],
             "path": {
                 "dom": "/html[1]/body[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Fail_3",

--- a/cypress-accessibility-checker/test/baselines/violations.json
+++ b/cypress-accessibility-checker/test/baselines/violations.json
@@ -8,7 +8,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Fail_3",

--- a/karma-accessibility-checker/boilerplates/basic/test/baselines/HelloWorld.html.json
+++ b/karma-accessibility-checker/boilerplates/basic/test/baselines/HelloWorld.html.json
@@ -8,7 +8,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Fail_3",
@@ -34,7 +34,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Fail_2",
@@ -112,7 +112,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Potential_1",

--- a/karma-accessibility-checker/src/README.md
+++ b/karma-accessibility-checker/src/README.md
@@ -307,7 +307,7 @@ Use a callback mechanism (`callback`) to extract the results and perform asserti
                     // xpath
                     "dom": "/html[1]",
                     // path of ARIA roles
-                    "aria": ""
+                    "aria": "/document[1]"
                 },
                 "ruleTime": 0,
                 // Generated message

--- a/karma-accessibility-checker/test/client/baseline/JSONObjectStructureVerification.html.json
+++ b/karma-accessibility-checker/test/client/baseline/JSONObjectStructureVerification.html.json
@@ -37,7 +37,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -65,7 +65,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -91,7 +91,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -117,7 +117,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 1,
             "reasonId": "Pass_0",
@@ -143,7 +143,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -169,7 +169,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -195,7 +195,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -221,7 +221,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -247,7 +247,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 1,
             "reasonId": "Pass_0",
@@ -273,7 +273,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -299,7 +299,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -325,7 +325,7 @@
             ],
             "path": {
                 "dom": "/html[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -351,7 +351,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -377,7 +377,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -403,7 +403,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -429,7 +429,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -455,7 +455,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 1,
             "reasonId": "Pass_0",
@@ -481,7 +481,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -507,7 +507,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -533,7 +533,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -559,7 +559,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -587,7 +587,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -613,7 +613,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 2,
             "reasonId": "Pass_0",
@@ -639,7 +639,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -665,7 +665,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -691,7 +691,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -717,7 +717,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -743,7 +743,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -769,7 +769,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/title[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -795,7 +795,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -821,7 +821,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -847,7 +847,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -873,7 +873,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -899,7 +899,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -925,7 +925,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -951,7 +951,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -977,7 +977,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[1]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1003,7 +1003,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1029,7 +1029,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1055,7 +1055,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1081,7 +1081,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1107,7 +1107,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1133,7 +1133,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1159,7 +1159,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",
@@ -1185,7 +1185,7 @@
             ],
             "path": {
                 "dom": "/html[1]/head[1]/meta[2]",
-                "aria": ""
+                "aria": "/document[1]"
             },
             "ruleTime": 0,
             "reasonId": "Pass_0",


### PR DESCRIPTION
Updates data and code in `ARIAMapper.elemToRoleMap/inputToRoleMap`
to match the `implicitRole` data in `ARIADefinitions.documentConformanceRequirement/documentConformanceRequirementSpecialTags`
and the code in `RPTUtil.getElementAriaProperty`, which is called by `RPTUtil.getImplicitRole`.

The `ARIADefinitions` data and `RPTUtil` code were originally updated in https://github.com/IBMa/equal-access/pull/414 to match https://www.w3.org/TR/html-aria/ (which moved to W3C Rec status last week!) But the ARIAMapper data/code were not updated at that time.

It is unfortunate that this data and logic for `implicitRole` is duplicated because that makes it harder to maintain, so I have opened https://github.com/IBMa/equal-access/issues/573 to remove the redundancy some day.

Here are the changes that were needed in ARIAMapper:
- deleted `menuitem` _element_ from all places it was refenced, because:
	a) it has not been supported in any browser for a long time (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menuitem#browser_compatibility),
	b) `menu` _element_'s role was changed to "list", which is not compatible with having children with role "menuitem"
- if `input type="search"` doesn't have a list, its implicit role is "searchbox", not "textbox"
- `input type="password"` does not have an implicit role (it is allowed to have _attributes_ that are allowed on textbox - I will be adding a new machanism to cover that)
- `body` no longer has "document" role (it now has no implicit role). Instead, the `html` element has "document" role.
- `dfn` has role "term"
- `dt` has role "term"
- `fieldset` has role "group"
- `figure` has role "figure"
- `footer`: applied the same changes to `header` from https://github.com/IBMa/equal-access/pull/431
- `form` only has implicit role "form" (landmark) if it has an accessible name
- `meter` no longer has implicit "progressbar" role (https://github.com/w3c/html-aria/issues/44)
- `section` only has implicit role "region" (landmark) if it has an accessible name
- adds check for size="" to `select` implicit role calculation because parseInt("") returns NaN
- `summary` has implicit role "button"
- `svg` has implicit role "graphics-document"
- moved `textarea` to alphabetical order
- adds check for parent role === "treegrid" to `td`
- change a few == to ===