### PR TITLE
presentation and none are equivalent

### DIFF
--- a/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-frame-rules.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/rules/rpt-frame-rules.ts
@@ -33,7 +33,7 @@ let a11yRulesFrame: Rule[] = [
             /*removed only the check for role=none. Although role=presentation is not allowed in the
              https://www.w3.org/TR/html-aria/#docconformance  table, the check has been kept due to the
              decisions taken in DAP "Check iframes with role="presentation" should consider role="none" also (96395)*/
-            if (RPTUtil.hasRole(ruleContext, "presentation") || !RPTUtil.isTabbable(ruleContext)) {
+            if (RPTUtil.hasRole(ruleContext, "presentation") || RPTUtil.hasRole(ruleContext, "none") || !RPTUtil.isTabbable(ruleContext)) {
                 return null;
             } else if (ARIAMapper.computeName(ruleContext).trim().length > 0) {
                 return RulePass("Pass_0");


### PR DESCRIPTION
Rule was only ignoring frames with role="presentation", but "none" is an equivalent role. Adding check to ignore role="none".