### PR TITLE
check cypress reporters for null before invoking onRunComplete

### DIFF
--- a/cypress-accessibility-checker/src/lib/ACTasks.js
+++ b/cypress-accessibility-checker/src/lib/ACTasks.js
@@ -66,9 +66,9 @@ let ACTasks = module.exports = {
     },
 
     onRunComplete: () => {
-        ACTasks.reporterHTML.onRunComplete();
-        ACTasks.reporterJSON.onRunComplete();
-        ACTasks.reporterCSV.onRunComplete();
+        ACTasks.reporterHTML && ACTasks.reporterHTML.onRunComplete();
+        ACTasks.reporterJSON && ACTasks.reporterJSON.onRunComplete();
+        ACTasks.reporterCSV && ACTasks.reporterCSV.onRunComplete();
         return true;
     },
 


### PR DESCRIPTION
Running specs that do not check compliance will not initialize the cypress reporters. In these cases, the onRunComplete task should not throw an exception.

Fixes: #744

Signed-off-by: Chris Danna <chrismdanna@gmail.com>