### PR TITLE
Add prohibited attribute mapping for 'presentation' and 'none' roles

### DIFF
--- a/accessibility-checker-engine/src/v2/aria/ARIADefinitions.ts
+++ b/accessibility-checker-engine/src/v2/aria/ARIADefinitions.ts
@@ -1229,6 +1229,7 @@ export class ARIADefinitions {
             reqChildren: null,
             htmlEquiv: null,
             roleType: "structure",
+            prohibitedProps: ["aria-label", "aria-labelledby"],
             deprecatedProps: ['aria-disabled', 'aria-errormessage', 'aria-haspopup', 'aria-invalid'] 
         },
 
@@ -1275,6 +1276,7 @@ export class ARIADefinitions {
             reqChildren: null,
             htmlEquiv: null,
             roleType: "structure",
+            prohibitedProps: ["aria-label", "aria-labelledby"],
             deprecatedProps: ['aria-disabled', 'aria-errormessage', 'aria-haspopup', 'aria-invalid'] 
         },
 

--- a/accessibility-checker-engine/src/v4/rules/aria_semantics.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_semantics.ts
@@ -140,7 +140,7 @@ export let aria_attribute_allowed: Rule = {
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],
-    act: "5c01ea",
+    act: ["5c01ea", { "46ca7f": { "Pass": "pass", "Fail_invalid_role_attr": "fail"}}],
     run: (context: RuleContext, options?: {}, contextHierarchies?: RuleContextHierarchy): RuleResult | RuleResult[] => {
         const ruleContext = context["dom"].node as Element;
         

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_fail1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_fail1.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <body>
+        <main>
+          <nav role="presentation" aria-label="global">
+            <a href="https://act-rules.github.io/" aria-label="ACT rules">ACT rules</a>
+          </nav>
+					</div>
+        </main>
+        <script>
+            UnitTest = {
+                ruleIds: ["aria_attribute_allowed"],
+                results: [
+                {
+            "ruleId": "aria_attribute_allowed",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/nav[1]",
+              "aria": "/document[1]/main[1]"
+            },
+            "reasonId": "Fail_invalid_role_attr",
+            "message": "The ARIA attributes \"aria-label\" are not valid for the element <nav> with ARIA role \"presentation\"",
+            "messageArgs": [
+              "aria-label",
+              "nav",
+              "presentation"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_attribute_allowed",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/nav[1]/a[1]",
+              "aria": "/document[1]/main[1]/link[1]"
+            },
+            "reasonId": "Pass",
+            "message": "ARIA attributes are valid for the element and ARIA role",
+            "messageArgs": [
+              "aria-label",
+              "a",
+              "link"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+          ],
+      };
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_fail2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_fail2.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <body>
+        <main>
+          <div>
+          <img src="/test-assets/shared/w3c-logo.png" alt="" aria-labelledby="label" /> 
+          <span hidden id="label">W3C logo</span>
+					</div>
+        </main>
+        <script>
+            UnitTest = {
+                ruleIds: ["aria_attribute_allowed"],
+                results: [
+                {
+            "ruleId": "aria_attribute_allowed",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[1]/img[1]",
+              "aria": "/document[1]/main[1]/presentation[1]"
+            },
+            "reasonId": "Fail_invalid_implicit_role_attr",
+            "message": "The ARIA attributes \"aria-labelledby\" are not valid for the element <img> with implicit ARIA role \"presentation\"",
+            "messageArgs": [
+              "aria-labelledby",
+              "img",
+              "presentation"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+          ],
+      };
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_fail3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_fail3.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <body>
+        <main>
+          <div>
+            <svg role="none" aria-label="Yellow circle">
+              <circle cx="50" cy="50" r="40" fill="yellow"></circle>
+            </svg>
+					</div>
+        </main>
+        <script>
+            UnitTest = {
+                ruleIds: ["aria_attribute_allowed"],
+                results: [
+                {
+            "ruleId": "aria_attribute_allowed",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[1]/svg[1]",
+              "aria": "/document[1]/main[1]"
+            },
+            "reasonId": "Fail_invalid_role_attr",
+            "message": "The ARIA attributes \"aria-label\" are not valid for the element <svg> with ARIA role \"none\"",
+            "messageArgs": [
+              "aria-label",
+              "svg",
+              "none"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+          ],
+      };
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_implicable.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_implicable.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <body>
+        <main>
+          <div>
+            <img src="/test-assets/shared/w3c-logo.png" aria-label="W3C logo" />
+					</div>
+        </main>
+        <script>
+            UnitTest = {
+                ruleIds: ["aria_attribute_allowed"],
+                results: [
+                {
+            "ruleId": "aria_attribute_allowed",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[1]/img[1]",
+              "aria": "/document[1]/main[1]/img[1]"
+            },
+            "reasonId": "Pass",
+            "message": "ARIA attributes are valid for the element and ARIA role",
+            "messageArgs": [
+              "aria-label",
+              "img",
+              "img"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+          ],
+      };
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass1.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <body>
+        <main>
+          <div>
+            <img src="/test-assets/shared/w3c-logo.png" alt="" />
+					</div>
+        </main>
+        <script>
+            UnitTest = {
+                ruleIds: ["aria_attribute_allowed"],
+                results: [],
+      };
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass2.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <body>
+        <main>
+          <div>
+            <img src="/test-assets/shared/w3c-logo.png" alt="" aria-hidden="true" />
+					</div>
+        </main>
+        <script>
+            UnitTest = {
+                ruleIds: ["aria_attribute_allowed"],
+                results: [
+                {
+            "ruleId": "aria_attribute_allowed",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[1]/img[1]",
+              "aria": "/document[1]/main[1]/presentation[1]"
+            },
+            "reasonId": "Pass",
+            "message": "ARIA attributes are valid for the element and ARIA role",
+            "messageArgs": [
+              "aria-hidden",
+              "img",
+              "presentation"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+          ],
+      };
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass3.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <body>
+        <main>
+          <div>
+            <img src="/test-assets/shared/w3c-logo.png" alt="" hidden />
+					</div>
+        </main>
+        <script>
+            UnitTest = {
+                ruleIds: ["aria_attribute_allowed"],
+                results: [],
+      };
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass4.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <body>
+        <main>
+          <div>
+            <nav role="presentation">
+              <a href="https://act-rules.github.io/" aria-label="ACT rules">ACT rules</a>
+            </nav>
+					</div>
+        </main>
+        <script>
+            UnitTest = {
+                ruleIds: ["aria_attribute_allowed"],
+                results: [
+                {
+            "ruleId": "aria_attribute_allowed",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[1]/nav[1]/a[1]",
+              "aria": "/document[1]/main[1]/link[1]"
+            },
+            "reasonId": "Pass",
+            "message": "ARIA attributes are valid for the element and ARIA role",
+            "messageArgs": [
+              "aria-label",
+              "a",
+              "link"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+          ],
+      };
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_decorative_pass5.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en-US">
+    <body>
+        <main>
+          <div>
+            <img src="/test-assets/shared/w3c-logo.png" role="presentation" alt="W3C logo" />
+					</div>
+        </main>
+        <script>
+            UnitTest = {
+                ruleIds: ["aria_attribute_allowed"],
+                results: [],
+      };
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
<!-- The title of this PR will be used for release notes, please provide a relevant title -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: aria_attribute_allowed

### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # -->
#1126

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->
None

### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
act test cases in test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/act_*

### I have conducted the following for this PR: 
- [x ] I validated this code in Chrome and FF 
- [x ] I validated this fix in my local env
- [x ] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x ] I understand that the title of this PR will be used for the next release notes.