### PR TITLE
Fixes related to 'separator' as a widget and usage of 'aria-valuenow'

### DIFF
--- a/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
@@ -725,7 +725,7 @@ export class RPTUtil {
             let requiredAttributes = ARIADefinitions.designPatterns[role].reqProps;
             // handle special case of separator
             if (role.toLowerCase() === "separator" && RPTUtil.isFocusable(ele)) {
-                RPTUtil.concatUniqueArrayItemList(["aria-valuenow"], requiredAttributes || []);
+                requiredAttributes = RPTUtil.concatUniqueArrayItemList(["aria-valuenow"], requiredAttributes || []);
             }
             return requiredAttributes;
         } else {

--- a/accessibility-checker-engine/src/v4/rules/element_tabbable_role_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_tabbable_role_valid.ts
@@ -96,6 +96,10 @@ export let element_tabbable_role_valid: Rule = {
             if (roles[i] === "row" || ARIADefinitions.designPatterns[roles[i]].roleType === 'widget') {
                  return RulePass("pass");
             }
+            // Focusable separators are widgets
+            if (roles[i] === "separator") {
+                return RulePass("pass");
+            }
         }
             
         return RuleFail("fail_invalid_role", [roles.length === 0 ? 'none' : roles.join(', ')]);

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/Rpt_Aria_RequiredProperties_ruleunit/separator.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/Rpt_Aria_RequiredProperties_ruleunit/separator.html
@@ -51,18 +51,44 @@
 
     <a name="navskip"></a>
 
-    <script type="text/javascript">
-        //<![CDATA[
-        if (typeof(OpenAjax) == 'undefined') OpenAjax = {}
-        if (typeof(OpenAjax.a11y) == 'undefined') OpenAjax.a11y = {}
-        OpenAjax.a11y.ruleCoverage = [{
-            ruleId: "1079",
-            passedXpaths: [],
-            failedXpaths: [
-            ]
-        }, ];
-        //]]>
-    </script>
-</body>
+    <script>
+        UnitTest = {
+          ruleIds: ["Rpt_Aria_RequiredProperties"],
+          results: [
+          {
+            "ruleId": "Rpt_Aria_RequiredProperties",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]",
+              "aria": "/document[1]/application[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "Rpt_Aria_RequiredProperties",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[2]",
+              "aria": "/document[1]/separator[3]"
+            },
+            "reasonId": "Fail_1",
+            "message": "An element with ARIA role 'separator' does not have the required ARIA attribute(s): 'aria-valuenow'",
+            "messageArgs": ["separator", "aria-valuenow"],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        };
+      </script></body>
 
 </html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/separator.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_semantics_role_ruleunit/separator.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>Sandbox</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body>
+    <main>
+      <h1>Test page</h1>
+      <div role="separator" tabindex="0" aria-valuenow="10" aria-valuemax="100" aria-valuemin="0">
+    </main>
+    <script>
+      UnitTest = {
+        ruleIds: ["aria_attribute_allowed"],
+        results: [
+          {
+            "ruleId": "aria_attribute_allowed",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[1]",
+              "aria": "/document[1]/main[1]/separator[1]"
+            },
+            "reasonId": "Pass",
+            "message": "ARIA attributes are valid for the element and ARIA role",
+            "messageArgs": [
+              "aria-valuenow, aria-valuemax, aria-valuemin",
+              "div",
+              "separator"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+      };
+    </script>
+  </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/element_tabbable_role_valid_ruleunit/separator.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/element_tabbable_role_valid_ruleunit/separator.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>Sandbox</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body>
+    <main>
+      <h1>Test page</h1>
+      <div role="separator"></div>
+      <div role="separator" tabindex="0"></div>
+    </main>
+    <script>
+      UnitTest = {
+        ruleIds: ["element_tabbable_role_valid"],
+        results: [
+          {
+            "ruleId": "element_tabbable_role_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[2]",
+              "aria": "/document[1]/main[1]/separator[2]"
+            },
+            "reasonId": "pass",
+            "message": "The tabbable element has a widget role",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
<!-- The title of this PR will be used for release notes, please provide a relevant title -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: element_tabbable_role_valid, Rpt_Aria_RequiredProperties, aria_attribute_allowed

### This PR is related to the following issue(s): 
- Fixes https://github.com/IBMa/equal-access/issues/923

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->
This addresses a series of issues with separators. Their classification and allowable values changes depending on whether or not they're tabbable.

### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->


### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [ ] I understand that the title of this PR will be used for the next release notes.