### PR TITLE
Fix color contrast issue for the content directly added to a shadow DOM 

### DIFF
--- a/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
@@ -2120,6 +2120,21 @@ export class RPTUtil {
         return retVal;
     }
 
+    /** Return the text content of the given node 
+     *  this is different than innerText or textContent that return text content of a node and its descendants
+    */
+    public static getNodeText(element) {
+        if (!element) return "";
+        let text = "";
+        let childNodes = element.childNodes;
+        for (let i = 0; i < childNodes.length; ++i) {
+            if (childNodes[i].nodeType == 3) {
+                text += childNodes[i].nodeValue;
+            }
+        }
+        return text;
+    }
+
     /**
      * This function is responsible for checking if elements inner text is empty or not.
      *
@@ -3338,7 +3353,7 @@ export class ColorObj {
         return "#" + this.toHexHelp(this.red) + this.toHexHelp(this.green) + this.toHexHelp(this.blue);
     };
 
-    contrastRatio(bgColor : ColorObj) {
+    contrastRatio(bgColor : ColorObj) { 
         let fgColor: ColorObj = this;
 
         if (typeof (this.alpha) != "undefined")

--- a/accessibility-checker-engine/src/v4/rules/IBMA_Color_Contrast_WCAG2AA.ts
+++ b/accessibility-checker-engine/src/v4/rules/IBMA_Color_Contrast_WCAG2AA.ts
@@ -42,7 +42,7 @@ export let IBMA_Color_Contrast_WCAG2AA: Rule = {
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE
     }],
-    act: [],
+    act: ['afw4f7'],
     run: (context: RuleContext, options?: {}, contextHierarchies?: RuleContextHierarchy): RuleResult | RuleResult[] => {
         const ruleContext = context["dom"].node as HTMLElement;
         let nodeName = ruleContext.nodeName.toLowerCase();

--- a/accessibility-checker-engine/src/v4/rules/IBMA_Color_Contrast_WCAG2AA.ts
+++ b/accessibility-checker-engine/src/v4/rules/IBMA_Color_Contrast_WCAG2AA.ts
@@ -54,6 +54,10 @@ export let IBMA_Color_Contrast_WCAG2AA: Rule = {
             return null;
         }
         
+        //skip no-html element
+        if (RPTUtil.getAncestor(ruleContext, "svg"))
+            return null;
+
         // Ensure that this element has children with actual text.
         let childStr = "";
         let childNodes = ruleContext.childNodes;
@@ -62,7 +66,8 @@ export let IBMA_Color_Contrast_WCAG2AA: Rule = {
                 childStr += childNodes[i].nodeValue;
             }
         }
-        if (childStr.trim().length == 0)
+        console.log("node="+ nodeName + ", node-id="+ ruleContext.getAttribute("id") +", isShadowHostElement=" + RPTUtil.isShadowHostElement(ruleContext));
+        if (childStr.trim().length == 0 && !RPTUtil.isShadowHostElement(ruleContext))
             return null;
 
         let doc = ruleContext.ownerDocument;

--- a/accessibility-checker-engine/src/v4/rules/IBMA_Color_Contrast_WCAG2AA.ts
+++ b/accessibility-checker-engine/src/v4/rules/IBMA_Color_Contrast_WCAG2AA.ts
@@ -13,7 +13,7 @@
 
 import { RPTUtil, RPTUtilStyle } from "../../v2/checker/accessibility/util/legacy";
 import { VisUtil } from "../../v2/dom/VisUtil";
-import { Rule, RuleResult, RuleFail, RuleContext, RulePotential, RuleManual, RulePass, RuleContextHierarchy } from "../api/IRule";
+import { Rule, RuleResult, RuleFail, RuleContext, RulePotential, RulePass, RuleContextHierarchy } from "../api/IRule";
 import { eRulePolicy, eToolkitLevel } from "../api/IRule";
 import { setCache } from "../util/CacheUtil";
 
@@ -54,20 +54,13 @@ export let IBMA_Color_Contrast_WCAG2AA: Rule = {
             return null;
         }
         
-        //skip no-html element
-        if (RPTUtil.getAncestor(ruleContext, "svg"))
+        //TODO ? should only consider native disabled, ignore aria-disabled
+        //skip disabled element
+        if (RPTUtil.isNodeDisabled(ruleContext))
             return null;
 
-        // Ensure that this element has children with actual text.
-        let childStr = "";
-        let childNodes = ruleContext.childNodes;
-        for (let i = 0; i < childNodes.length; ++i) {
-            if (childNodes[i].nodeType == 3) {
-                childStr += childNodes[i].nodeValue;
-            }
-        }
-        console.log("node="+ nodeName + ", node-id="+ ruleContext.getAttribute("id") +", isShadowHostElement=" + RPTUtil.isShadowHostElement(ruleContext));
-        if (childStr.trim().length == 0 && !RPTUtil.isShadowHostElement(ruleContext))
+        //skip no-html element
+        if (RPTUtil.getAncestor(ruleContext, "svg"))
             return null;
 
         let doc = ruleContext.ownerDocument;
@@ -79,8 +72,14 @@ export let IBMA_Color_Contrast_WCAG2AA: Rule = {
         if (!win) {
             return null;
         }
-        let style = win.getComputedStyle(ruleContext);
 
+        // Ensure that this element has children with actual text.
+        let childStr = RPTUtil.getNodeText(ruleContext);
+        
+        if (childStr.trim().length == 0 && (!RPTUtil.isShadowHostElement(ruleContext) || (RPTUtil.isShadowHostElement(ruleContext) && RPTUtil.getNodeText(ruleContext.shadowRoot) === '')))
+            return null;
+
+        let style = win.getComputedStyle(ruleContext);
 
         // JCH clip INFO:
         //      The clip property lets you specify a rectangle to clip an absolutely positioned element. 

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/Shadow.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/Shadow.html
@@ -7,7 +7,7 @@
   <body>
     <main>
       The checker should flag errors on all three of the following checkboxes
-      <div style="background-color: black;">
+      <div id='div_1' style="background-color: black;">
         <div id="shadowOpen"></div>
       </div>
     </main>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_1.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: #AAA; background: white;">
+    Some text in English
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "Fail_1",
+            "message": "Text contrast of 2.32 with its background is less than the WCAG AA minimum requirements for text of size 16px and weight of 400",
+            "messageArgs": [
+              "2.32",
+              16,
+              400,
+              "#aaaaaa",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_10.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_10.html
@@ -17,20 +17,20 @@
             "ruleId": "IBMA_Color_Contrast_WCAG2AA",
             "value": [
               "INFORMATION",
-              "PASS"
+              "FAIL"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/div[1]",
+              "aria": "/document[1]/button[1]"
             },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
+            "reasonId": "Fail_1",
+            "message": "Text contrast of 3.86 with its background is less than the WCAG AA minimum requirements for text of size 16px and weight of 400",
             "messageArgs": [
-              "9.40",
+              "3.86",
               16,
               400,
-              "#0000ee",
-              "#ffffff",
+              "#777777",
+              "#eeeeee",
               false,
               false
             ],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_10.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_10.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <div role="button" style="color: #777; background: #EEE;">My button!</div>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_2.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: #AAA; background: linear-gradient(to right, #FFF, #00F); width: 300px">
+    Some text in English
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_2.html
@@ -15,30 +15,7 @@
         UnitTest = {
             ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
             results: [
-            {
-            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "9.40",
-              16,
-              400,
-              "#0000ee",
-              "#ffffff",
-              false,
-              false
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
+            
         ]
         }
         

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_3.html
@@ -10,6 +10,8 @@
   <p
 	style="color: #555; height:50px; padding-top:20px; background: black no-repeat -20px -20px url('/test-assets/contrast/black-hole.jpeg');"
 >
+	Black hole sun
+</p>
 
 <script type="text/javascript">
         UnitTest = {

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_3.html
@@ -15,30 +15,7 @@
         UnitTest = {
             ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
             results: [
-            {
-            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "9.40",
-              16,
-              400,
-              "#0000ee",
-              "#ffffff",
-              false,
-              false
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
+            
         ]
         }
         

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_3.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p
+	style="color: #555; height:50px; padding-top:20px; background: black no-repeat -20px -20px url('/test-assets/contrast/black-hole.jpeg');"
+>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_4.html
@@ -19,19 +19,19 @@
             "ruleId": "IBMA_Color_Contrast_WCAG2AA",
             "value": [
               "INFORMATION",
-              "PASS"
+              "FAIL"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
             },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
+            "reasonId": "Fail_1",
+            "message": "Text contrast of 2.11 with its background is less than the WCAG AA minimum requirements for text of size 16px and weight of 400",
             "messageArgs": [
-              "9.40",
+              "2.11",
               16,
               400,
-              "#0000ee",
+              "#b3b3b3",
               "#ffffff",
               false,
               false

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_4.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: rgba(0,0,0,.3); background: #FFF">
+    Some text in English
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_5.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <div style="background: #FFF">
+    <p style="color: #000; opacity: .3">
+      Some text in English
+    </p>
+  </div>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_5.html
@@ -21,19 +21,19 @@
             "ruleId": "IBMA_Color_Contrast_WCAG2AA",
             "value": [
               "INFORMATION",
-              "PASS"
+              "FAIL"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/div[1]/p[1]",
+              "aria": "/document[1]"
             },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
+            "reasonId": "Fail_1",
+            "message": "Text contrast of 2.11 with its background is less than the WCAG AA minimum requirements for text of size 16px and weight of 400",
             "messageArgs": [
-              "9.40",
+              "2.11",
               16,
               400,
-              "#0000ee",
+              "#b3b3b3",
               "#ffffff",
               false,
               false

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_6.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_6.html
@@ -3,15 +3,15 @@
  
 <head>
   <title>Test Suite</title>
-  <script>
-    const shadowRoot = document.getElementById('p').attachShadow({ mode: 'open' })
-    shadowRoot.textContent = 'Some text in English'
-  </script>
+  
 </head>
 
 <body>
-
   <p style="color: #aaa; background: #fff;" id="p"></p>
+<script>
+    const shadowRoot = document.getElementById('p').attachShadow({ mode: 'open' })
+    shadowRoot.textContent = 'Some text in English'
+</script>
 
 <script type="text/javascript">
         UnitTest = {
@@ -21,19 +21,19 @@
             "ruleId": "IBMA_Color_Contrast_WCAG2AA",
             "value": [
               "INFORMATION",
-              "PASS"
+              "FAIL"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
             },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
+            "reasonId": "Fail_1",
+            "message": "Text contrast of 2.32 with its background is less than the WCAG AA minimum requirements for text of size 16px and weight of 400",
             "messageArgs": [
-              "9.40",
+              "2.32",
               16,
               400,
-              "#0000ee",
+              "#aaaaaa",
               "#ffffff",
               false,
               false

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_6.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_6.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+  <script>
+    const shadowRoot = document.getElementById('p').attachShadow({ mode: 'open' })
+    shadowRoot.textContent = 'Some text in English'
+  </script>
+</head>
+
+<body>
+
+  <p style="color: #aaa; background: #fff;" id="p"></p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_7.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_7.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+  <style>
+    #backgroundSplit {
+      color: rgba(90, 90, 90, 0.8);
+      background-position: top 0 left 0;
+      background-image: linear-gradient(90deg, transparent, transparent 3.3em, black 3.3em, black 6em);
+      padding: 0 1em;
+    }
+  </style>
+</head>
+
+<body>
+
+  <span id="backgroundSplit">
+    Hello world
+  </span>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_7.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_7.html
@@ -23,30 +23,7 @@
         UnitTest = {
             ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
             results: [
-            {
-            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "9.40",
-              16,
-              400,
-              "#0000ee",
-              "#ffffff",
-              false,
-              false
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
+            
         ]
         }
         

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_8.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_8.html
@@ -25,17 +25,41 @@
               "PASS"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",
             "messageArgs": [
-              "9.40",
+              "12.63",
               16,
               400,
-              "#0000ee",
+              "#333333",
               "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/p[2]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "Fail_1",
+            "message": "Text contrast of 3.86 with its background is less than the WCAG AA minimum requirements for text of size 16px and weight of 400",
+            "messageArgs": [
+              "3.86",
+              16,
+              400,
+              "#777777",
+              "#eeeeee",
               false,
               false
             ],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_8.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_8.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: #333; background: #FFF;">
+    Helvetica is a widely used sans-serif typeface developed in 1957 by Max Miedinger and Eduard Hoffmann.
+  </p>
+  <p style="font-family: helvetica; background: #EEE; color: #777;">
+    The quick brown fox jumps over the lazy dog.
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_9.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_9.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <button style="color: #777; background: #EEE;">My button!</button>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_9.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_9.html
@@ -17,20 +17,20 @@
             "ruleId": "IBMA_Color_Contrast_WCAG2AA",
             "value": [
               "INFORMATION",
-              "PASS"
+              "FAIL"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/button[1]",
+              "aria": "/document[1]/button[1]"
             },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
+            "reasonId": "Fail_1",
+            "message": "Text contrast of 3.86 with its background is less than the WCAG AA minimum requirements for text of size 13.3333px and weight of 400",
             "messageArgs": [
-              "9.40",
-              16,
+              "3.86",
+              13.3333,
               400,
-              "#0000ee",
-              "#ffffff",
+              "#777777",
+              "#eeeeee",
               false,
               false
             ],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_1.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="display: none">Some invisible text in English</p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_10.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_10.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <button style="color: #777; background: #EEE;" disabled>My button!</button>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_11.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_11.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <div role="button" style="color: #777; background: #EEE;" aria-disabled="true">My button!</div>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_2.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="position:absolute; top: -999em">Some invisible text in English</p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_3.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: white; background: white;" aria-hidden="true">Hidden text - U U D D L R L R B A S</p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_3.html
@@ -13,7 +13,30 @@
         UnitTest = {
             ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
             results: [
-            
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "Potential_1",
+            "message": "The foreground text and its background color are both detected as #ffffff. Verify the text meets the WCAG 2.1 AA requirements for minimum contrast",
+            "messageArgs": [
+              "1.00",
+              16,
+              400,
+              "#ffffff",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
         ]
         }
         

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_4.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <svg>
+    <text x="0" y="15">I love SVG!</text>
+  </svg>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_5.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p>
+    <img scr="/test-assets/contrast/example.png" alt="example" />
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_6.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_6.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <label style="color:#888; background: white;">
+    My name
+    <input type="text" disabled />
+  </label>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_6.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_6.html
@@ -16,7 +16,30 @@
         UnitTest = {
             ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
             results: [
-            
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "3.54",
+              16,
+              400,
+              "#888888",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
         ]
         }
         

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_7.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_7.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <label id="my_pets_name" style="color:#888; background: white;">
+    My pet's name
+  </label>
+  <div
+    role="textbox"
+    aria-labelledby="my_pets_name"
+    aria-disabled="true"
+    style="height:20px; width:100px; border:1px solid black;"
+  >
+    test
+  </div>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_7.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_7.html
@@ -23,7 +23,30 @@
         UnitTest = {
             ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
             results: [
-            
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "3.54",
+              16,
+              400,
+              "#888888",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
         ]
         }
         

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_8.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_8.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <fieldset disabled style="color:#888; background: white;">
+    <label>
+      My name
+      <input />
+    </label>
+  </fieldset>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_9.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_inapplicable_9.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <div role="group" aria-disabled="true" style="color:#888; background: white;">
+    <label>
+      My name
+      <input />
+    </label>
+  </div>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_1.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: #333; background: #FFF;">
+    Some text in a human language
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "12.63",
+              16,
+              400,
+              "#333333",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_10.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_10.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <button>My button!</button>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_10.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_10.html
@@ -20,17 +20,17 @@
               "PASS"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/button[1]",
+              "aria": "/document[1]/button[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",
             "messageArgs": [
-              "9.40",
-              16,
+              "18.26",
+              13.3333,
               400,
-              "#0000ee",
-              "#ffffff",
+              "#000000",
+              "#efefef",
               false,
               false
             ],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_11.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_11.html
@@ -20,16 +20,16 @@
               "PASS"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/div[1]",
+              "aria": "/document[1]/button[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",
             "messageArgs": [
-              "9.40",
+              "21.00",
               16,
               400,
-              "#0000ee",
+              "#000000",
               "#ffffff",
               false,
               false

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_11.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_11.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <div role="button">My button!</div>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_2.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: #333; background: linear-gradient(to right, #FFF, #00F); width: 500px;">
+    Some text in a human language
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_2.html
@@ -15,30 +15,7 @@
         UnitTest = {
             ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
             results: [
-            {
-            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "9.40",
-              16,
-              400,
-              "#0000ee",
-              "#ffffff",
-              false,
-              false
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
+            
         ]
         }
         

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_3.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+  <style>
+    p {
+      color: #CCC;
+      height: 50px;
+      padding-top: 15px;
+      background: #000 no-repeat -20px -20px url('/test-assets/contrast/black-hole.jpeg');
+      text-shadow: 0px 0px 2px black;
+    }
+    </style>
+</head>
+
+<body>
+
+  <p>Black hole sun</p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_3.html
@@ -22,30 +22,7 @@
         UnitTest = {
             ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
             results: [
-            {
-            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "9.40",
-              16,
-              400,
-              "#0000ee",
-              "#ffffff",
-              false,
-              false
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
+            
         ]
         }
         

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_4.html
@@ -19,20 +19,20 @@
             "ruleId": "IBMA_Color_Contrast_WCAG2AA",
             "value": [
               "INFORMATION",
-              "PASS"
+              "FAIL"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
             },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
+            "reasonId": "Fail_1",
+            "message": "Text contrast of 4.43 with its background is less than the WCAG AA minimum requirements for text of size 16px and weight of 400",
             "messageArgs": [
-              "9.40",
+              "4.43",
               16,
               400,
-              "#0000ee",
-              "#ffffff",
+              "#000000",
+              "#737373",
               false,
               false
             ],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_4.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: #000; background: #737373; text-shadow: white 0 0 3px">
+    Some text in a human language
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_5.html
@@ -22,17 +22,17 @@
               "PASS"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",
             "messageArgs": [
-              "9.40",
-              16,
+              "3.66",
+              24,
               400,
-              "#0000ee",
-              "#ffffff",
+              "#000000",
+              "#666666",
               false,
               false
             ],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_5.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: #000; font-size:18pt; background: #666;">
+    Some text in a human language
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_6.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_6.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: #000; font-size:14pt; font-weight:700; background: #666;">
+    Some text in English
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_6.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_6.html
@@ -22,17 +22,17 @@
               "PASS"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",
             "messageArgs": [
-              "9.40",
-              16,
-              400,
-              "#0000ee",
-              "#ffffff",
+              "3.66",
+              18.6667,
+              700,
+              "#000000",
+              "#666666",
               false,
               false
             ],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_7.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_7.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p style="color: #000; background: #666;">
+    ----=====++++++++___________***********%%%%%%%%%%%±±±±@@@@@@@@
+  </p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "Fail_1",
+            "message": "Text contrast of 3.66 with its background is less than the WCAG AA minimum requirements for text of size 16px and weight of 400",
+            "messageArgs": [
+              "3.66",
+              16,
+              400,
+              "#000000",
+              "#666666",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_8.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_8.html
@@ -20,16 +20,16 @@
               "PASS"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]"
             },
             "reasonId": "Pass_0",
             "message": "Rule Passed",
             "messageArgs": [
-              "9.40",
+              "21.00",
               16,
               400,
-              "#0000ee",
+              "#000000",
               "#ffffff",
               false,
               false

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_8.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_8.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+</head>
+
+<body>
+
+  <p>Some text in a human language</p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_9.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_9.html
@@ -5,7 +5,7 @@
   <title>Test Suite</title>
   <script>
     const shadowRoot = document.getElementById('p').attachShadow({ mode: 'open' })
-    shadowRoot.innerHTML = '<span style="color: #333;">Some text in English</span>'
+    shadowRoot.innerHTML = '<span id="span1" style="color: #333;">Some text in English</span>'
   </script>
 </head>
 

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_9.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_9.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en-US">
+ 
+<head>
+  <title>Test Suite</title>
+  <script>
+    const shadowRoot = document.getElementById('p').attachShadow({ mode: 'open' })
+    shadowRoot.innerHTML = '<span style="color: #333;">Some text in English</span>'
+  </script>
+</head>
+
+<body>
+
+  <p style="color: #CCC; background: #fff;" id="p"></p>
+
+<script type="text/javascript">
+        UnitTest = {
+            ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
+            results: [
+            {
+            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [
+              "9.40",
+              16,
+              400,
+              "#0000ee",
+              "#ffffff",
+              false,
+              false
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+        ]
+        }
+        
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_9.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_pass_9.html
@@ -17,30 +17,7 @@
         UnitTest = {
             ruleIds: ["IBMA_Color_Contrast_WCAG2AA"],
             results: [
-            {
-            "ruleId": "IBMA_Color_Contrast_WCAG2AA",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/a[1]",
-              "aria": "/document[1]/link[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [
-              "9.40",
-              16,
-              400,
-              "#0000ee",
-              "#ffffff",
-              false,
-              false
-            ],
-            "apiArgs": [],
-            "category": "Accessibility"
-          }
+            
         ]
         }
         


### PR DESCRIPTION
<!-- The title of this PR will be used for release notes, please provide a relevant title -->
#1151 

* Rule bug: **List rule IDs**. IBMA_Color_Contrast_WCAG2AA


### This PR is related to the following issue(s): 
#1151 


### Additional information can be found here: 
none


### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
in test/v2/checker/accessibility/rules/IBMA_Color_Contrast_WCAG2AA_ruleunit/act_fail_6.html

### I have conducted the following for this PR: 
- [x ] I validated this code in Chrome and FF 
- [x ] I validated this fix in my local env
- [x ] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x ] I understand that the title of this PR will be used for the next release notes.