### PR TITLE
fix(node): Allow specification of nested config.cacheFolder on windows

### DIFF
--- a/accessibility-checker/src-ts/lib/ACEngineManager.ts
+++ b/accessibility-checker/src-ts/lib/ACEngineManager.ts
@@ -126,7 +126,7 @@ try {
                 let nodePath = path.join(engineDir, "ace-node")
                 fs.writeFile(nodePath + ".js", data, function (err) {
                     try {
-                        if (nodePath.charAt(0) !== '/') {
+                        if (nodePath.charAt(0) !== '/' && nodePath.charAt(0) !== '\\') {
                             nodePath = "../../" + nodePath;
                         }
                         err && console.log(err);


### PR DESCRIPTION
No matter how you specify config.cacheFolder on windows: "/..", "\.." it always comes through "\".

Needs this fix to work on windows properly - right now it always appends ../../

### I have conducted the following for this PR: 
- [x ] I validated this code in Chrome and FF 
- [x ] I validated this fix in my local env
- [ x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
