### PR TITLE
fix(engine) make nodePath Windows-compatible

### DIFF
--- a/accessibility-checker/src-ts/lib/ACEngineManager.ts
+++ b/accessibility-checker/src-ts/lib/ACEngineManager.ts
@@ -126,9 +126,6 @@ try {
                 let nodePath = path.join(engineDir, "ace-node")
                 fs.writeFile(nodePath + ".js", data, function (err) {
                     try {
-                        if (nodePath.charAt(0) !== '/') {
-                            nodePath = "../../" + nodePath;
-                        }
                         err && console.log(err);
                         var ace_ibma = require(nodePath);
                         checker = new ace_ibma.Checker();


### PR DESCRIPTION
<!-- The title of this PR will be used for release notes, please provide a relevant title. 
The following formats should be use for the release notes and PRs.

**Rule/Engine updates:**
newrule(`ruleid`): Title of PR
fixrule(`ruleid`): Title of PR
feature(engine): Title of PR
fix(engine): Title of PR
chore(`ruleid`|engine): Title of PR

**Tool updates:
feature(extension|node|karma|cypress): Title of PR
fix(extension|node|karma|cypress): Title of PR
chore(extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
Remove code that prefixed nodePath with '../../' if nodePath did not begin with '/'. This code worked on a unix-like host, but on Windows it changed an absolute path such as 'C:\Users\...' to '../../C:\Users\..', which was invalid. Removing this code made this module work in tests on both Windows and Mac, provided that config.cacheFolder was set to an absolute path, such as `${__dirname}/temp`. Testing has not been done with relative or default values of config.cacheFolder.

### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # -->


### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->


### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->

Without this change, getCompliance threw this error on a Windows host, when config.cacheFolder was `${__dirname}/temp`:

ERROR: getCompliance failed (Cannot find module '../../C:\Users\c162712\Documents\repos\testaro\temp\engine\ace-node'Require stack:
- C:\Users\c162712\Documents\repos\testaro\node_modules\accessibility-checker\lib\ACEngineManager.js
- C:\Users\c162712\Documents\repos\testaro\node_modules\accessibility-checker\index.js
- ...

With this change, no error was thrown.

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
