### PR TITLE
fix(engine) Make results.label Windows-compatible

### DIFF
--- a/accessibility-checker/src-ts/lib/ACEngineManager.ts
+++ b/accessibility-checker/src-ts/lib/ACEngineManager.ts
@@ -126,9 +126,6 @@ try {
                 let nodePath = path.join(engineDir, "ace-node")
                 fs.writeFile(nodePath + ".js", data, function (err) {
                     try {
-                        if (nodePath.charAt(0) !== '/') {
-                            nodePath = "../../" + nodePath;
-                        }
                         err && console.log(err);
                         var ace_ibma = require(nodePath);
                         checker = new ace_ibma.Checker();

--- a/accessibility-checker/src-ts/lib/reporters/ACReporterJSON.ts
+++ b/accessibility-checker/src-ts/lib/reporters/ACReporterJSON.ts
@@ -119,6 +119,8 @@ export class ACReporterJSON {
 
         // Build the full file name based on the label provide in the results and also the results dir specified in the
         // configuration.
+        // Replace the colons in the label with hyphen-minuses.
+        results.label = results.label.replace(/:/g, '-');
         let resultsFileName = pathLib.join(resultDir, results.label + '.json');
 
         /**************************************************** DEBUG INFORMATION ***************************************************************


### PR DESCRIPTION
<!-- The title of this PR will be used for release notes, please provide a relevant title. 
The following formats should be use for the release notes and PRs.

**Rule/Engine updates:**
newrule(`ruleid`): Title of PR
fixrule(`ruleid`): Title of PR
feature(engine): Title of PR
fix(engine): Title of PR
chore(`ruleid`|engine): Title of PR

**Tool updates:
feature(extension|node|karma|cypress): Title of PR
fix(extension|node|karma|cypress): Title of PR
chore(extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes -->

<!-- Specify what this PR is doing. Remove all that do not apply -->

Add an edit to results.label, to replace its colon characters with hyphen-minus characters. The value of results.label becomes part of a file path. The file path is invalid for Windows if it contains a colon. This change prevents this incompatibility.

### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # -->


### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->


### Testing reference: 

Testing without this change on Windows resulted in ACReporterJSON.js throwing this error:

Error: ENOENT: no such file or directory, open 'C:\Users\c162712\Documents\repos\testaro\ibmOutput\2023-03-02T17:09:01.json'
    at Object.openSync (node:fs:600:3)
    at Object.writeFileSync (node:fs:2221:35)
    at ACReporterJSON.writeObjectToFileAsJSON (C:\Users\c162712\Documents\repos\testaro\node_modules\accessibility-checker\lib\reporters\ACReporterJSON.js:143:12)
    at ACReporterJSON.savePageResults (C:\Users\c162712\Documents\repos\testaro\node_modules\accessibility-checker\lib\reporters\ACReporterJSON.js:116:14)
    at ACReporterJSON.report (C:\Users\c162712\Documents\repos\testaro\node_modules\accessibility-checker\lib\reporters\ACReporterJSON.js:62:14)
    at Function.<anonymous> (C:\Users\c162712\Documents\repos\testaro\node_modules\accessibility-checker\lib\ACReportManager.js:136:60)
    at step (C:\Users\c162712\Documents\repos\testaro\node_modules\accessibility-checker\lib\ACReportManager.js:33:23)
    at Object.next (C:\Users\c162712\Documents\repos\testaro\node_modules\accessibility-checker\lib\ACReportManager.js:14:53)

Testing with this change did not result in any error thrown on both Windows and Macintosh hosts.

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
