### PR TITLE
fixrule(input_haspopup_invalid): Update help link from ARIA 1.1 to ARIA 1.2

### DIFF
--- a/accessibility-checker-engine/help-v4/en-US/input_haspopup_invalid.html
+++ b/accessibility-checker-engine/help-v4/en-US/input_haspopup_invalid.html
@@ -48,7 +48,7 @@
 [text](https://html.spec.whatwg.org/multipage/input.html#text-%28type=text%29-state-and-search-state-%28type=search%29), [search](https://html.spec.whatwg.org/multipage/input.html#text-%28type=text%29-state-and-search-state-%28type=search%29), [tel](https://html.spec.whatwg.org/multipage/input.html#telephone-state-%28type=tel%29), [url](https://html.spec.whatwg.org/multipage/input.html#url-state-%28type=url%29), and [email](https://html.spec.whatwg.org/multipage/input.html#e-mail-state-%28type=email%29) 
 (or inputs with a missing or invalid type) that also have a [list](https://html.spec.whatwg.org/multipage/input.html#attr-input-list) attribute have an implicit role of combobox, which in turn has an implicit `aria-haspopup="listbox"`;
 therefore, developers should not explicitly assign the `aria-haspopup` attribute, which will be either redundant or possibly conflicting.
-When HTML elements use both `aria-*` attributes and their HTML implied equivalents, browsers **_must_** ignore the explicit (redundant or conflicting) ARIA attribute – the native HTML attribute with their [implied ARIA semantics](https://www.w3.org/TR/wai-aria-1.1/#implicit_semantics) take precedence.
+When HTML elements use both `aria-*` attributes and their HTML implied equivalents, browsers **_must_** ignore the explicit (redundant or conflicting) ARIA attribute – the native HTML attribute with their [implied ARIA semantics](https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics) take precedence.
 
 * To ensure that Assistive Technologies (AT) can gather information, proper coding is required so that the end users can understand and interact with the content.
 If standard HTML controls are created according to specification, the conditions of this provision will be met.


### PR DESCRIPTION
<!-- Specify what this PR is doing. Remove all that do not apply -->
* New or modified help files: **input_haspopup_invalid**

### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # -->

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->

### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
