### PR TITLE
fix(checker): Loading of .js config files was broken

### DIFF
--- a/common/module/src/config/ACConfigManager.ts
+++ b/common/module/src/config/ACConfigManager.ts
@@ -213,7 +213,7 @@ function initializeDefaults(config: IConfigInternal) {
  *
  * @memberOf this
  */
-function loadConfigFromYAMLorJSONFile() {
+async function loadConfigFromYAMLorJSONFile() {
     ACConstants.DEBUG && console.log("START 'loadConfigFromYAMLorJSONFile' function");
 
     // Variable Decleration
@@ -281,7 +281,15 @@ function loadConfigFromYAMLorJSONFile() {
                     ACConstants.DEBUG && console.log("Loading: " + jsOrJSONFile)
 
                     // Load in as json or js and return this object
-                    return JSON.parse(fs.readFileSync(fileToCheck).toString());
+                    try {
+                        return require(fileToCheck);
+                    } catch (err) {
+                        try {
+                            return await import(fileToCheck);
+                        } catch (err) {
+                            return JSON.parse(fs.readFileSync(jsOrJSONFile).toString());
+                        }
+                    }
                 }
             } catch (e) {
                 ACConstants.DEBUG && console.log("JSON or JS file does not exists, will load default config.")
@@ -318,7 +326,7 @@ async function processConfiguration(config?) : Promise<IConfigInternal> {
     let configFromFile = null;
 
     // Read in the .yaml (.yml) or .json file to load in the configuration
-    configFromFile = loadConfigFromYAMLorJSONFile();
+    configFromFile = await loadConfigFromYAMLorJSONFile();
 
     ACConstants.DEBUG && console.log("Loaded config from file: ");
     ACConstants.DEBUG && console.log(configFromFile);


### PR DESCRIPTION
<!-- Specify what this PR is doing. Remove all that do not apply -->
* Automated tool bug

### This PR is related to the following issue(s): 
- #1536 

### Additional information can be found here: 
- When switched to common config loader, did not account for loading of js files in the same way as before

### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
