### PR TITLE
fix(widget_tabbable_exists): Update help What to do

### DIFF
--- a/accessibility-checker-engine/help-v4/en-US/widget_tabbable_exists.html
+++ b/accessibility-checker-engine/help-v4/en-US/widget_tabbable_exists.html
@@ -40,19 +40,22 @@
         <div class="bx--row">
             <div class="bx--col-sm-4 bx--col-md-5 bx--col-lg-8 toolMain">
 <!-- Start main panel -->
-<mark-down><script type="text/plain">
+<mark-down><script type="text/plain">)
 
 ### Why is this important?
 
-Unlike native HTML form elements, browsers do not provide keyboard support for graphical user interface (GUI) components that are made accessible with ARIA - authors must incorporate the code for keyboard access.
+Unlike native HTML form elements and controls, browsers do not provide keyboard support for custom ARIA widgets, such as menus and grids, as well as interactive ARIA components, such as toolbars and dialogs.
+Authors have to provide keyboard support in their code to manage the movement of keyboard focus between components, e.g., how the focus moves when the `Tab` and `Shift+Tab` keys are pressed.
+Many assistive technology users rely on being able to use the keyboard to navigate to operate custom components.     
 
 <!-- This is where the code snippet is injected -->
 <div id="locSnippet"></div>
 
 ### What to do
 
-Use the HTML tabindex attribute to include the component in the tab sequence.
-(Refer to the [ARIA practices - Developing a Keyboard Interface](https://w3c.github.io/aria-practices/#keyboard) for more information on how to manage keyboard focus.)
+After deciding that the component should, in fact, be keyboard interactive, use the `tabindex` attribute to include the component in the tab sequence.
+Otherwise, change the role to a non-widget or non-interactive type component so there is no expectation from this rule or from users that the component should be interactable with the keyboard.   
+Refer to the [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/) for more information on how to manage keyboard focus.
 
 </script></mark-down>
 <!-- End main panel -->
@@ -66,13 +69,15 @@ Use the HTML tabindex attribute to include the component in the tab sequence.
 ### About this requirement
 
 * [IBM 2.1.1 Keyboard](https://www.ibm.com/able/requirements/requirements/#2_1_1)
-* [ARIA practices - Developing a Keyboard Interface](https://w3c.github.io/aria-practices/#keyboard)
+* [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
+* [ARIA specification - Widget Roles](https://www.w3.org/TR/2023/REC-wai-aria-1.2-20230606/#widget_roles)    
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People who physically cannot use a pointing device
-* People with tremor or other movement disorders
+* People with tremor or other movement disorders using a keyboard-like switch device
+* People using a keyboard and alternate keyboards or input devices that act as keyboard emulators like speech input software and on-screen keyboards    
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/widget_tabbable_exists.html
+++ b/accessibility-checker-engine/help-v4/en-US/widget_tabbable_exists.html
@@ -44,18 +44,19 @@
 
 ### Why is this important?
 
+Many assistive technology users rely on being able to use the keyboard to navigate to and operate interactive components.
+Users expect that certain elements are not removed from the tab sequence by authors.
+
 Unlike native HTML form elements and controls, browsers do not provide keyboard support for custom ARIA widgets, such as menus and grids, as well as interactive ARIA components, such as toolbars and dialogs.
 Authors have to provide keyboard support in their code to manage the movement of keyboard focus between components, e.g., how the focus moves when the `Tab` and `Shift+Tab` keys are pressed.
-Many assistive technology users rely on being able to use the keyboard to navigate to operate custom components.     
 
 <!-- This is where the code snippet is injected -->
 <div id="locSnippet"></div>
 
 ### What to do
 
-After deciding that the component should, in fact, be keyboard interactive, use the `tabindex` attribute to include the component in the tab sequence.
-Otherwise, change the role to a non-widget or non-interactive type component so there is no expectation from this rule or from users that the component should be interactable with the keyboard.   
-Refer to the [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/) for more information on how to manage keyboard focus.
+* After deciding that the component should, in fact, be keyboard-interactive, use the `tabindex` attribute to include the component in the tab sequence.
+* Otherwise, change the role to a non-widget or non-interactive type component so there is no expectation that the component should be interactable with the keyboard.   
 
 </script></mark-down>
 <!-- End main panel -->

--- a/accessibility-checker-engine/help-v4/en-US/widget_tabbable_exists.html
+++ b/accessibility-checker-engine/help-v4/en-US/widget_tabbable_exists.html
@@ -40,7 +40,7 @@
         <div class="bx--row">
             <div class="bx--col-sm-4 bx--col-md-5 bx--col-lg-8 toolMain">
 <!-- Start main panel -->
-<mark-down><script type="text/plain">)
+<mark-down><script type="text/plain">
 
 ### Why is this important?
 


### PR DESCRIPTION
#924


* New or modified help files: **[widget_tabbable_exists](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/help-v4/en-US/widget_tabbable_exists.html)**

### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with # --> 
- #924 


### Additional information can be found here: 
- RuleID: [widget_tabbable_exists](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/help-v4/en-US/widget_tabbable_exists.html)
- group message: **_Component must have at least one tabbable element_**
- Reason ID: **_fail_no_tabbable_**
- fail message: **_Component with "{0}" role does not have a tabbable element_**<!-- Provide the name of the rule & reference link or doc(s) -->


### Testing reference: 
The following test cases will trigger rule help: 
- ~~[widget-button-tabbable.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_exists_ruleunit/widget-button-tabbable.html) No fail examples.~~
- [widget-link-tabbable.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_exists_ruleunit/widget-link-tabbable.html) 3 fail examples.
- ~~[widget-radio-tabbable.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_exists_ruleunit/widget-radio-tabbable.html) No fail examples.~~

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
