### PR TITLE
fixrule(aria_accessiblename_exists): Fix issue related to the table element with a caption child

### DIFF
--- a/accessibility-checker-engine/src/v4/rules/aria_accessiblename_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_accessiblename_exists.ts
@@ -48,6 +48,12 @@ export let aria_accessiblename_exists: Rule = {
         //skip the rule
         if (VisUtil.isNodeHiddenFromAT(ruleContext)) return null;
 
+        // when table element with a caption as first child
+        if (ruleContext.nodeName.toLocaleLowerCase() === 'table' 
+            && ruleContext.firstElementChild && ruleContext.firstElementChild.nodeName.toLowerCase() === 'caption'
+            && ruleContext.firstElementChild.textContent && ruleContext.firstElementChild.textContent.trim().length > 0)
+            return RulePass("pass");
+
         const invalidRoles = getRolesUndefinedByAria(ruleContext);
         if (invalidRoles && invalidRoles.length > 0) return null;
         const deprecatedRoles = getDeprecatedAriaRoles(ruleContext);

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_accessiblename_exists_ruleunit/aria_table.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_accessiblename_exists_ruleunit/aria_table.html
@@ -1,0 +1,122 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+	<title> Test Suite</title>
+</head>
+
+<body>
+
+<table>
+  <caption>
+    Table 2. Application server is running. Check when complete
+  </caption>
+</table>
+<table aria-label="a table">
+</table>
+<table>
+  <caption></caption>
+</table>
+<table>
+</table>
+
+    
+<script type="text/javascript">
+  UnitTest = {
+      ruleIds: ["aria_accessiblename_exists"],
+      results: [
+      {
+            "ruleId": "aria_accessiblename_exists",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[1]",
+              "aria": "/document[1]/table[1]"
+            },
+            "reasonId": "pass",
+            "message": "An accessible name is provided for the element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_accessiblename_exists",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[2]",
+              "aria": "/document[1]/table[2]"
+            },
+            "reasonId": "pass",
+            "message": "An accessible name is provided for the element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_accessiblename_exists",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[3]",
+              "aria": "/document[1]/table[3]"
+            },
+            "reasonId": "fail_no_accessible_name",
+            "message": "Element <table> with \"table\" role has no accessible name",
+            "messageArgs": [
+              "table",
+              "table"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_accessiblename_exists",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[4]",
+              "aria": "/document[1]/table[4]"
+            },
+            "reasonId": "fail_no_accessible_name",
+            "message": "Element <table> with \"table\" role has no accessible name",
+            "messageArgs": [
+              "table",
+              "table"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+      ]
+  }
+</script>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- The title of this PR will be used for release notes, please provide a relevant title. 
The following formats should be use for the release notes and PRs.

fixrule(aria_accessiblename_exists): Fix issue related to the table element with a caption child

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes -->

<!-- Specify what this PR is doing. Remove all that do not apply -->

Rule bug: aria_accessiblename_exists

### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # -->
#1544 

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->


### Testing reference: 
test/v2/checker/accessibility/rules/aria_accessiblename_exists_ruleunit/aria_table.html

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
