### PR TITLE
fixrule('input_autocomplete_valid'): add additional valid values for the attribute autocomplete

### DIFF
--- a/accessibility-checker-engine/src/v4/rules/input_autocomplete_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_autocomplete_valid.ts
@@ -65,7 +65,7 @@ export let input_autocomplete_valid: Rule = {
             "tokensOnOff": ["on", "off"],
             "tokenOptionalSection": "section-",
             "tokensOptionalPurpose": ["shipping", "billing"],
-            "tokensMandatoryGroup1_password": ["new-password", "current-password"],
+            "tokensMandatoryGroup1_password": ["new-password", "current-password", "one-time-code"],
             "tokensMandatoryGroup1_multiline": ["street-address"],
             "tokensMandatoryGroup1_month": ["cc-exp"],
             "tokensMandatoryGroup1_numeric": ["cc-exp-month",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_autocomplete_valid_ruleunit/autocomplete_attributes.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_autocomplete_valid_ruleunit/autocomplete_attributes.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+	<head>
+		<title>Checks that the HTML autocomplete attribute has a correct value </title>
+	</head>
+	<body>   
+
+    <input type='text' aria-label='digit 1' inputmode="numeric" autocomplete="one-time-code">
+    
+    <script>
+      UnitTest = {
+          ruleIds: ["input_autocomplete_valid"],
+          results: [
+          {
+            "ruleId": "input_autocomplete_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/form[1]/input[3]",
+              "aria": "/document[1]/form[1]/textbox[3]"
+            },
+            "reasonId": 1,
+            "message": "input_autocomplete_valid_1",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_autocomplete_valid",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/form[2]/input[3]",
+              "aria": "/document[1]/form[2]/textbox[3]"
+            },
+            "reasonId": 2,
+            "message": "input_autocomplete_valid_2",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+          ]
+      }
+    </script>
+	</body>
+	</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_autocomplete_valid_ruleunit/autocomplete_attributes.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_autocomplete_valid_ruleunit/autocomplete_attributes.html
@@ -23,8 +23,10 @@
 	</head>
 	<body>   
 
-    <input type='text' aria-label='digit 1' inputmode="numeric" autocomplete="one-time-code">
-    
+    <input type='text' aria-label='a text' autocomplete="one-time-code">
+    <input type='password' aria-label='password' autocomplete="one-time-code">
+    <input type='tel' aria-label='password' autocomplete="one-time-code">
+
     <script>
       UnitTest = {
           ruleIds: ["input_autocomplete_valid"],
@@ -36,11 +38,27 @@
               "PASS"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/form[1]/input[3]",
-              "aria": "/document[1]/form[1]/textbox[3]"
+              "dom": "/html[1]/body[1]/input[1]",
+              "aria": "/document[1]/textbox[1]"
             },
-            "reasonId": 1,
-            "message": "input_autocomplete_valid_1",
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_autocomplete_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/input[2]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"
@@ -52,11 +70,11 @@
               "FAIL"
             ],
             "path": {
-              "dom": "/html[1]/body[1]/form[2]/input[3]",
-              "aria": "/document[1]/form[2]/textbox[3]"
+              "dom": "/html[1]/body[1]/input[3]",
+              "aria": "/document[1]/textbox[2]"
             },
-            "reasonId": 2,
-            "message": "input_autocomplete_valid_2",
+            "reasonId": "Fail_1",
+            "message": "The 'autocomplete' attribute's token(s) are not appropriate for the input form field",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"


### PR DESCRIPTION
<!-- The title of this PR will be used for release notes, please provide a relevant title. 
The following formats should be use for the release notes and PRs.

fixrule('input_autocomplete_valid'): add additional valid values for the attribute autocomplete

Rule bug: input_autocomplete_valid

### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # -->
#1435 

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->


### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
test/v2/checker/accessibility/rules/input_autocomplete_valid_ruleunit/autocomplete_attributes.html

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
