### PR TITLE
fixrule(`aria_child_valid`): fix false positive when a caption element is used as a table child

### DIFF
--- a/accessibility-checker-engine/src/v2/aria/ARIADefinitions.ts
+++ b/accessibility-checker-engine/src/v2/aria/ARIADefinitions.ts
@@ -1584,7 +1584,7 @@ export class ARIADefinitions {
             container: null,
             props: ["aria-colcount", "aria-rowcount"],
             reqProps: null,
-            reqChildren: ["row", "rowgroup"], // rowgroup is not required, but it is allowed
+            reqChildren: ["row", "rowgroup", "caption"], // rowgroup and caption are not required, but it is allowed
             htmlEquiv: "table",
             roleType: "structure",
             nameRequired: true,

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_child_valid_ruleunit/table_children.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_child_valid_ruleunit/table_children.html
@@ -1,0 +1,242 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+	<title> Test Suite</title>
+</head>
+
+<body>
+
+<table>
+  <caption>
+    Table 2. Application server is running. Check when complete
+  </caption>
+  <tr><td>cell</td></tr>
+</table>
+<table aria-label="a table"><tr><td>cell</td></tr>
+</table>
+<table>
+  <caption></caption><tr><td>cell</td></tr>
+</table>
+<table><tr><td>cell</td></tr>
+</table>
+
+
+<script type="text/javascript">
+  UnitTest = {
+      ruleIds: ["aria_child_valid"],
+      results: [
+      {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[1]",
+              "aria": "/document[1]/table[1]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[1]/tbody[1]",
+              "aria": "/document[1]/table[1]/rowgroup[1]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[1]/tbody[1]/tr[1]",
+              "aria": "/document[1]/table[1]/rowgroup[1]/row[1]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[2]",
+              "aria": "/document[1]/table[2]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[2]/tbody[1]",
+              "aria": "/document[1]/table[2]/rowgroup[1]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[2]/tbody[1]/tr[1]",
+              "aria": "/document[1]/table[2]/rowgroup[1]/row[1]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[3]",
+              "aria": "/document[1]/table[3]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[3]/tbody[1]",
+              "aria": "/document[1]/table[3]/rowgroup[1]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[3]/tbody[1]/tr[1]",
+              "aria": "/document[1]/table[3]/rowgroup[1]/row[1]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[4]",
+              "aria": "/document[1]/table[4]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[4]/tbody[1]",
+              "aria": "/document[1]/table[4]/rowgroup[1]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_child_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/table[4]/tbody[1]/tr[1]",
+              "aria": "/document[1]/table[4]/rowgroup[1]/row[1]"
+            },
+            "reasonId": "Pass",
+            "message": "An element with a ARIA role owns a required child",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+      ]
+  }
+</script>
+</body>
+
+</html>


### PR DESCRIPTION
<!-- The title of this PR will be used for release notes, please provide a relevant title. 
The following formats should be use for the release notes and PRs.

fixrule(`aria_child_valid`): fix false positive when a caption element is used as a table child

<!-- Specify what this PR is doing. Remove all that do not apply -->
Rule bug: aria_child_valid

### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # -->
#1445 

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->


### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
test/v2/checker/accessibility/rules/aria_child_valid_ruleunit/table_children.html
   use the old checker and the new checker built with the branch to compare differences: the old one contains the false positive indicating caption is not allowed as a child of a table. The new rule fixed the issue.

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
