### PR TITLE
fixrule(all): update links in Help to ARIA practices

### DIFF
--- a/accessibility-checker-engine/help-v4/en-US/Rpt_Aria_ArticleRoleLabel_Implicit.html
+++ b/accessibility-checker-engine/help-v4/en-US/Rpt_Aria_ArticleRoleLabel_Implicit.html
@@ -76,11 +76,12 @@ For example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Article Role](https://w3c.github.io/aria-practices/#article)
+* [ARIA practices - Landmarks Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/)
+* [ARIA specification - article role](https://www.w3.org/TR/wai-aria-1.2/#article)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/Rpt_Aria_GroupRoleLabel_Implicit.html
+++ b/accessibility-checker-engine/help-v4/en-US/Rpt_Aria_GroupRoleLabel_Implicit.html
@@ -87,12 +87,13 @@ For example:
 
 ### About this requirement
 
-* [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)  
-* [ARIA practices - Group Role](https://w3c.github.io/aria-practices/#group)
+* [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
+* [ARIA practices - Examples by Role](https://www.w3.org/WAI/ARIA/apg/example-index/)  
+* [ARIA specification - group role](https://www.w3.org/TR/wai-aria-1.2/#group)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/application_content_accessible.html
+++ b/accessibility-checker-engine/help-v4/en-US/application_content_accessible.html
@@ -54,7 +54,7 @@ Within an element with the role `"application"`, only focusable elements are acc
 * Verify that the content is decorative;
 * **Or**, associate the content with a focusable element using the `aria-labelledby` or `aria-describedby` attribute;
 * **Or**, place the content in a focusable element that has role `"document"` or `"article"`;
-* **Or**, manage the focus of descendants as described in [Managing Focus](https://w3c.github.io/aria-practices/#managingfocus) by updating the value of `aria-activedescendant` to reference the element containing the focused content.
+* **Or**, manage the focus of descendants as described in [Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/) by updating the value of `aria-activedescendant` to reference the element containing the focused content.
 
 </script></mark-down>
 <!-- End main panel -->
@@ -68,11 +68,11 @@ Within an element with the role `"application"`, only focusable elements are acc
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
-* [ARIA practices - Application Role](https://w3c.github.io/aria-practices/#application)
+* [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People with low vision who have trouble finding or tracking a pointer indicator on the screen
 * People who physically cannot use a pointing device
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_accessiblename_exists.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_accessiblename_exists.html
@@ -87,7 +87,7 @@ If the element supports a role with a required or allowed accessible name:
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
 * [ARIA specification](https://www.w3.org/TR/wai-aria-1.2/)
 * [Accessible Name and Description Computation specification](https://www.w3.org/TR/accname-1.2/)
-* [ARIA authoring practices guide](https://www.w3.org/WAI/ARIA/apg/)
+* [ARIA practices guide](https://www.w3.org/WAI/ARIA/apg/)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_activedescendant_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_activedescendant_valid.html
@@ -80,11 +80,11 @@ The following example* shows a radio group using `aria-activedescendant` to indi
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
-* [ARIA practices - Managing Focus in Composites Using aria-activedescendant](https://w3c.github.io/aria-practices/#kbd_focus_activedescendant)
+* [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/aria_application_labelled.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_application_labelled.html
@@ -76,7 +76,7 @@ For example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
+* [ARIA practices - Providing Accessible Names and Descriptions](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_application_labelled.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_application_labelled.html
@@ -76,11 +76,11 @@ For example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Application Role](https://w3c.github.io/aria-practices/#application)
+* [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/aria_attribute_conflict.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_attribute_conflict.html
@@ -61,7 +61,7 @@ while also implementing the necessary scripting to functionally disable the butt
 ### What to do
 
 * Remove one of the conflicting HTML or ARIA _attributes_ from the element. 
-* Review the "[Rules of ARIA attribute usage by HTML feature](https://w3c.github.io/html-aria/#docconformance-attr)" table to help determine which attribute to correctly use.
+* Review the [Requirements for use of ARIA attributes in place of equivalent HTML attributes](https://www.w3.org/TR/html-aria/#docconformance-attr) table to help determine which attribute to correctly use.
 
 
 Example correctly using an element with only an ARIA attribute:
@@ -84,11 +84,11 @@ Example correctly using an element with only an ARIA attribute:
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
 * [ARIA 1.2 specification - Conflicts with Host Language Semantics](https://www.w3.org/TR/wai-aria-1.2/#host_general_conflict)
-* [ARIA in HTML](https://w3c.github.io/html-aria/#docconformance-attr)
+* [ARIA in HTML specification](https://www.w3.org/TR/html-aria/#docconformance-attr)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People using text only browser with Braille display
 * People with dexterity impairment using voice control
 * People using other assistive technologies that expose accessibility information 

--- a/accessibility-checker-engine/help-v4/en-US/aria_attribute_exists.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_attribute_exists.html
@@ -51,7 +51,7 @@ For each ARIA attribute (a property or a state) used in an element, a valid valu
 
 ### What to do
 
- * Provide a valid value for the empty required attribute(s). Refer to the [ARIA practices - Taxonomy of States and Properties](https://w3c.github.io/aria-practices/#state_prop_taxonomy) for valid values for each attribute.
+ * Provide a valid value for the empty required attribute(s). Refer to the [ARIA practices guide](https://www.w3.org/WAI/ARIA/apg/) for valid values for each attribute.
 
 For example, the following element uses an `aria-live` property. The `aria-live` property requires a valid non-empty value set, one of which is `"polite"`.
 
@@ -71,11 +71,11 @@ For example, the following element uses an `aria-live` property. The `aria-live`
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
-* [ARIA practices - Taxonomy of States and Properties](https://w3c.github.io/aria-practices/#state_prop_taxonomy)
+* [ARIA practices guide](https://www.w3.org/WAI/ARIA/apg/)
 
 ### Who does this affect?
 
- * People using a screen reader, including blind, low vision and neurodivergent people
+ * People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/aria_attribute_redundant.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_attribute_redundant.html
@@ -57,7 +57,7 @@ Conflicting _attributes or values_ cause the ARIA attribute or value to be ignor
 ### What to do
 
 * Remove the unnecessary ARIA attribute that is redundant with HTML attribute.
-* Review the "[Rules of ARIA attribute usage by HTML feature](https://w3c.github.io/html-aria/#docconformance-attr)" table to help determine when an ARIA attribute should be correctly used.
+* Review the [Requirements for use of ARIA attributes in place of equivalent HTML attributes](https://www.w3.org/TR/html-aria/#docconformance-attr) table to help determine when an ARIA attribute should be correctly used.
 
 
 </script></mark-down>
@@ -73,11 +73,11 @@ Conflicting _attributes or values_ cause the ARIA attribute or value to be ignor
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
 * [ARIA 1.2 specification - Conflicts with Host Language Semantics](https://www.w3.org/TR/wai-aria-1.2/#host_general_conflict)
-* [ARIA in HTML - Requirements for use of ARIA attributes in place of equivalent HTML attributes](https://w3c.github.io/html-aria/#docconformance-attr)
+* [ARIA in HTML - Requirements for use of ARIA attributes in place of equivalent HTML attributes](https://www.w3.org/TR/html-aria/#docconformance-attr)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People using text only browser with Braille display
 * People with dexterity impairment using voice control
 * People using other assistive technologies that expose accessibility information 

--- a/accessibility-checker-engine/help-v4/en-US/aria_attribute_required.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_attribute_required.html
@@ -44,7 +44,7 @@
 
 ### Why is this important?
 
-When elements are assigned a ARIA `role`, there are required attributes for that role. These attributes represent states and properties of the element. If these are not defined, assistive technologies may not be able to describe the element or its status to users.
+When elements are assigned an ARIA `role`, there are required attributes for that role. These attributes represent states and properties of the element. If these are not defined, assistive technologies may not be able to describe the element or its status to users.
 
 <!-- This is where the code snippet is injected -->
 <div id="locSnippet"></div>
@@ -80,11 +80,11 @@ The following example shows all the required properties defined for the `scrollb
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
-* [ARIA practices - required states](https://w3c.github.io/aria-practices/#requiredState)
+* [ARIA practices guide](https://www.w3.org/WAI/ARIA/apg/)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People with dexterity impairment using voice control
 
 </script></mark-down>

--- a/accessibility-checker-engine/help-v4/en-US/aria_attribute_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_attribute_valid.html
@@ -75,11 +75,11 @@ For example:
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
-* [ARIA - States and Properties](https://www.w3.org/TR/wai-aria-1.2/#introstates)
+* [ARIA specification - States and Properties](https://www.w3.org/TR/wai-aria-1.2/#introstates)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People with dexterity impairment using voice control
 
 </script></mark-down>

--- a/accessibility-checker-engine/help-v4/en-US/aria_banner_single.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_banner_single.html
@@ -75,7 +75,7 @@ For example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - HTML Sectioning Elements](https://w3c.github.io/aria-practices/examples/landmarks/HTML5.html)
+* [ARIA practices - HTML Sectioning Elements](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/#htmlsectioningelements)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_child_tabbable.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_child_tabbable.html
@@ -73,7 +73,7 @@ The following example shows a component with `role="tree"` with its required chi
 ### About this requirement
 
 * [IBM 2.1.1 Keyboard](https://www.ibm.com/able/requirements/requirements/#2_1_1)
-* [ARIA practices - The Tab Sequence](https://w3c.github.io/aria-practices/#kbd_general_between)
+* [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_child_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_child_valid.html
@@ -91,8 +91,8 @@ Example with an implicit role:
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
-* [ARIA authoring practices guide](https://www.w3.org/WAI/ARIA/apg/)
-* [ARIA specification - Required Owned Elements](https://w3c.github.io/aria/#mustContain)
+* [ARIA practices guide](https://www.w3.org/WAI/ARIA/apg/)
+* [ARIA specification - Required Owned Elements](https://www.w3.org/TR/wai-aria-1.2/#mustContain)
 
 **Note**: this rule's level was lowered from a "Violation" to a "Recommendation" temporarily.
 In some cases, such as `listitems` only being allowed inside `lists`, 
@@ -102,7 +102,7 @@ In most cases this rule should be interpreted as a "Violation" and remediated as
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/aria_complementary_label_visible.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_complementary_label_visible.html
@@ -75,11 +75,12 @@ For example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Complementary Role](https://w3c.github.io/aria-practices/#complementary)
+* [ARIA specification - complementary role](https://www.w3.org/TR/wai-aria-1.2/#complementary)
+* [ARIA practices - Landmark Regions](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/aria_complementary_labelled.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_complementary_labelled.html
@@ -76,7 +76,8 @@ For example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Complementary Role](https://w3c.github.io/aria-practices/#complementary)
+* [ARIA specification - Complementary Role](https://www.w3.org/TR/wai-aria-1.2/#complementary)
+* [ARIA practices - Landmark Regions](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_content_in_landmark.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_content_in_landmark.html
@@ -68,11 +68,11 @@ Landmark roles provide programmatic access to sections of a web page, making it 
 * [IBM 1.3.1 Info and Relationships](https://www.ibm.com/able/requirements/requirements/#1_3_1)
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
 * [WCAG technique ARIA11](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA11)
-* [HTML5 Sectioning Elements](https://w3c.github.io/aria-practices/examples/landmarks/HTML5.html)
+* [ARIA practices- HTML5 Sectioning Elements](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/#htmlsectioningelements)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People who physically cannot use a pointing device
 
 </script></mark-down>

--- a/accessibility-checker-engine/help-v4/en-US/aria_contentinfo_misuse.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_contentinfo_misuse.html
@@ -79,11 +79,12 @@ For example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Contentinfo Role](https://w3c.github.io/aria-practices/#contentinfo)
+* [ARIA specification - contentinfo role](https://www.w3.org/TR/wai-aria-1.2/#contentinfo)
+* [ARIA practices - Landmark Regions](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/aria_contentinfo_single.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_contentinfo_single.html
@@ -75,7 +75,8 @@ For example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Contentinfo Landmark](https://w3c.github.io/aria-practices/examples/landmarks/contentinfo.html)
+* [ARIA specification - Contentinfo Role](https://www.w3.org/TR/wai-aria-1.2/#contentinfo)
+* [ARIA practices - Landmark Regions](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_eventhandler_role_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_eventhandler_role_valid.html
@@ -67,7 +67,7 @@ When UI elements are programmed with script to receive focus and be interactive,
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
-* [ARIA practices - Design Patterns and Widgets](https://w3c.github.io/aria-practices/#aria_ex)
+* [ARIA practices - Patterns](https://www.w3.org/WAI/ARIA/apg/patterns/)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_keyboard_handler_exists.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_keyboard_handler_exists.html
@@ -54,7 +54,7 @@ Unlike native HTML form elements, browsers do not provide keyboard support for g
  * Confirm you can use only the keyboard to navigate to and interact with the UI component;
  * **Or**, if the component is not keyboard accessible, implement `onkeydown` or `onkeypress` keyboard handlers on the element itself using [ARIA practices](https://www.w3.org/TR/wai-aria-practices-1.2);
  * **Or**, if the inaccessible component has required children, implement `onkeydown` or `onkeypress` keyboard handlers on all the required children (example below) or a grandchild of each required child;
- * **Or**, use other methods to provide keyboard access as described in [ARIA practices - Design Patterns and Widgets](https://w3c.github.io/aria-practices/#aria_ex).
+ * **Or**, use other methods to provide keyboard access as described in [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/).
 
 For example:
 
@@ -76,8 +76,8 @@ For example:
 ### About this requirement
 
 * [IBM 2.1.1 Keyboard](https://www.ibm.com/able/requirements/requirements/#2_1_1)  
-* [ARIA practices - Design Patterns and Widgets](https://w3c.github.io/aria-practices/#aria_ex)  
-* [ARIA practices - Developing a Keyboard Interface](https://w3c.github.io/aria-practices/#keyboard)
+* [ARIA practices - Patterns](https://www.w3.org/WAI/ARIA/apg/patterns/)  
+* [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_main_label_unique.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_main_label_unique.html
@@ -83,7 +83,8 @@ For example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Main Landmark](https://w3c.github.io/aria-practices/examples/landmarks/main.html)
+* [ARIA specification - Main](https://www.w3.org/TR/wai-aria-1.2/#main)
+* [ARIA practices - Landmark Regions](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_region_labelled.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_region_labelled.html
@@ -44,7 +44,8 @@
 
 ### Why is this important?
 
-Elements with a `"region"` role must have a label that describes the purpose of the region. This information helps people using assistive technologies to find and navigate the region.
+Elements with a `"region"` role must have a label that describes the purpose of the region.
+This information helps people using assistive technologies to find and navigate the region.
 
 <!-- This is where the code snippet is injected -->
 <div id="locSnippet"></div>
@@ -75,11 +76,14 @@ For example, the HTML `<section>` element has an implicit role of `"region"`:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Region Landmark](https://w3c.github.io/aria-practices/examples/landmarks/region.html)
+* [ARIA practices - Landmark Regions](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
+* [ARIA examples - Region Landmark](https://www.w3.org/WAI/ARIA/apg/patterns/landmarks/examples/region.html)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
+* People with dexterity impairment using voice control
+* People using assistive technologies that expose accessibility information
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/aria_role_redundant.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_role_redundant.html
@@ -81,11 +81,11 @@ In the following corrected examples, only an HTML role is used:
 ### About this requirement
 
 * [IBM 4.1.2 Name, role, value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
-* [ARIA in HTML - Avoid specifying redundant roles](https://w3c.github.io/html-aria/#avoid-specifying-redundant-roles)
+* [ARIA in HTML - Avoid specifying redundant roles](https://www.w3.org/TR/html-aria/#avoid-specifying-redundant-roles)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/aria_widget_labelled.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_widget_labelled.html
@@ -75,11 +75,11 @@ The following code snippet shows a tree widget labelled with an `aria-labelledby
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
 * [ARIA specification - Widget Roles](https://www.w3.org/TR/wai-aria-1.2/#widget_roles)  
-* [W3C - Accessible Name and Description Computation](https://w3c.github.io/accname/#mapping_additional_nd)
+* [W3C - Accessible Name and Description Computation](https://www.w3.org/TR/accname-1.2/#mapping_additional_nd)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People with low vision using screen magnification
 * People with dexterity impairment using voice control
 

--- a/accessibility-checker-engine/help-v4/en-US/combobox_active_descendant.html
+++ b/accessibility-checker-engine/help-v4/en-US/combobox_active_descendant.html
@@ -71,7 +71,7 @@ Alert: The guidance for combobox is changing significantly in ARIA 1.2 due to pr
    </ul>
 ```
 
-Note, example code includes material copied from or derived from [W3C, Accessible Rich Internet Applications (ARIA) latest editor's draft](https://w3c.github.io/aria-practices/#combobox). Copyright © [2018-2021] W3C® (MIT, ERCIM, Keio, Beihang).
+Note, example code includes material copied from or derived from [W3C, ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/). Copyright © [2018-2021] W3C® (MIT, ERCIM, Keio, Beihang).
 
 </script></mark-down>
 <!-- End main panel -->
@@ -85,7 +85,8 @@ Note, example code includes material copied from or derived from [W3C, Accessibl
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
-* [ARIA practices - Combobox](https://w3c.github.io/aria-practices/#combobox)
+* [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
+* [ARIA specification - Combobox](https://www.w3.org/TR/wai-aria-1.2/#combobox)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/combobox_active_descendant.html
+++ b/accessibility-checker-engine/help-v4/en-US/combobox_active_descendant.html
@@ -86,11 +86,11 @@ Note, example code includes material copied from or derived from [W3C, ARIA Auth
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
 * [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
-* [ARIA specification - Combobox](https://www.w3.org/TR/wai-aria-1.2/#combobox)
+* [ARIA specification - combobox role](https://www.w3.org/TR/wai-aria-1.2/#combobox)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/combobox_autocomplete_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/combobox_autocomplete_valid.html
@@ -99,7 +99,7 @@ Combobox with autocomplete list example:
 
 Note 1: The guidance for `combobox` changed significantly in [ARIA specificaation 1.2](https://www.w3.org/TR/wai-aria-1.2/) due to problems with implementation of the previous patterns.
 
-Note 2: Example code includes material copied from or derived from [ARIA practices](https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-list.html). Copyright © [2013-2017] W3C® (MIT, ERCIM, Keio, Beihang).
+Note 2: Example code includes material copied from or derived from [W3C ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/). Copyright © [2013-2017] W3C® (MIT, ERCIM, Keio, Beihang).
     
 </script></mark-down>
 <!-- End main panel -->
@@ -113,12 +113,12 @@ Note 2: Example code includes material copied from or derived from [ARIA practic
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2) 
-* [ARIA practices - Combobox](https://w3c.github.io/aria-practices/#combobox)
+* [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
 * [ARIA specification - aria-autocomplete property](https://www.w3.org/TR/wai-aria-1.2/#aria-autocomplete)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
     
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/combobox_design_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/combobox_design_valid.html
@@ -71,11 +71,11 @@ supported by browsers and assistive technologies.
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
 * [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
-* [ARIA specification - Combobox](https://www.w3.org/TR/wai-aria-1.2/#combobox)
+* [ARIA specification - combobox role](https://www.w3.org/TR/wai-aria-1.2/#combobox)
 
 ### Who does this affect?
 
- * People using a screen reader, including blind, low vision and neurodivergent people
+ * People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/combobox_design_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/combobox_design_valid.html
@@ -56,7 +56,7 @@ supported by browsers and assistive technologies.
 
 ### What to do
 
-* Code the combobox as in the [ARIA practices - Examples](https://w3c.github.io/aria-practices/#examples-1)
+* Code the combobox as in the [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
 
 </script></mark-down>
 <!-- End main panel -->
@@ -70,7 +70,8 @@ supported by browsers and assistive technologies.
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
-* [ARIA practices - Combobox](https://w3c.github.io/aria-practices/#combobox)
+* [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
+* [ARIA specification - Combobox](https://www.w3.org/TR/wai-aria-1.2/#combobox)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/combobox_focusable_elements.html
+++ b/accessibility-checker-engine/help-v4/en-US/combobox_focusable_elements.html
@@ -69,11 +69,12 @@ navigate and interact with the content.
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
-* [ARIA practices - Combobox](https://w3c.github.io/aria-practices/#combobox)
+* [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
+* [ARIA specification - Combobox](https://www.w3.org/TR/wai-aria-1.2/#combobox)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/combobox_focusable_elements.html
+++ b/accessibility-checker-engine/help-v4/en-US/combobox_focusable_elements.html
@@ -70,7 +70,7 @@ navigate and interact with the content.
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
 * [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
-* [ARIA specification - Combobox](https://www.w3.org/TR/wai-aria-1.2/#combobox)
+* [ARIA specification - combobox role](https://www.w3.org/TR/wai-aria-1.2/#combobox)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/combobox_haspopup_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/combobox_haspopup_valid.html
@@ -70,7 +70,7 @@ Alert: The guidance for combobox is changing significantly in ARIA 1.2 due to pr
    </ul>
 ```
 
-Note, example code includes material copied from or derived from [W3C, Accessible Rich Internet Applications (ARIA) latest editor's draft](https://w3c.github.io/aria-practices/#combobox). Copyright © [2018-2021] W3C® (MIT, ERCIM, Keio, Beihang).
+Note, example code includes material copied from or derived from [W3C, ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/). Copyright © [2018-2021] W3C® (MIT, ERCIM, Keio, Beihang).
 
 </script></mark-down>
 <!-- End main panel -->
@@ -84,11 +84,12 @@ Note, example code includes material copied from or derived from [W3C, Accessibl
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
-* [ARIA practices - Combobox](https://w3c.github.io/aria-practices/#combobox)
+* [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
+* [ARIA specification - combobox role](https://www.w3.org/TR/wai-aria-1.2/#combobox)
 
 ### Who does this affect?
 
- * People using screen readers
+ * People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/combobox_popup_reference.html
+++ b/accessibility-checker-engine/help-v4/en-US/combobox_popup_reference.html
@@ -76,7 +76,7 @@ popup to the user.
   </ul>
 ```
 
-Note, example code includes material copied from or derived from [W3C, Accessible Rich Internet Applications (ARIA) latest editor's draft](https://w3c.github.io/aria-practices/#combobox). Copyright © [2018-2021] W3C® (MIT, ERCIM, Keio, Beihang).
+Note, example code includes material copied from or derived from [W3C, ARIA Authoring Practices Guide (APG) ](https://www.w3.org/WAI/ARIA/apg/). Copyright © [2018-2021] W3C® (MIT, ERCIM, Keio, Beihang).
 
 </script></mark-down>
 <!-- End main panel -->
@@ -90,11 +90,12 @@ Note, example code includes material copied from or derived from [W3C, Accessibl
 ### About this requirement
 
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)  
-* [ARIA practices - Combobox](https://w3c.github.io/aria-practices/#combobox)
+* [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
+* [ARIA specification - combobox role](https://www.w3.org/TR/wai-aria-1.2/#combobox)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/help-v4/en-US/skip_main_exists.html
+++ b/accessibility-checker-engine/help-v4/en-US/skip_main_exists.html
@@ -78,11 +78,12 @@ Main landmark example:
 ### About this requirement
 
 * [IBM 2.4.1 Bypass Blocks](https://www.ibm.com/able/requirements/requirements/#2_4_1)
-* [ARIA practices - Main Landmark](https://w3c.github.io/aria-practices/examples/landmarks/main.html)
+* [ARIA practices - Landmark Regions](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/)
+* [ARIA specification - main role](https://www.w3.org/TR/wai-aria-1.2/#main)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People who rely on keyboard control
 
 </script></mark-down>

--- a/accessibility-checker-engine/help-v4/en-US/widget_tabbable_single.html
+++ b/accessibility-checker-engine/help-v4/en-US/widget_tabbable_single.html
@@ -44,14 +44,15 @@
 
 ### Why is this important?
 
-The primary keyboard navigation convention uses Tab and `Shift+Tab` key commands to move focus from one UI component to another. Other keys (primarily the arrow keys) move focus within components comprised of multiple focusable elements. Authors must follow this convention and provide no more than one tab stop per component (providing keyboard focus).
+The primary keyboard navigation convention uses `Tab` and `Shift+Tab` key commands to move focus from one UI component to another.
+Other keys (primarily the arrow keys) move focus within components comprised of multiple focusable elements.
+Authors must follow this convention and provide no more than one tab stop per component (providing keyboard focus).
 
 <!-- This is where the code snippet is injected -->
 <div id="locSnippet"></div>
 
 ### What to do
-* Modify the widget’s keyboard navigation model to contain only one tab stop to set focus in or on the widget. 
-(Refer to the [ARIA practices](https://w3c.github.io/aria-practices/#keyboard) for more information on how to manage keyboard focus.)
+* Modify the widget’s keyboard navigation model to contain only one tab stop to set focus in or on the widget.
 
 </script></mark-down>
 <!-- End main panel -->
@@ -65,11 +66,11 @@ The primary keyboard navigation convention uses Tab and `Shift+Tab` key commands
 ### About this requirement
 
 * [IBM 2.1.1 Keyboard](https://www.ibm.com/able/requirements/requirements/#2_1_1)
-* [ARIA practices - The Tab Sequence](https://w3c.github.io/aria-practices/#kbd_general_between)
+* [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
 
 ### Who does this affect?
 
-* People using a screen reader, including blind, low vision and neurodivergent people
+* People using a screen reader, including blind, low vision, and neurodivergent people
 * People who physically cannot use a pointing device
 * People with tremor or other movement disorders
 


### PR DESCRIPTION
<!-- Specify what this PR is doing. Remove all that do not apply -->
**Modified help files**: see 31 Help files changed, including `...accessibility-checker-engine/help-v4/en-US/`:
1. Rpt_Aria_ArticleRoleLabel_Implicit.html
2. Rpt_Aria_GroupRoleLabel_Implicit.html
3. application_content_accessible.html
4. aria_activedescendant_valid.html
5. aria_application_labelled.html
6. aria_attribute_conflict.html
7. aria_attribute_exists.html
8. aria_attribute_redundant.html
9. aria_attribute_required.html
10. aria_banner_single.html
11. aria_child_tabbable.html
12. aria_child_valid.html
13. aria_complementary_label_visible.html
14. aria_content_in_landmark
15. etc.


### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # --> #1540 


### Testing reference: 
None of the links in updated Help should go to a page with 
[Content Moved - The content previously at this location has been moved to ...](https://w3c.github.io/aria-practices/)
or [Content Moved - The content previously at this location has been moved to ...](https://w3c.github.io/aria-practices/examples/landmarks/HTML5.html) 
The test cases that trigger the Help files with the link changes are in the `IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/...ruleunit/` directories, such as the following:
1. [Rpt_Aria_ArticleRoleLabel_Implicit_ruleunit/hasEmptyAriaLabel.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/Rpt_Aria_ArticleRoleLabel_Implicit_ruleunit/hasEmptyAriaLabel.html)
2. [Rpt_Aria_GroupRoleLabel_Implicit_ruleunit/hasEmptyAriaLabel.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/Rpt_Aria_GroupRoleLabel_Implicit_ruleunit/hasEmptyAriaLabel.html)
3. [application_content_accessible_ruleunit/Application-Role-Text.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/application_content_accessible_ruleunit/Application-Role-Text.html)
4. [aria_activedescendant_valid_ruleunit/D808_3.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_activedescendant_valid_ruleunit/D808_3.html)
5. [aria_application_labelled_ruleunit/hasNoLabel.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_application_labelled_ruleunit/hasNoLabel.html)
6. [aria_attribute_conflict_ruleunit/Fail.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_attribute_conflict_ruleunit/Fail.html)
7. [aria_attribute_exists_ruleunit/aria_checked_empty.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_attribute_exists_ruleunit/aria_checked_empty.html)
8. [aria_attribute_redundant_ruleunit/Fail.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_attribute_redundant_ruleunit/Fail.html)
9. [aria_attribute_required_ruleunit/D902.html](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_attribute_required_ruleunit/D902.html)
10. etc.

Note: the tester still has to select the correct issue identified and click the `Learn more` link to see the updated Help file with the updated links.

#### Examples of the new links:
- [ARIA practices guide](https://www.w3.org/WAI/ARIA/apg/)
- [ARIA practices - Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
- [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
- [ARIA practices- HTML5 Sectioning Elements](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/#htmlsectioningelements)
- [ARIA practices - Providing Accessible Names and Descriptions](https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/)
- [ARIA specification](https://www.w3.org/TR/wai-aria-1.2/)
- [ARIA specification - combobox role](https://www.w3.org/TR/wai-aria-1.2/#combobox)
- [ARIA specification - States and Properties](https://www.w3.org/TR/wai-aria-1.2/#introstates)
- [ARIA 1.2 specification - Conflicts with Host Language Semantics](https://www.w3.org/TR/wai-aria-1.2/#host_general_conflict) when a version is important
- [Accessible Name and Description Computation specification](https://www.w3.org/TR/accname-1.2/)
- [ARIA in HTML - Requirements for use of ARIA attributes in place of equivalent HTML attributes](https://www.w3.org/TR/html-aria/#docconformance-attr)

Note: The automated build checks the URL syntax changes to ensure the link changes are valid.

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
