### PR TITLE
chore(engine): Fix issue with running local tests on Mac with type definitions

### DIFF
--- a/accessibility-checker-engine/karma.conf.js
+++ b/accessibility-checker-engine/karma.conf.js
@@ -18,6 +18,9 @@
     const path = require("path");
     let webpackConfig = require("./webpack-debug.config");
     delete webpackConfig.output;
+    webpackConfig.module.rules[0].options = {
+        configFile: "tsconfig-nodeclare.json"
+    }
     webpackConfig.module.rules.push({
         test: /\.ts$/,
         exclude: [path.resolve(__dirname, "test")],

--- a/accessibility-checker-engine/tsconfig-nodeclare.json
+++ b/accessibility-checker-engine/tsconfig-nodeclare.json
@@ -1,0 +1,29 @@
+{
+    "compilerOptions": {
+        "declaration": false,
+        "allowJs": false,
+        "target": "ES5",
+        "removeComments": false,
+        "noEmitOnError": true,
+        "sourceMap": true,
+        "moduleResolution": "node",
+        "alwaysStrict": true,
+        "experimentalDecorators": true,
+        "resolveJsonModule": true,
+        // "module": "commonjs",
+        "outDir": "dist",
+        "emitDecoratorMetadata": true,
+        "lib": [
+            "dom",
+            "es7"
+         ]
+    },
+    "include": [
+        "src/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "coverage",
+        ".nyc_output"
+    ]
+}

--- a/accessibility-checker-engine/webpack-debug.config.js
+++ b/accessibility-checker-engine/webpack-debug.config.js
@@ -25,7 +25,7 @@ module.exports = {
     module: {
         rules: [{
             test: /\.tsx?$/,
-            use: 'ts-loader',
+            loader: "ts-loader",
             exclude: /node_modules/
         }]
     },

--- a/accessibility-checker/test/webdriverio/.npmrc
+++ b/accessibility-checker/test/webdriverio/.npmrc
@@ -1,0 +1,1 @@
+detect_chromedriver_version=true


### PR DESCRIPTION
<!-- Specify what this PR is doing. Remove all that do not apply -->
* Other (Provide information)

On Mac OS, something in the Karma/Webpack environment is getting confused by the .d.ts files. There are needed for development, but not for testing. This PR omits generating those files when running the 'npm test' on the engine.

### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # -->

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->

### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [ ] I understand that the title of this PR will be used for the next release notes.
