### PR TITLE
fix(engine): Mapping to SCs incorrect for ACT report

### DIFF
--- a/accessibility-checker/test-act-w3/act.js
+++ b/accessibility-checker/test-act-w3/act.js
@@ -83,16 +83,11 @@ async function getTestcases() {
 async function getAssertion(ruleId, aceRules, result) {
     const ruleset = await rulesetP;
     let ruleTitle = "";
+    let scs = []
     for (let aceRule of aceRules) {
         if (aceRule.ruleId === ruleId) {
             ruleTitle = `${aceRule.ruleId}:${aceRule.reasonIds.join(",")}`;
-        }
-    }
-    return {
-        "@type": "Assertion",
-        "test": { 
-            "title": ruleTitle,
-            "isPartOf": ruleset.checkpoints
+            scs = scs.concat(ruleset.checkpoints
                 // Get checkpoints that have this rule
                 .filter(cp => (
                     cp.rules 
@@ -101,9 +96,16 @@ async function getAssertion(ruleId, aceRules, result) {
                         rule.id === ruleId
                         // and either maps to all reasons, or one the these reasons is selected
                         && (!rule.reasonCodes || rule.reasonCodes.filter(code => aceRule.reasonIds.includes(code)))
-                    ).length > 0)
+                    )).length > 0
                 // Replace with the scId
-                )).map(cp => cp.scId)
+                )).map(cp => cp.scId));            
+        }
+    }
+    return {
+        "@type": "Assertion",
+        "test": { 
+            "title": ruleTitle,
+            "isPartOf": Array.from(new Set(scs))
         },
         "result": { "outcome": result }
     }


### PR DESCRIPTION
<!-- Specify what this PR is doing. Remove all that do not apply -->
* Other (Provide information)
Wilco reported that we were mapping results to all SCs. Our code for generating the ACT report had some syntax errors.

### This PR is related to the following issue(s): 
- 

### Additional information can be found here: 
- 

### Testing reference: 
- 

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [ ] I understand that the title of this PR will be used for the next release notes.
