### PR TITLE
feature(extension): Options updated for selecting WCAG 2.2 related rules 

### DIFF
--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -338,8 +338,8 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
             <aside aria-label="About Accessibility Checker Options">
             <p>
                 By default, the Accessibility Checker uses a set of rules that correspond to 
-                the WCAG standards plus some additional IBM requirements. Rule sets 
-                are available for specific WCAG versions. The rule sets are updated regularly, 
+                the WCAG standards plus some additional IBM requirements. Guidelines 
+                are available for specific WCAG versions. The guidelines are updated regularly, 
                 and each update has a date of deployment. If you need to replicate an earlier test, 
                 choose the deployment date of the original test. 
             </p>

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -344,9 +344,18 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                 choose the deployment date of the original test. 
             </p>
             <p>    
-                See the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/" target="_blank" style={{ color: '#002D9C' }} >IBM Accessibility requirements</Link> that need to be met for conforming with standards and regulations.</p>
+                See the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/" target="_blank" style={{ color: '#002D9C' }} >IBM Accessibility requirements</Link> that need to be met 
+                for conforming to standards and regulations.</p>
             </p>
-                <p>
+            <p 
+                <strong>Rule updates</strong>: For details on rule changes at each deployment, 
+                see the <Link inline={true} size="md" className="link" href="https://github.com/IBMa/equal-access/releases" target="_blank" style={{ color: '#002D9C' }}>Release notes</Link>
+            </p>
+            <p>
+                <strong>Rule sets</strong>: A packaged set of guidelines, each of which is a collection of rules mapped to the requirements in the accessibility guideline,
+                see the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link>
+            </p>
+            <p>
                 For more in-depth guidance, see <Link 
                     size="lg"
                     inline={true}

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -464,15 +464,15 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                             }).bind(this)}
                         >
                             <p style={{ maxWidth: "100%" }}><strong>Dated deployment</strong>: Use a rule set from a specific date
-                                for consistent testing throughout a project to replicate an earlier test</p>
+                                for consistent testing throughout a project to replicate an earlier test.</p>
 
                             <p style={{ maxWidth: "100%" }}><strong>Preview rules</strong>: Try an experimental preview of a possible future rule set.</p>
 
                             <p style={{ maxWidth: "100%" }}><strong>Rule updates</strong>: For details on rule changes at each deployment, 
-                                see the <Link inline={true} size="md" className="link" href="https://github.com/IBMa/equal-access/releases" target="_blank" style={{ color: '#002D9C' }}>Release notes</Link></p>
+                                see the <Link inline={true} size="md" className="link" href="https://github.com/IBMa/equal-access/releases" target="_blank" style={{ color: '#002D9C' }}>Release notes</Link>.</p>
 
                             <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: A packaged set of guidelines, each of which is a collection of rules mapped to the requirements in the accessibility guideline,
-                                see the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>
+                                see the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link>.</p>
                         </Modal>, document.body)}
 
                         {typeof document === 'undefined' ? null : ReactDOM.createPortal(<Modal
@@ -546,11 +546,16 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                             }).bind(this)}
                         >
                             <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.2</strong>: Rules for WCAG 2.1 plus additional IBM requirements.</p>
+                            
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: Rules for the latest W3C specification. Content that conforms to WCAG 2.2 also conforms to 2.1 and 2.0.</p>
+                            
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0. Referenced by EN 301 549 and other policies, but not the latest W3C specification.</p>
+                            
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA)</strong>: Referenced by US Section 508, but not the latest W3C specification.</p>
+                            
                             <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: A packaged set of guidelines, each of which is a collection of rules mapped to requirements in the accessibility guideline, 
-                                see <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link>.</p>
+                                see the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link>.</p>
+                            
                         </Modal>, document.body)}
                     </div>
 

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -338,10 +338,14 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
             <aside aria-label="About Accessibility Checker Options">
             <p>
                 By default, the Accessibility Checker uses a set of rules that correspond to 
-                the most recent WCAG standards plus some additional IBM requirements. Rule sets 
+                the WCAG standards plus some additional IBM requirements. Rule sets 
                 for specific WCAG versions are also available. The rule sets are updated regularly, 
                 and each update has a date of deployment. If you need to replicate an earlier test, 
-                choose the deployment date of the original test.
+                choose the deployment date of the original test. 
+            </p>
+            <p>    
+                Experiment with a preview of a possible future rule set,
+                such as the new WCAG 2.2 related rules, by selecting "Preview Rules".
             </p>
             <p>
                 For more in-depth guidance, see <Link 
@@ -429,12 +433,17 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                                 this.setState({ modalRuleSet: false });
                             }).bind(this)}
                         >
-                            <p style={{ maxWidth: "100%" }}><strong>Dated deployment: </strong> Use a rule set from a specific date
+                            <p style={{ maxWidth: "100%" }}><strong>Dated deployment</strong>: Use a rule set from a specific date
                                 for consistent testing throughout a project to replicate an earlier test</p>
 
-                            <p style={{ maxWidth: "100%" }}><strong>Preview rules: </strong> Try an experimental preview of possible future rule set</p>
+                            <p style={{ maxWidth: "100%" }}><strong>Preview rules</strong>: Try an experimental preview of a possible future rule set
+                                such as the new WCAG 2.2 related rules</p>
 
-                            <p style={{ maxWidth: "100%" }}>For details on rule set changes between deployments, see <Link inline={true} size="md" className="link" href="https://github.com/IBMa/equal-access/releases" target="_blank" style={{ color: '#002D9C' }}>Release notes</Link></p>
+                            <p style={{ maxWidth: "100%" }}><strong>Rule updates</strong>: For details on rule changes at each deployment, 
+                                see the <Link inline={true} size="md" className="link" href="https://github.com/IBMa/equal-access/releases" target="_blank" style={{ color: '#002D9C' }}>Release notes</Link></p>
+
+                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: For a listing of the rules mapped to requirements in a selected accessibility guideline, 
+                                see <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>
                         </Modal>, document.body)}
 
                         {typeof document === 'undefined' ? null : ReactDOM.createPortal(<Modal
@@ -460,7 +469,7 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                     {/**** Select ruleset / policy  */}
                     <div>
                         <div className="select-a-rule-set" style={{ marginTop: "1rem" }}>
-                            Select accessibility guidelines
+                            Select an accessibility guideline
                             <Button
                                 renderIcon={Information}
                                 kind="ghost"
@@ -478,7 +487,7 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                         {!this.state.selected_archive && <DropdownSkeleton />}
                         {this.state.selected_archive && <>
                             <Dropdown
-                                ariaLabel="Select accessibility guidelines"
+                                ariaLabel="Select an accessibility guideline"
                                 disabled={false}
                                 helperText={this.state.selected_ruleset && ("Currently active: " + this.getGuideline(this.state.lastSettings?.selected_archive!, this.state.lastSettings?.selected_ruleset.id!).name)}
                                 id="rulesetSelection"
@@ -500,16 +509,20 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
 
                         {typeof document === 'undefined' ? null : ReactDOM.createPortal(<Modal
                             aria-label="Guidelines information"
-                            modalHeading="Selecting accessibility guidelines"
+                            modalHeading="Selecting an accessibility guideline"
                             passiveModal={true}
                             open={this.state.modalGuidelines}
                             onRequestClose={(() => {
                                 this.setState({ modalGuidelines: false });
                             }).bind(this)}
                         >
-                            <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility: </strong> Rules for WCAG 2.1 AA plus additional IBM requirements</p>
-                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA): </strong> This is the current W3C recommendation. Content that conforms to WCAG 2.1 also conforms to WCAG 2.0</p>
-                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA): </strong> Referenced by US Section 508, but not the latest W3C recommendation</p>
+                            <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.2</strong>: Rules for WCAG 2.1 plus additional IBM requirements.
+                                See the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/" target="_blank" style={{ color: '#002D9C' }} >IBM Accessibility requirements</Link> that need to be met for recent releases of standards and regulations.</p>
+                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: This is the latest W3C specification. "Preview rules" must also be selected.</p>
+                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0</p>
+                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA)</strong>: Referenced by US Section 508, but not the latest W3C specifiction</p>
+                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: For a listing of the rules mapped to requirements in the selected accessibility guideline, 
+                                see <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>
                         </Modal>, document.body)}
                     </div>
 

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -346,18 +346,17 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
             <p>    
                 See the <Link 
                             inline={true} 
-                            size="md" 
+                            size="lg"
                             className="link" 
-                            href="https://www.ibm.com/able/requirements/" 
+                            href="https://www.ibm.com/able/requirements/requirements"
                             target="_blank" rel="noopener noreferred"
-                            >IBM Accessibility requirements</Link> 
-                that need to be met for conforming to standards and regulations.
+                            >IBM Accessibility requirements</Link> that need to be met to comply with standards and regulations.
             </p>
             <p> 
                 <strong>Rule updates</strong>: For details on rule changes at each deployment, 
                 see the <Link 
                             inline={true} 
-                            size="md" 
+                            size="lg" 
                             className="link"
                             href="https://github.com/IBMa/equal-access/releases"
                             target="_blank" rel="noopener noreferred"
@@ -369,7 +368,7 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                 each of which is a collection of rules mapped to the requirements in the accessibility guideline,
                 see the <Link
                             inline={true}
-                            size="md"
+                            size="lg"
                             className="link"
                             href="https://www.ibm.com/able/requirements/checker-rule-sets"
                             target="_blank" rel="noopener noreferred"

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -344,21 +344,43 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                 choose the deployment date of the original test. 
             </p>
             <p>    
-                See the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/" target="_blank" style={{ color: '#002D9C' }} >IBM Accessibility requirements</Link> that need to be met 
-                for conforming to standards and regulations.</p>
+                See the <Link 
+                            inline={true} 
+                            size="md" 
+                            className="link" 
+                            href="https://www.ibm.com/able/requirements/" 
+                            target="_blank" rel="noopener noreferred"
+                            >IBM Accessibility requirements</Link> 
+                that need to be met for conforming to standards and regulations.
             </p>
-            <p 
+            <p> 
                 <strong>Rule updates</strong>: For details on rule changes at each deployment, 
-                see the <Link inline={true} size="md" className="link" href="https://github.com/IBMa/equal-access/releases" target="_blank" style={{ color: '#002D9C' }}>Release notes</Link>
+                see the <Link 
+                            inline={true} 
+                            size="md" 
+                            className="link"
+                            href="https://github.com/IBMa/equal-access/releases"
+                            target="_blank" rel="noopener noreferred"
+                            // style={{ color: '#002D9C' }}
+                            >Release notes</Link>.
             </p>
             <p>
-                <strong>Rule sets</strong>: A packaged set of guidelines, each of which is a collection of rules mapped to the requirements in the accessibility guideline,
-                see the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link>
+                <strong>Rule sets</strong>: A packaged set of guidelines, 
+                each of which is a collection of rules mapped to the requirements in the accessibility guideline,
+                see the <Link
+                            inline={true}
+                            size="md"
+                            className="link"
+                            href="https://www.ibm.com/able/requirements/checker-rule-sets"
+                            target="_blank" rel="noopener noreferred"
+                            // style={{ color: '#002D9C' }}
+                            >Checker rule sets</Link>.
             </p>
             <p>
                 For more in-depth guidance, see <Link 
                     size="lg"
                     inline={true}
+                    // should className="Link" be used?
                     href={chrome.runtime.getURL("usingAC.html")}
                     target="_blank"
                     rel="noopener noreferred"

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -515,7 +515,7 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                             }).bind(this)}
                         >
                             <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.2</strong>: Rules for WCAG 2.1 plus additional IBM requirements
-                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: Rules for the latest W3C specification. The "Preview Rules" rule set must also be selected.</p>
+                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: Rules for the latest W3C specification. Content that conforms to WCAG 2.2 also conforms to 2.1 and 2.0.</p>
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0. Referenced by EN 301 549 and other policies, but not the latest W3C specification</p>
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA)</strong>: Referenced by US Section 508, but not the latest W3C specifiction</p>
                             <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: List of the rules mapped to requirements in the selected accessibility guideline, 

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -518,7 +518,7 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: Rules for the latest W3C specification. Content that conforms to WCAG 2.2 also conforms to 2.1 and 2.0.</p>
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0. Referenced by EN 301 549 and other policies, but not the latest W3C specification</p>
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA)</strong>: Referenced by US Section 508, but not the latest W3C specifiction</p>
-                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: List of the rules mapped to requirements in the selected accessibility guideline, 
+                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: A packaged set of guidelines, each of which is a collection of rules mapped to requirements in the accessibility guideline, 
                                 see <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>
                         </Modal>, document.body)}
                     </div>

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -517,7 +517,7 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                         >
                             <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.2</strong>: Rules for WCAG 2.1 plus additional IBM requirements
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: Rules for the latest W3C specification. The "Preview Rules" rule set must also be selected.</p>
-                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0</p>
+                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0. Referenced by EN 301 549 and other policies, but not the latest W3C specification</p>
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA)</strong>: Referenced by US Section 508, but not the latest W3C specifiction</p>
                             <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: List of the rules mapped to requirements in the selected accessibility guideline, 
                                 see <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -435,8 +435,7 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                             <p style={{ maxWidth: "100%" }}><strong>Dated deployment</strong>: Use a rule set from a specific date
                                 for consistent testing throughout a project to replicate an earlier test</p>
 
-                            <p style={{ maxWidth: "100%" }}><strong>Preview rules</strong>: Try an experimental preview of a possible future rule set
-                                such as the new WCAG 2.2 related rules</p>
+                            <p style={{ maxWidth: "100%" }}><strong>Preview rules</strong>: Try an experimental preview of a possible future rule set.</p>
 
                             <p style={{ maxWidth: "100%" }}><strong>Rule updates</strong>: For details on rule changes at each deployment, 
                                 see the <Link inline={true} size="md" className="link" href="https://github.com/IBMa/equal-access/releases" target="_blank" style={{ color: '#002D9C' }}>Release notes</Link></p>

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -440,7 +440,7 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                             <p style={{ maxWidth: "100%" }}><strong>Rule updates</strong>: For details on rule changes at each deployment, 
                                 see the <Link inline={true} size="md" className="link" href="https://github.com/IBMa/equal-access/releases" target="_blank" style={{ color: '#002D9C' }}>Release notes</Link></p>
 
-                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: List of the rules mapped to requirements in a selected accessibility guideline, 
+                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: A packaged set of guidelines, each of which is a collection of rules mapped to the requirements in the accessibility guideline,
                                 see the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>
                         </Modal>, document.body)}
 

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -545,12 +545,12 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                                 this.setState({ modalGuidelines: false });
                             }).bind(this)}
                         >
-                            <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.2</strong>: Rules for WCAG 2.1 plus additional IBM requirements
+                            <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.2</strong>: Rules for WCAG 2.1 plus additional IBM requirements.</p>
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: Rules for the latest W3C specification. Content that conforms to WCAG 2.2 also conforms to 2.1 and 2.0.</p>
-                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0. Referenced by EN 301 549 and other policies, but not the latest W3C specification</p>
-                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA)</strong>: Referenced by US Section 508, but not the latest W3C specifiction</p>
+                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0. Referenced by EN 301 549 and other policies, but not the latest W3C specification.</p>
+                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA)</strong>: Referenced by US Section 508, but not the latest W3C specification.</p>
                             <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: A packaged set of guidelines, each of which is a collection of rules mapped to requirements in the accessibility guideline, 
-                                see <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>
+                                see <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link>.</p>
                         </Modal>, document.body)}
                     </div>
 

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -339,15 +339,18 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
             <p>
                 By default, the Accessibility Checker uses a set of rules that correspond to 
                 the WCAG standards plus some additional IBM requirements. Rule sets 
-                for specific WCAG versions are also available. The rule sets are updated regularly, 
+                are available for specific WCAG versions. The rule sets are updated regularly, 
                 and each update has a date of deployment. If you need to replicate an earlier test, 
                 choose the deployment date of the original test. 
             </p>
             <p>    
                 Experiment with a preview of a possible future rule set,
-                such as the new WCAG 2.2 related rules, by selecting "Preview Rules".
+                such as the new WCAG 2.2 related rules, by selecting the "Preview Rules" rule set.
             </p>
-            <p>
+            <p>    
+                See the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/" target="_blank" style={{ color: '#002D9C' }} >IBM Accessibility requirements</Link> that need to be met for conforming with standards and regulations.</p>
+            </p>
+                <p>
                 For more in-depth guidance, see <Link 
                     size="lg"
                     inline={true}
@@ -442,8 +445,8 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                             <p style={{ maxWidth: "100%" }}><strong>Rule updates</strong>: For details on rule changes at each deployment, 
                                 see the <Link inline={true} size="md" className="link" href="https://github.com/IBMa/equal-access/releases" target="_blank" style={{ color: '#002D9C' }}>Release notes</Link></p>
 
-                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: For a listing of the rules mapped to requirements in a selected accessibility guideline, 
-                                see <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>
+                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: List of the rules mapped to requirements in a selected accessibility guideline, 
+                                see the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>
                         </Modal>, document.body)}
 
                         {typeof document === 'undefined' ? null : ReactDOM.createPortal(<Modal
@@ -516,12 +519,11 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                                 this.setState({ modalGuidelines: false });
                             }).bind(this)}
                         >
-                            <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.2</strong>: Rules for WCAG 2.1 plus additional IBM requirements.
-                                See the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/" target="_blank" style={{ color: '#002D9C' }} >IBM Accessibility requirements</Link> that need to be met for recent releases of standards and regulations.</p>
-                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: This is the latest W3C specification. "Preview rules" must also be selected.</p>
+                            <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.2</strong>: Rules for WCAG 2.1 plus additional IBM requirements
+                            <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: Rules for the latest W3C specification. The "Preview Rules" rule set must also be selected.</p>
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0</p>
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA)</strong>: Referenced by US Section 508, but not the latest W3C specifiction</p>
-                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: For a listing of the rules mapped to requirements in the selected accessibility guideline, 
+                            <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: List of the rules mapped to requirements in the selected accessibility guideline, 
                                 see <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link></p>
                         </Modal>, document.body)}
                     </div>

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -344,10 +344,6 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                 choose the deployment date of the original test. 
             </p>
             <p>    
-                Experiment with a preview of a possible future rule set,
-                such as the new WCAG 2.2 related rules, by selecting the "Preview Rules" rule set.
-            </p>
-            <p>    
                 See the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/" target="_blank" style={{ color: '#002D9C' }} >IBM Accessibility requirements</Link> that need to be met for conforming with standards and regulations.</p>
             </p>
                 <p>


### PR DESCRIPTION
<!-- Specify what this PR is doing. Remove all that do not apply -->
1. Extension UI "IBM Accessibility Checker options" page update
2. Rule set info pop-up update for "Select a rule set deployment date"
3. Guidelines info pop-up update for "Select an accessibility guideline"

### This PR is related to the following issue(s): 
- [E2E 5966 Checker options page needs updates for WCAG 2.2](https://github.ibm.com/IBMa/E2E/issues/5966) 
<!-- Provide each ticket on a new line with # -->


### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->


### Testing procedures: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
1. Open Checker settings
2. Open `Rule set info` icon  at the "**_Select a rule set deployment date_**" heading 
3. Review the pop-up for text format, grammar, etc. 
4. Select the `Preview Rules` option at the end
5. Open `Guidelines info` icon at the "**_Select an accessibility guideline_**" heading
6. Review the pop-up for text format, grammar, etc.
7. Select the `WCAG 2.2 (A, AA)` option
8. Save

![image](https://github.com/IBMa/equal-access/assets/16193609/aa09c5c6-86c9-421a-9894-b9d7470a353c)
![image](https://github.com/IBMa/equal-access/assets/16193609/d053da01-b779-423d-b360-92fdd548677b)


### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
