### PR TITLE
fixrule(`input_label_exists`) fix issue related to button element with a label

### DIFF
--- a/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
@@ -2188,6 +2188,7 @@ export class RPTUtil {
         // Test  a) if the parent is a label which is the implicit label
         //       b) if the form element is the first child of the label
         //       c) if the form element requires an implicit or explicit label : "input",  "textarea", "select", "keygen", "progress", "meter", "output"
+        //       d) form elements which may have a label: button
         // form elements that do not require implicit or explicit label element are:
         // "optgroup", "option", "datalist"(added later). These were handled differently in the main rule, might need to refactor the code later
 

--- a/accessibility-checker-engine/src/v4/rules/input_label_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_label_exists.ts
@@ -140,6 +140,17 @@ export let input_label_exists: Rule = {
             if (!passed) POF = 2 + textTypes.length + buttonTypes.length + 1;
         }
 
+        //check if a native button is labelled
+        if (!passed && nodeName == "button") {
+             if (RPTUtil.hasImplicitLabel(ruleContext))
+                passed = true;
+             else {
+                let label = RPTUtil.getLabelForElement(ruleContext);
+                if (label && RPTUtil.hasInnerContentHidden(label))
+                    passed = true;    
+             }    
+        }
+
         // Rpt_Aria_ValidIdRef determines if the aria-labelledby id points to a valid element
         if (!passed && (buttonTypes.indexOf(type) !== -1)) {
             if (ruleContext.hasAttribute("class") && ruleContext.getAttribute("class") == "dijitOffScreen" && DOMWalker.parentElement(ruleContext).hasAttribute("widgetid")) {
@@ -163,23 +174,7 @@ export let input_label_exists: Rule = {
             passed = RPTUtil.attributeNonEmpty(ruleContext, "label") || ruleContext.innerHTML.trim().length > 0;
             if (!passed) POF = 2 + textTypes.length + buttonTypes.length + 3;
         } 
-        /**if (!passed) {
-            // check aria role
-            //any more roles for input? 
-            const nameFromBoth = RPTUtil.hasRoleInSemantics(ruleContext, "menuitemcheckbox") || RPTUtil.hasRoleInSemantics(ruleContext, "menuitemradio")
-                || RPTUtil.hasRoleInSemantics(ruleContext, "radio") || RPTUtil.hasRoleInSemantics(ruleContext, "checkbox");
-            const nameFromAuthorOnly = RPTUtil.hasRoleInSemantics(ruleContext, "listbox") || RPTUtil.hasRoleInSemantics(ruleContext, "searchbox") 
-                || RPTUtil.hasRoleInSemantics(ruleContext, "textbox") || RPTUtil.hasRoleInSemantics(ruleContext, "combobox")
-                || !RPTUtil.hasAnyRole(ruleContext, true);   
-            
-            if (nameFromBoth)
-                passed = RPTUtil.getInnerText(ruleContext) && RPTUtil.getInnerText(ruleContext).trim().length > 0;
-            
-            if (!passed) {
-                if (nameFromBoth || nameFromAuthorOnly)
-                passed = RPTUtil.getAriaLabel(ruleContext).trim().length > 0 || RPTUtil.attributeNonEmpty(ruleContext, "title");
-            } 
-        }*/
+        
         if (!passed)
             passed = RPTUtil.getAriaLabel(ruleContext).trim().length > 0 || RPTUtil.attributeNonEmpty(ruleContext, "title");
                 

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_exists_ruleunit/button_label.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_exists_ruleunit/button_label.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>Sandbox</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body>
+    <main>
+      <h1>Test page</h1>
+      <div class="cds--toggle">
+        <button
+          id="toggle-1"
+          class="cds--toggle__button"
+          role="switch"
+          type="button"
+          aria-checked="true"
+        ></button>
+        <label for="toggle-1" class="cds--toggle__label">
+          <span class="cds--toggle__label-text">Toggle element label 1</span>
+        </label>
+      </div>
+      <div>
+        <label for="toggle-2" class="cds--toggle__label">
+          <button 
+            id="toggle-2"
+            class="cds--toggle__button"
+            type="button"
+          ></button>
+          <span class="cds--toggle__label-text">Toggle element label 2</span>
+        </label>
+      </div>
+    </main>
+
+  <script>
+    UnitTest = {
+      ruleIds: ["input_label_exists"],
+      results: [
+      {
+            "ruleId": "input_label_exists",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[1]/button[1]",
+              "aria": "/document[1]/main[1]/switch[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_exists",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[2]/label[1]/button[1]",
+              "aria": "/document[1]/main[1]/button[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+      ]
+    };
+  </script>
+</body>
+</html>


### PR DESCRIPTION
… #761

<!-- The title of this PR will be used for release notes, please provide a relevant title. 
fixrule(`input_label_exists`) fix issue related to button element with a label

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: input_label_exists

### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # -->
#761 

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->


### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
test case: test/v2/checker/accessibility/rules/input_label_exists_ruleunit/button_label.html
After the fix is applied, the following violations should be fixed:
      Form control element <button> has no associated label
      Form control with "switch" role has no associated label 

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
