### PR TITLE
fix(extension): Better bad dom path / null protection for getBounds for viewInspect

### DIFF
--- a/accessibility-checker-extension/src/ts/contentScripts/ElementUtils.ts
+++ b/accessibility-checker-extension/src/ts/contentScripts/ElementUtils.ts
@@ -18,7 +18,7 @@ import { Bounds } from "../interfaces/interfaces";
 
 export class ElementUtils {
     static getBounds(node: Node, forScreenShot: boolean) : Bounds | null {
-        if (node.nodeType === 1 /*Node.ELEMENT_NODE*/) {
+        if (node && node.nodeType === 1 /*Node.ELEMENT_NODE*/) {
             let adjustment = 1;
             if (forScreenShot && node.ownerDocument && node.ownerDocument.defaultView && node.ownerDocument.defaultView.devicePixelRatio) {
                 adjustment = node.ownerDocument.defaultView.devicePixelRatio;

--- a/accessibility-checker-extension/src/ts/contentScripts/viewInspect.ts
+++ b/accessibility-checker-extension/src/ts/contentScripts/viewInspect.ts
@@ -210,10 +210,10 @@ type Overlays = { elem: HTMLDivElement, info: HTMLDivElement };
     
     async function showOverlay(issue: IIssue) {
         let elem = DomPathUtils.domPathToElem(issue.path.dom);
-        let bounds = ElementUtils.getBounds(elem, false);
         let noVisibleElement = false;
         let elemOffScreen = false;
         if (elem) {
+            let bounds = ElementUtils.getBounds(elem, false);
             if (bounds) {
                 // handle bounds for non-visible elements, i.e., no width or height
                 if (bounds.width == 0 && bounds.height == 0) {


### PR DESCRIPTION
<!-- Specify what this PR is doing. Remove all that do not apply -->
* Extension UI bug

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [ ] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [ ] I understand that the title of this PR will be used for the next release notes.
