### PR TITLE
fix(node): Resolve ace_ibma.Checker is not a constructor error

### DIFF
--- a/accessibility-checker/src-ts/lib/ACEngineManager.ts
+++ b/accessibility-checker/src-ts/lib/ACEngineManager.ts
@@ -256,32 +256,40 @@ export class ACEngineManager {
                 if (!fs.existsSync(engineDir)) {
                     fs.mkdirSync(engineDir, { recursive: true });
                 }
-                const nodePath = path.join(engineDir, "ace-node")
 
-                if(fs.existsSync(`${nodePath}.js`)) {
+                let fileSuffix = "";
+
+                if (!config.toolVersion) {
+                    fileSuffix = config.ruleArchiveVersion;
+                } else {
+                    fileSuffix = `${config.toolVersion}-${config.ruleArchiveVersion}`
+                }
+
+                const nodePath = path.join(engineDir, `ace-node-${fileSuffix}`);
+                if (fs.existsSync(`${nodePath}.js`)) {
                     const ace_ibma = require(nodePath);
                     checker = new ace_ibma.Checker();
-                    resolve();
-                } else {
-                    fs.writeFile(nodePath + ".js", data, function (err) {
-                        try {
-                            if(err) {
-                                console.error(err);
-                                return reject(err);
-                            }
-
-                            const ace_ibma = require(nodePath);
-                            checker = new ace_ibma.Checker();
-                        } catch (e) {
-                            console.log(e);
-                            return reject(e);
-                        }
-                        resolve();
-                    });
+                    return resolve();
                 }
+
+                fs.writeFile(nodePath + ".js", data, function (err) {
+                    if(err) {
+                        console.log(err);
+                        return reject(err);
+                    }
+
+                    try {
+                        const ace_ibma = require(nodePath);
+                        checker = new ace_ibma.Checker();
+                        resolve();
+                    } catch (e) {
+                        console.log(e);
+                        reject(e);
+                    }
+                });
             });
         }
-        return this.localLoadPromise;
+        return ACEngineManager.localLoadPromise;
     }
 
     static isPuppeteer(content) {

--- a/accessibility-checker/src-ts/lib/ACEngineManager.ts
+++ b/accessibility-checker/src-ts/lib/ACEngineManager.ts
@@ -256,18 +256,29 @@ export class ACEngineManager {
                 if (!fs.existsSync(engineDir)) {
                     fs.mkdirSync(engineDir, { recursive: true });
                 }
-                let nodePath = path.join(engineDir, "ace-node")
-                fs.writeFile(nodePath + ".js", data, function (err) {
-                    try {
-                        err && console.log(err);
-                        var ace_ibma = require(nodePath);
-                        checker = new ace_ibma.Checker();
-                    } catch (e) {
-                        console.log(e);
-                        return reject(e);
-                    }
+                const nodePath = path.join(engineDir, "ace-node")
+
+                if(fs.existsSync(`${nodePath}.js`)) {
+                    const ace_ibma = require(nodePath);
+                    checker = new ace_ibma.Checker();
                     resolve();
-                });
+                } else {
+                    fs.writeFile(nodePath + ".js", data, function (err) {
+                        try {
+                            if(err) {
+                                console.error(err);
+                                return reject(err);
+                            }
+
+                            const ace_ibma = require(nodePath);
+                            checker = new ace_ibma.Checker();
+                        } catch (e) {
+                            console.log(e);
+                            return reject(e);
+                        }
+                        resolve();
+                    });
+                }
             });
         }
         return this.localLoadPromise;

--- a/rule-server/gulp/gulpfile.js
+++ b/rule-server/gulp/gulpfile.js
@@ -53,7 +53,7 @@ function maxVersion(verA, verB) {
 }
 
 const archivePolicies = () => {
-    let releaseTag = process.env.GITHUB_SHA;
+    let releaseTag = (process.env.GITHUB_REF || "").substring(10).replace("/merge", "");
     // Adds the policy ids to the archive file
     return gulp.src(["../src/static/archives.json"])
         .pipe(modifyFile((content, path, file) => {

--- a/rule-server/gulp/gulpfile.js
+++ b/rule-server/gulp/gulpfile.js
@@ -53,7 +53,7 @@ function maxVersion(verA, verB) {
 }
 
 const archivePolicies = () => {
-    let releaseTag = (process.env.GITHUB_REF || "").substring(10);
+    let releaseTag = process.env.GITHUB_SHA;
     // Adds the policy ids to the archive file
     return gulp.src(["../src/static/archives.json"])
         .pipe(modifyFile((content, path, file) => {


### PR DESCRIPTION
<!-- The title of this PR will be used for release notes, please provide a relevant title. 
The following formats should be use for the release notes and PRs.

**Rule/Engine updates:**
newrule(`ruleid`): Title of PR
fixrule(`ruleid`): Title of PR
feature(engine): Title of PR
fix(engine): Title of PR
chore(`ruleid`|engine): Title of PR

**Tool updates:
feature(extension|node|karma|cypress): Title of PR
fix(extension|node|karma|cypress): Title of PR
chore(extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Try to resolve the `ace_ibma.Checker is not a constructor error`

### This PR is related to the following issue(s): 
- #1025 

### Additional information can be found here: 
Currently, the generated `ace-node.js` file is updated multiple times when running in multiple threads, causing the `ace_ibma.Checker is not a constructor` error while reading it when the file is being overwritten.

This commit does the following things:
1. Read the generated `ace-node.js` file if it exists and create the accessibility checker without overwriting the file.
1. Throw error if there was a problem in writing the `ace-node.js` file instead of attempting to create the constructor from the non-existing file.

Due to the above change, we must update the generated file name.
The current file is stored as `<cache-folder-name>/ace-node.js`. If the cache folder is not cleared, this would cause issues when either rule archive or package version is changed, as we are no longer overwriting the file.

Suffixing rule and package version to the file name  (e.g. `ace-node-3.0.0-3.1.67.js`) prevents this from happening.

### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
To test, run multiple accessibility tests using jest parallelly,  `ace_ibma.Checker is not a constructor error` should not occur.
To verify that the generated file is not being overwritten, run `fswatch -uvx <cache-folder-path>`

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
