### PR TITLE
fixrule(`list_markup_review`) Reduce Needs Review false positives for a list

### DIFF
--- a/accessibility-checker-engine/src/v4/rules/list_markup_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/list_markup_review.ts
@@ -14,6 +14,7 @@
 import { Rule, RuleResult, RuleFail, RuleContext, RulePotential, RuleManual, RulePass, RuleContextHierarchy } from "../api/IRule";
 import { eRulePolicy, eToolkitLevel } from "../api/IRule";
 import { NodeWalker, RPTUtil } from "../../v2/checker/accessibility/util/legacy";
+import { VisUtil } from "../../v2/dom/VisUtil";
 
 export let list_markup_review: Rule = {
     id: "list_markup_review",
@@ -25,16 +26,16 @@ export let list_markup_review: Rule = {
     },
     help: {
         "en-US": {
-            "Pass_0": "list_markup_review.html",
-            "Potential_1": "list_markup_review.html",
+            "pass": "list_markup_review.html",
+            "potential_list": "list_markup_review.html",
             "group": "list_markup_review.html"
         }
     },
     messages: {
         "en-US": {
-            "Pass_0": "Rule Passed",
-            "Potential_1": "Verify whether this is a list that should use HTML list elements",
-            "group": "Use proper HTML list elements to create lists"
+            "pass": "Proper HTML elements are used to create a list",
+            "potential_list": "Verify this is a list and if so, modify to use proper HTML elements for the list",
+            "group": "Proper HTML elements should be used to create a list"
         }
     },
     rulesets: [{
@@ -46,6 +47,29 @@ export let list_markup_review: Rule = {
     act: [],
     run: (context: RuleContext, options?: {}, contextHierarchies?: RuleContextHierarchy): RuleResult | RuleResult[] => {
         const ruleContext = context["dom"].node as Element;
+
+        // Extract the nodeName of the context node
+        let nodeName = ruleContext.nodeName.toLowerCase();
+
+        //skip the check if the element is hidden or disabled
+        if (RPTUtil.isNodeDisabled(ruleContext) || VisUtil.hiddenByDefaultElements.includes(nodeName))
+            return null;
+
+        // Don't trigger if we're not in the body or if we're in a script
+        if (RPTUtil.getAncestor(ruleContext, ["body"]) === null) 
+            return null;
+
+        // ignore script, label and their child elements
+        if (RPTUtil.getAncestor(ruleContext, ["script", 'label']) !== null)
+            return null;
+
+        // ignore all widgets and headings, and their children, and certain structure roles
+        let roles = RPTUtil.getRolesWithTypes(ruleContext, ["widget", "heading"]);
+        // add some structure roles
+        RPTUtil.concatUniqueArrayItemList(["caption", "code", "columnheader",  "figure", "list", "listitem", "math", "meter",  "rowheader"], roles);
+        if (RPTUtil.getAncestorWithRoles(ruleContext, roles) !== null) 
+            return null;
+
         let passed = true;
         let walkNode = ruleContext.firstChild as Node;
         while (passed && walkNode) {
@@ -86,8 +110,8 @@ export let list_markup_review: Rule = {
             passed = checkAncestor == null || checkAncestor.nodeName.toLowerCase() != "body";
         }
 
-        if (passed) return RulePass("Pass_0");
-        if (!passed) return RulePotential("Potential_1");
+        if (passed) return null;
+        if (!passed) return RulePotential("potential_list");
 
     }
 }

--- a/accessibility-checker-engine/src/v4/rules/list_markup_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/list_markup_review.ts
@@ -63,10 +63,10 @@ export let list_markup_review: Rule = {
         if (RPTUtil.getAncestor(ruleContext, ["script", 'label']) !== null)
             return null;
 
-        // ignore all widgets and headings, and their children, and certain structure roles
-        let roles = RPTUtil.getRolesWithTypes(ruleContext, ["widget", "heading"]);
+        // ignore all widgets and their children, and certain structure roles
+        let roles = RPTUtil.getRolesWithTypes(ruleContext, ["widget"]);
         // add some structure roles
-        RPTUtil.concatUniqueArrayItemList(["caption", "code", "columnheader",  "figure", "list", "listitem", "math", "meter",  "rowheader"], roles);
+        RPTUtil.concatUniqueArrayItemList(["caption", "code", "columnheader",  "figure", "list", "listitem", "math", "meter", "columnheader", "rowheader"], roles);
         if (RPTUtil.getAncestorWithRoles(ruleContext, roles) !== null) 
             return null;
 
@@ -77,7 +77,7 @@ export let list_markup_review: Rule = {
             // and for each element it only checks that single elements text nodes and nothing else. So all inner elements will be
             // covered on their own. Currently for this rule by default Check Hidden Content will work, as we are doing
             // a node walk only on siblings so it would not get text nodes from other siblings at all.
-            // In the case in the future something chnges, just need to add && !RPTUtil.shouldNodeBeSkippedHidden(walkNode) to the below
+            // In the case in the future something changes, just need to add && !RPTUtil.shouldNodeBeSkippedHidden(walkNode) to the below
             // if.
             if (walkNode.nodeName == "#text") {
                 let txtVal = walkNode.nodeValue;
@@ -102,12 +102,6 @@ export let list_markup_review: Rule = {
                 }
             }
             walkNode = walkNode.nextSibling;
-        }
-
-        if (!passed) {
-            // Don't trigger if we're not in the body or if we're in a script
-            let checkAncestor = RPTUtil.getAncestor(ruleContext, ["body", "script"]);
-            passed = checkAncestor == null || checkAncestor.nodeName.toLowerCase() != "body";
         }
 
         if (passed) return null;

--- a/accessibility-checker-engine/src/v4/rules/text_sensory_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/text_sensory_misuse.ts
@@ -11,32 +11,35 @@
   limitations under the License.
 *****************************************************************************/
 
-import { Rule, RuleResult, RuleFail, RuleContext, RulePotential, RuleManual, RulePass, RuleContextHierarchy } from "../api/IRule";
+import { Rule, RuleResult, RuleContext, RulePotential, RuleContextHierarchy } from "../api/IRule";
 import { eRulePolicy, eToolkitLevel } from "../api/IRule";
 import { RPTUtil } from "../../v2/checker/accessibility/util/legacy";
 import { getCache, setCache } from "../util/CacheUtil";
 import { VisUtil } from "../../v2/dom/VisUtil";
+import { ARIADefinitions } from "../../v2/aria/ARIADefinitions";
 
 export let text_sensory_misuse: Rule = {
     id: "text_sensory_misuse",
     context: "dom:body, dom:body dom:*",
     refactor: {
         "RPT_Text_SensoryReference": {
-            "Pass_0": "Pass_0",
-            "Potential_1": "Potential_1"}
+            "Pass_0": "pass",
+            "Potential_1": "potential_position, potential_other"}
     },
     help: {
         "en-US": {
-            "Pass_0": "text_sensory_misuse.html",
-            "Potential_1": "text_sensory_misuse.html",
+            "pass": "text_sensory_misuse.html",
+            "potential_position": "text_sensory_misuse.html",
+            "potential_other": "text_sensory_misuse.html",
             "group": "text_sensory_misuse.html"
         }
     },
     messages: {
         "en-US": {
-            "Pass_0": "Rule Passed",
-            "Potential_1": "If the word(s) '{0}' is part of instructions for using page content, check it is still understandable without this location or shape information",
-            "group": "Instructions must be meaningful without shape or location words"
+            "pass": "Instructions are meaningful without relying solely on shape, size, or location words",
+            "potential_position": "Confirm the word(s) '{0}' of the user instruction is used to indicate a logical rather than visual position",
+            "potential_other": "Confirm the user instruction is still understandable without the word(s) '{0}'",
+            "group": "Instructions should be meaningful without relying solely on shape, size, or location words"
         }
     },
     rulesets: [{
@@ -47,123 +50,170 @@ export let text_sensory_misuse: Rule = {
     }],
     act: [],
     run: (context: RuleContext, options?: {}, contextHierarchies?: RuleContextHierarchy): RuleResult | RuleResult[] => {
-        const validateParams = {
-            sensoryText: {
-                value: ["top-left", "top-right", "bottom-right", "bottom-left",
-                    "round", "square", "shape", "rectangle", "triangle",
-                    "right", "left", "above", "below", "top", "bottom",
-                    "upper", "lower", "corner", "beside"],
-                type: "[string]"
-            }
-        }
         const ruleContext = context["dom"].node as Element;
-        if (VisUtil.hiddenByDefaultElements.includes(ruleContext.nodeName.toLowerCase())) {
-            return null;
-        }
-
         // Extract the nodeName of the context node
         let nodeName = ruleContext.nodeName.toLowerCase();
+        
+        //skip the check if the element is hidden or disabled
+        if (!VisUtil.isNodeVisible(ruleContext) || RPTUtil.isNodeDisabled(ruleContext) || VisUtil.hiddenByDefaultElements.includes(nodeName))
+            return null;
+        
+        // Don't trigger if we're not in the body or if we're in a script
+        if (RPTUtil.getAncestor(ruleContext, ["body"]) === null) 
+            return null;
+        
+        // ignore script, link, label and their child elements
+        if (RPTUtil.getAncestor(ruleContext, ["script", "a", 'label']) !== null)
+            return null;
+    
+        // ignore text on landmark roles, but not on their children (e.g., section, main)
+        const role = RPTUtil.getResolvedRole(ruleContext);
+        if (role) {
+            let lmRoles = RPTUtil.getRolesWithTypes(ruleContext, ["landmark"]);
+            if (lmRoles && lmRoles.includes(role))
+                return null;
+        }    
+        
+        // ignore all widgets and headings, and their children, and certain structure roles
+        let roles = RPTUtil.getRolesWithTypes(ruleContext, ["widget", "heading"]);
+        // add some structure roles
+        RPTUtil.concatUniqueArrayItemList(["caption", "cell", "code", "columnheader", "definition", "figure", "list", "listitem", "math", "meter", "row", "rowgroup", "rowheader", "term"], roles);
+        if (RPTUtil.getAncestorWithRoles(ruleContext, roles) !== null) 
+            return null;
 
-        // In the case this is a style or link element, skip triggering rule as we do not want to scan
-        // CSS for sensory words, as there can be CSS keys which contain theses sensory text that is matching.
-        if (nodeName === "style" || nodeName === "link") {
-            return RulePass(1);
-        }
-
-        let violatedtextArray = null;
-        let violatedtext = null;
-        let sensoryRegex = getCache(ruleContext.ownerDocument, "text_sensory_misuse", null);
-        if (sensoryRegex == null) {
-            let sensoryText = validateParams.sensoryText.value;
-            let regexStr = "(" + sensoryText[0];
-            for (let j = 1; j < sensoryText.length; ++j)
-                regexStr += "|" + sensoryText[j];
-            regexStr += ")\\W";
-            sensoryRegex = new RegExp(regexStr, "gi");
-            setCache(ruleContext.ownerDocument, "text_sensory_misuse", sensoryRegex);
-        }
-        let passed = true;
+        let violatedPositionText = "";
+        let violatedOtherText = "";
         let walkNode = ruleContext.firstChild as Node;
-        while (passed && walkNode) {
-            // Comply to the Check Hidden Content setting will be done by default as this rule triggers on each element
-            // and for each element it only checks that single elements text nodes and nothing else. So all inner elements will be
-            // covered on their own. Currently for this rule by default Check Hidden Content will work, as we are doing
-            // a node walk only on siblings so it would not get text nodes from other siblings at all.
-            // In the case in the future something chnges, just need to add && !RPTUtil.shouldNodeBeSkippedHidden(walkNode) to the below
-            // if.
-            if (walkNode.nodeName == "#text") {
-                let txtVal = walkNode.nodeValue.trim();
-                if (txtVal.length > 0) {
-                    violatedtextArray = txtVal.match(sensoryRegex);
-                    if (violatedtextArray != null) {
-                        let hash = {}, result = [];
-                        let exemptWords = ["right-click", "left-click", "right-clicking", "right-clicks", "left-clicking", "left-clicks"];
-
-                        // Note: split(/[\n\r ]+/) will spread the string into group of words using space,
-                        // carriage return or linefeed as separators.
-                        let counts = txtVal.split(/[\n\r ]+/).reduce(function (map, word) {
-                            let sensoryTextArr = validateParams.sensoryText.value;
-                            let wordWoTrailingPunc = word.replace(/[.?!:;()'",`\]]+$/, "");
-                            let lcWordWoPunc = word.toLowerCase().replace(/[.?!:;()'",`\]]/g, "");
-
-                            for (let counter = 0; counter < sensoryTextArr.length; counter++) {
-                                let a = lcWordWoPunc.indexOf(sensoryTextArr[counter]);
-                                let b = exemptWords.indexOf(lcWordWoPunc);
-                                let sensoryWordLen = sensoryTextArr[counter].length;
-                                let charFollowSensoryText = lcWordWoPunc.charAt(sensoryWordLen + a);
-
-                                // If the word does not contains substring of sensoryTextArr[counter]
-                                // proceed to the next loop iteration for next sensoryText.
-                                if (a < 0) { continue; }
-
-                                let isPuncfollowing = ((charFollowSensoryText == '\-') ||
-                                    (charFollowSensoryText == '\.') ||
-                                    (charFollowSensoryText == '\?') || (charFollowSensoryText == '\!') ||
-                                    (charFollowSensoryText == '\:') || (charFollowSensoryText == '\;') ||
-                                    (charFollowSensoryText == '\(') || (charFollowSensoryText == '\)') ||
-                                    (charFollowSensoryText == '\'') || (charFollowSensoryText == '\"') ||
-                                    (charFollowSensoryText == '\,') || (charFollowSensoryText == '.\`') ||
-                                    (charFollowSensoryText == '\\') || (charFollowSensoryText == '\]'));
-
-                                let isPuncPreceding = false;
-                                if (a > 0) {
-                                    let charPrecedeSensoryText = lcWordWoPunc.charAt(a - 1);
-                                    isPuncPreceding = ((charPrecedeSensoryText == '\-') ||
-                                        (charPrecedeSensoryText == '\.') ||
-                                        (charPrecedeSensoryText == '\?') || (charPrecedeSensoryText == '\!') ||
-                                        (charPrecedeSensoryText == '\:') || (charPrecedeSensoryText == '\;') ||
-                                        (charPrecedeSensoryText == '\(') || (charPrecedeSensoryText == '\)') ||
-                                        (charPrecedeSensoryText == '\'') || (charPrecedeSensoryText == '\"') ||
-                                        (charPrecedeSensoryText == '\,') || (charPrecedeSensoryText == '.\`') ||
-                                        (charPrecedeSensoryText == '\\') || (charPrecedeSensoryText == '\]'));
-
-                                }
-
-                                if (((lcWordWoPunc.length == sensoryWordLen) || (isPuncfollowing == true) || (isPuncPreceding == true)) && (b < 0)) {
-                                    passed = false;
-                                    if (!hash.hasOwnProperty(wordWoTrailingPunc)) {
-                                        hash[wordWoTrailingPunc] = true;
-                                        result.push(wordWoTrailingPunc);
-                                    }
-                                    counter = sensoryTextArr.length;
-                                }
-                            }
-                            map[wordWoTrailingPunc] = (map[wordWoTrailingPunc] || 0) + 1;
-                            return map;
-                        }, Object.create(null));
-                        violatedtext = result.join(", ");
-                    }
-                }
+        let txtVal = ""; 
+        while (walkNode) {
+            // for each element it only checks that single elements text nodes and nothing else. 
+            // all inner elements will be covered on their own. 
+            // whitespace characters (space, newline, tab) between elements are considered a node too.
+            if (walkNode.nodeName === "#text") {
+                let txt = walkNode.nodeValue.trim();
+                if (txt.length > 0)
+                    txtVal += (txtVal.length > 0 ? ", " + txt : txt);
             }
             walkNode = walkNode.nextSibling;
         }
+        
+        if (txtVal.length > 0) {
+             // first to remove each exempt word with a single space in the text
+            let exemptRegex = getRegex(ruleContext.ownerDocument, "exemptText");
+            txtVal = txtVal.replace(exemptRegex, " ");
 
-        if (!passed) {
-            // Don't trigger if we're not in the body or if we're in a script
-            let checkAncestor = RPTUtil.getAncestor(ruleContext, ["body", "script"]);
-            passed = (checkAncestor == null || checkAncestor.nodeName.toLowerCase() != "body");
+            violatedPositionText = getViolatedText(ruleContext.ownerDocument, "positionText", txtVal);
+            violatedOtherText = getViolatedText(ruleContext.ownerDocument, "otherText", txtVal);
         }
 
-        return passed ? RulePass("Pass_0") : RulePotential("Potential_1", [violatedtext]);
+        let ret = []; 
+        if (violatedPositionText) ret.push(RulePotential("potential_position", [violatedPositionText]));
+        if (violatedOtherText) ret.push(RulePotential("potential_other", [violatedOtherText]));
+        return ret.length == 0 ? null : ret;
     }
 }
+
+const validateParams = {
+    positionText: {
+        value: ["top-left", "top-right", "bottom-right", "bottom-left",
+            "top-to-bottom", "left-to-right", "bottom-to-top", "right-to-left",
+            "right", "left", "above", "below", "top", "bottom",
+            "upper", "lower", "corner", "beside"
+        ],
+        type: "[string]"
+    },
+    otherText: {
+        value: ["round", "square", "shape", "rectangle", "triangle",
+            "size", "large", "small", "medium", "big", "huge", "tiny", "extra",
+            "larger", "smaller", "bigger", "little", "largest", "smallest", "biggest"
+        ],
+        type: "[string]"
+    },
+    exemptText: {
+        value: ["right-click", "left-click", "right-clicking", "right-clicks", 
+           "left-clicking", "left-clicks", "square root", "right now", "off the top"   //append as needed
+        ],
+        type: "[string]"
+    }    
+}
+
+function getRegex(doc, type) {
+    if (!validateParams[type]) return "";
+    let sensoryRegex = getCache(doc, type + "_sensory_misuse", null);
+    if (sensoryRegex == null) {
+        let sensoryText = validateParams[type].value;
+        let regexStr = "(\s\s+|" + sensoryText[0];
+        for (let j = 1; j < sensoryText.length; ++j) {
+            let words = sensoryText[j].trim().split(" ");
+            regexStr += "|" + words[0];
+            if (words.length > 1) {
+                for (let c = 1; c < words.length; ++c)
+                    regexStr += " +" + words[c];
+            }
+        }
+        //regexStr += ")\\W";
+        regexStr += ")";
+        sensoryRegex = new RegExp(regexStr, "gi");
+        setCache(doc, type +"_sensory_misuse", sensoryRegex);
+    }
+    return sensoryRegex;
+}
+
+function getViolatedText(doc, type, txtVal) {
+    if (!txtVal) return "";
+    let sensoryTextArr = validateParams[type].value
+    let hash = {}, result = [];
+    
+    // split the string into words
+    let counts = txtVal.split(/\s+/).reduce(function (map, word) {
+        let wordWoTrailingPunc = word.replace(/[.?!:;()'",`\]]+$/, "");
+        let lcWordWoPunc = word.toLowerCase().replace(/[.?!:;()'",`\]]/g, "");
+
+        for (let counter = 0; counter < sensoryTextArr.length; counter++) {
+            let a = lcWordWoPunc.indexOf(sensoryTextArr[counter]);
+            
+            let sensoryWordLen = sensoryTextArr[counter].length;
+            let charFollowSensoryText = lcWordWoPunc.charAt(sensoryWordLen + a);
+
+            // If the word does not contains substring of sensoryTextArr[counter]
+            // proceed to the next loop iteration for next sensoryText.
+            if (a < 0) { continue; }
+
+            //check the following and proceeding punctuations
+            //let isPuncfollowing = ((charFollowSensoryText == '\-') ||
+            let isPuncfollowing = (
+                (charFollowSensoryText == '\.') ||
+                (charFollowSensoryText == '\?') || (charFollowSensoryText == '\!') ||
+                (charFollowSensoryText == '\:') || (charFollowSensoryText == '\;') ||
+                (charFollowSensoryText == '\(') || (charFollowSensoryText == '\)') ||
+                (charFollowSensoryText == '\'') || (charFollowSensoryText == '\"') ||
+                (charFollowSensoryText == '\,') || (charFollowSensoryText == '.\`') ||
+                (charFollowSensoryText == '\\') || (charFollowSensoryText == '\]'));
+
+            let isPuncPreceding = false;
+            if (a > 0) {
+                let charPrecedeSensoryText = lcWordWoPunc.charAt(a - 1);
+                isPuncPreceding = ((charPrecedeSensoryText == '\-') ||
+                    (charPrecedeSensoryText == '\.') ||
+                    (charPrecedeSensoryText == '\?') || (charPrecedeSensoryText == '\!') ||
+                    (charPrecedeSensoryText == '\:') || (charPrecedeSensoryText == '\;') ||
+                    (charPrecedeSensoryText == '\(') || (charPrecedeSensoryText == '\)') ||
+                    (charPrecedeSensoryText == '\'') || (charPrecedeSensoryText == '\"') ||
+                    (charPrecedeSensoryText == '\,') || (charPrecedeSensoryText == '.\`') ||
+                    (charPrecedeSensoryText == '\\') || (charPrecedeSensoryText == '\]'));
+
+            }
+
+            if (((lcWordWoPunc.length == sensoryWordLen) || (isPuncfollowing == true) || (isPuncPreceding == true))) {
+                if (!hash.hasOwnProperty(wordWoTrailingPunc)) {
+                    hash[wordWoTrailingPunc] = true;
+                    result.push(wordWoTrailingPunc);
+                }
+                counter = sensoryTextArr.length;
+            }
+        }
+        map[wordWoTrailingPunc] = (map[wordWoTrailingPunc] || 0) + 1;
+        return map;
+    }, Object.create(null));
+    return result.join(", ");
+} 

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/Noscript_visible_ruleunit/Noscript_visible.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/Noscript_visible_ruleunit/Noscript_visible.html
@@ -38,38 +38,7 @@
 <script>
     UnitTest = {
         ruleIds: ["text_sensory_misuse"],
-        results: [{
-            "ruleId": "text_sensory_misuse",
-            "value": [
-            "INFORMATION",
-            "PASS"
-            ],
-            "path": {
-            "dom": "/html[1]/body[1]",
-            "aria": "/document[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "category": "Accessibility"
-        },
-        {
-            "ruleId": "text_sensory_misuse",
-            "value": [
-              "INFORMATION",
-              "PASS"
-            ],
-            "path": {
-              "dom": "/html[1]/body[1]/main[1]",
-              "aria": "/document[1]/main[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "category": "Accessibility"
-        }]
+        results: []
     }
 </script>
 </main>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/fieldset_label_valid_ruleunit/FieldSet-nested.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/fieldset_label_valid_ruleunit/FieldSet-nested.html
@@ -1,0 +1,102 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+	<title>RPT Test Suite</title>
+</head>
+
+<body>
+
+<a href="#navskip">skip to main content</a>
+
+
+<h2>Test case: FieldSet-nested.html</h2>
+
+<form action="..." method="post">
+  <fieldset aria-labelledby="mylegend">
+    <legend id="mylegend">Please enter following information</legend>
+    <label for="cpname">Company Name</label>
+    <input type="text" name="cpname" id="cpname" value="enter company name">
+
+    <fieldset aria-labelledby="alegend">
+      <legend id="alegend">Please enter following information</legend>
+  
+      <label for="phone">Phone</label>
+      <input type="text" name="phone" id="phone" value="enter company phone">
+  
+    </fieldset>
+
+  </fieldset>
+
+</form>
+
+
+<a name="navskip"></a>
+
+
+<script>
+  UnitTest = {
+      ruleIds: ["fieldset_label_valid"],
+      results: [
+      {
+            "ruleId": "fieldset_label_valid",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/form[1]/fieldset[1]",
+              "aria": "/document[1]/form[1]/group[1]"
+            },
+            "reasonId": "Fail_2",
+            "message": "Group/Fieldset \"Please enter following information\" has a duplicate name to another group",
+            "messageArgs": [
+              "Please enter following information"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "fieldset_label_valid",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/form[1]/fieldset[1]/fieldset[1]",
+              "aria": "/document[1]/form[1]/group[1]/group[1]"
+            },
+            "reasonId": "Fail_2",
+            "message": "Group/Fieldset \"Please enter following information\" has a duplicate name to another group",
+            "messageArgs": [
+              "Please enter following information"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+      ]
+
+  }
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/Lists-invalidTextAlphaNum.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/Lists-invalidTextAlphaNum.html
@@ -68,7 +68,7 @@
 
 
 <script type="text/javascript">
-//<![CDATA[
+/** //<![CDATA[
   if (typeof(OpenAjax) == 'undefined') OpenAjax = {}
   if (typeof(OpenAjax.a11y) == 'undefined') OpenAjax.a11y = {}
   OpenAjax.a11y.ruleCoverage = [
@@ -82,7 +82,44 @@
       ]
     }
   ];
-//]]>
+//]]>*/
+UnitTest = {
+    ruleIds: ["list_markup_review"],
+    results: [
+    {
+            "ruleId": "list_markup_review",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/p[1]",
+              "aria": "/document[1]/paragraph[1]"
+            },
+            "reasonId": "potential_list",
+            "message": "Verify this is a list and if so, modify to use proper HTML elements for the list",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "list_markup_review",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/pre[1]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "potential_list",
+            "message": "Verify this is a list and if so, modify to use proper HTML elements for the list",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+};
 </script></body>
 
 </html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/list-inapplicable.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/list-inapplicable.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+	<title>RPT Test Suite</title>
+</head>
+
+<body>
+  <main>
+    <div>
+      <ul>
+          <li> -— test options --- </li>
+          <li>** test 0 </li>
+          <li> - test 1 </li>
+          <li> - test 2 </li>
+      </ul>
+    </div>
+  </main>
+
+<script type="text/javascript">
+  UnitTest = {
+            ruleIds: ["list_markup_review"],
+            results: [
+            
+            ]
+        };
+//]]>
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/list-links.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/list-links.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+	<title>RPT Test Suite</title>
+</head>
+
+<body>
+  <main>
+    <div>
+      <a href="aa.com"><span>-— click here --- </span></a>
+      <a href="bb.com"><span>-— click there --- </span></a>
+    </div>
+  </main>
+
+<script type="text/javascript">
+  UnitTest = {
+            ruleIds: ["list_markup_review"],
+            results: [
+            
+            ]
+        };
+//]]>
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/list-links.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/list-links.html
@@ -31,6 +31,18 @@
       <a href="bb.com"><span>-— click there --- </span></a>
     </div>
   </main>
+ 
+<div role="group" aria-label="outer 1">
+  <div role="group" aria-label="inner 1" > div1 content
+  </div>
+  <div role="group" aria-label="inner 2">div1 content
+  </div>
+</div>
+<div role="group" aria-label="inner 2">div1 content
+  <div role="group" aria-label="inner 1">div1 content
+  </div>
+</div>
+ 
 
 <script type="text/javascript">
   UnitTest = {

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/list-widget-inapplicable.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/list_markup_review_ruleunit/list-widget-inapplicable.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+	<title>RPT Test Suite</title>
+</head>
+
+<body>
+  <main>
+    <div>
+      <select>
+        <option> -— test options --- </option>
+        <option>** test 0 </option>
+        <option> - test 1 </option>
+        <option> - test 2 </option>
+      </select>
+    </div>
+  </main>
+
+<script type="text/javascript">
+  UnitTest = {
+            ruleIds: ["list_markup_review"],
+            results: [
+            
+            ]
+        };
+//]]>
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-Sensory-widget.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-Sensory-widget.html
@@ -28,21 +28,34 @@
 
 <a href="#navskip">skip to main content</a>
 
-<h2>Test case: Contents-hasSensory.html</h2>
+<h2>Test case: Contents-Sensory-widget.html</h2>
 
 <!-- ################################################################### -->
 
 <h3>Sensory Content Tests</h3>
 
+<p>File has sensory related text terms</p>
+
+<table>
+  <caption>assign top talent in right position</caption>
+  <tr><td>top talent</td><td>right position</td></tr>
+</table>
+
+<label for="sel">select right position for the object</label>
+<select id="sel">
+  <option>top</option>
+  <option>bottom</option>
+  <option>right</option>
+  <option>left</option>
+</select>
 
 <a name="navskip"></a>
 
 
 <script type="text/javascript">
-   UnitTest = {
+  UnitTest = {
             ruleIds: ["text_sensory_misuse"],
             results: [
-            
             ]
         };
 //]]>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-hasSensoryInCSS.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-hasSensoryInCSS.html
@@ -55,18 +55,29 @@
 
 
 <script type="text/javascript">
-//<![CDATA[
-  if (typeof(OpenAjax) == 'undefined') OpenAjax = {}
-  if (typeof(OpenAjax.a11y) == 'undefined') OpenAjax.a11y = {}
-  OpenAjax.a11y.ruleCoverage = [
-    {
-      ruleId: "502",
-      passedXpaths: [
-      ],
-      failedXpaths: [
-      ]
-    }
-  ];
+    UnitTest = {
+            ruleIds: ["text_sensory_misuse"],
+            results: [
+            {
+            "ruleId": "text_sensory_misuse",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/p[3]",
+              "aria": "/document[1]/paragraph[3]"
+            },
+            "reasonId": "potential_other",
+            "message": "Confirm the user instruction is still understandable without the word(s) 'Large'",
+            "messageArgs": [
+              "Large"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+            ]
+        };
 //]]>
 </script></body>
 

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-notSensory-hidden.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-notSensory-hidden.html
@@ -62,16 +62,48 @@ beside
 </div>
 
 <a name="navskip"></a>
-
-
 <script type="text/javascript">
-//<![CDATA[
-  if (typeof(OpenAjax) == 'undefined') OpenAjax = {}
-  if (typeof(OpenAjax.a11y) == 'undefined') OpenAjax.a11y = {}
-  OpenAjax.a11y.ruleCoverage = [
-
-  ];
-//]]>
-</script></body>
-
+  UnitTest = {
+            ruleIds: ["text_sensory_misuse"],
+            results: [
+            {
+            "ruleId": "text_sensory_misuse",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/p[1]",
+              "aria": "/document[1]/generic[1]/paragraph[1]"
+            },
+            "reasonId": "potential_position",
+            "message": "Confirm the word(s) 'right, left, top-left, top-right, bottom-right, bottom-left, above, below, top, bottom, upper, lower, corner, beside' of the user instruction is used to indicate a logical rather than visual position",
+            "messageArgs": [
+              "right, left, top-left, top-right, bottom-right, bottom-left, above, below, top, bottom, upper, lower, corner, beside"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "text_sensory_misuse",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/p[1]",
+              "aria": "/document[1]/generic[1]/paragraph[1]"
+            },
+            "reasonId": "potential_other",
+            "message": "Confirm the user instruction is still understandable without the word(s) 'round, square, shape, rectangle, triangle'",
+            "messageArgs": [
+              "round, square, shape, rectangle, triangle"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+            ]
+        };
+</script>
+</body>
 </html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-notSensory.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-notSensory.html
@@ -63,19 +63,47 @@ beside
 
 
 <script type="text/javascript">
-//<![CDATA[
-  if (typeof(OpenAjax) == 'undefined') OpenAjax = {}
-  if (typeof(OpenAjax.a11y) == 'undefined') OpenAjax.a11y = {}
-  OpenAjax.a11y.ruleCoverage = [
-    {
-      ruleId: "502",
-      passedXpaths: [
-      ],
-      failedXpaths: [
-        "/html/body/p[2]"
-      ]
-    }
-  ];
+  UnitTest = {
+            ruleIds: ["text_sensory_misuse"],
+            results: [
+            {
+            "ruleId": "text_sensory_misuse",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/p[2]",
+              "aria": "/document[1]/paragraph[2]"
+            },
+            "reasonId": "potential_position",
+            "message": "Confirm the word(s) 'right, left, top-left, top-right, bottom-right, bottom-left, above, below, top, bottom, upper, lower, corner, beside' of the user instruction is used to indicate a logical rather than visual position",
+            "messageArgs": [
+              "right, left, top-left, top-right, bottom-right, bottom-left, above, below, top, bottom, upper, lower, corner, beside"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "text_sensory_misuse",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/p[2]",
+              "aria": "/document[1]/paragraph[2]"
+            },
+            "reasonId": "potential_other",
+            "message": "Confirm the user instruction is still understandable without the word(s) 'round, square, shape, rectangle, triangle'",
+            "messageArgs": [
+              "round, square, shape, rectangle, triangle"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+            ]
+        };
 //]]>
 </script></body>
 

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-notSensoryHidden.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/Content-notSensoryHidden.html
@@ -63,21 +63,47 @@
 	
 
 	<script type="text/javascript">
-	//<![CDATA[
-	  if (typeof(OpenAjax) == 'undefined') OpenAjax = {}
-	  if (typeof(OpenAjax.a11y) == 'undefined') OpenAjax.a11y = {}
-	  OpenAjax.a11y.ruleCoverage = [
-	    {
-	      ruleId: "502",
-	      passedXpaths: [
-	      ],
-	      failedXpaths: [
-	        "/html/body/div/p"
-	        // "/html/body/div/p/span[1]",    // hidden content
-	        // "/html/body/div/p/span[2]"     // hidden content
-	      ]
-	    }
-	  ];
+	  UnitTest = {
+            ruleIds: ["text_sensory_misuse"],
+            results: [
+            {
+            "ruleId": "text_sensory_misuse",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/p[1]",
+              "aria": "/document[1]/paragraph[2]"
+            },
+            "reasonId": "potential_position",
+            "message": "Confirm the word(s) 'right, bottom-right, bottom-left, below, top, bottom, upper, lower, corner, beside' of the user instruction is used to indicate a logical rather than visual position",
+            "messageArgs": [
+              "right, bottom-right, bottom-left, below, top, bottom, upper, lower, corner, beside"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "text_sensory_misuse",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/p[1]",
+              "aria": "/document[1]/paragraph[2]"
+            },
+            "reasonId": "potential_other",
+            "message": "Confirm the user instruction is still understandable without the word(s) 'round, square, shape, rectangle, triangle'",
+            "messageArgs": [
+              "round, square, shape, rectangle, triangle"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+            ]
+        };
 	//]]>
 	</script>
 	

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/double-words-sensory.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/double-words-sensory.html
@@ -1,0 +1,71 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en-US">
+  <head>
+    <title>Sandbox</title>
+    <meta charset="UTF-8" />
+  </head>
+
+  <body>
+    <main>
+      <h1>Test page</h1>
+      <div>daylight-stop-minute</div>
+      <div>top-level</div>
+      <div>square root</div>
+      <div>SQUARE ROOT</div>
+      <div>right-click</div>
+      <div>left-CLICK</div>
+      <div>left-to-right and right-to-left</div>
+      <div>right now</div>
+      <div>right     now    </div>
+      <div>off the top</div>
+      <div>off the      top</div>
+      <div>off     the      top</div>
+    </main>
+
+<script type="text/javascript">
+  UnitTest = {
+            ruleIds: ["text_sensory_misuse"],
+            results: [
+            {
+            "ruleId": "text_sensory_misuse",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[7]",
+              "aria": "/document[1]/main[1]"
+            },
+            "reasonId": "potential_position",
+            "message": "Confirm the word(s) 'left-to-right, right-to-left' of the user instruction is used to indicate a logical rather than visual position",
+            "messageArgs": [
+              "left-to-right, right-to-left"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+            ]
+        };
+//]]>
+</script></body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/right-click.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/text_sensory_misuse_ruleunit/right-click.html
@@ -25,24 +25,45 @@
 </head>
 
 <body>
-
-<a href="#navskip">skip to main content</a>
-
-<h2>Test case: Contents-hasSensory.html</h2>
-
-<!-- ################################################################### -->
-
-<h3>Sensory Content Tests</h3>
-
-
-<a name="navskip"></a>
-
+  <main>
+    <h1>Test page</h1>
+    <div title="one">Test</div>
+    <div>
+      <div role="list">
+        <div aria-live="polite">
+          <div role="listitem">Item 1</div>
+        </div>
+      </div>
+      <p>This is a right-click problem.</p>
+      <p>I have a problem to the right of here.</p>
+      <p>please stop here.</p>
+      <p>left-wing politician.</p>
+      <p>this is one topic.</p>
+    </div>
+  </main>
 
 <script type="text/javascript">
-   UnitTest = {
+  UnitTest = {
             ruleIds: ["text_sensory_misuse"],
             results: [
-            
+            {
+            "ruleId": "text_sensory_misuse",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/div[2]/p[2]",
+              "aria": "/document[1]/main[1]/paragraph[2]"
+            },
+            "reasonId": "potential_position",
+            "message": "Confirm the word(s) 'right' of the user instruction is used to indicate a logical rather than visual position",
+            "messageArgs": [
+              "right"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
             ]
         };
 //]]>

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
@@ -29,32 +29,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/page_title_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ctitle%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22page_title_valid%22%2C%22msgArgs%22%3A%5B%22Helo%20World%22%5D%7D"
         },
         {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/head[1]/title[1]",
-                "aria": "/document[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 0,
-                "top": 0,
-                "height": 0,
-                "width": 0
-            },
-            "snippet": "<title>",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ctitle%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "img_alt_background",
             "value": [
                 "RECOMMENDATION",
@@ -105,32 +79,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/aria_content_in_landmark.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ctitle%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22aria_content_in_landmark%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/head[1]/meta[2]",
-                "aria": "/document[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 0,
-                "top": 0,
-                "height": 0,
-                "width": 0
-            },
-            "snippet": "<meta content=\"text\" name=\"Description\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cmeta%20content%3D%5C%22text%5C%22%20name%3D%5C%22Description%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "img_alt_background",
@@ -185,32 +133,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/aria_content_in_landmark.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cmeta%20content%3D%5C%22text%5C%22%20name%3D%5C%22Description%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22aria_content_in_landmark%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/head[1]/meta[1]",
-                "aria": "/document[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 0,
-                "top": 0,
-                "height": 0,
-                "width": 0
-            },
-            "snippet": "<meta charset=\"utf-8\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cmeta%20charset%3D%5C%22utf-8%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "img_alt_background",
             "value": [
                 "RECOMMENDATION",
@@ -261,32 +183,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/aria_content_in_landmark.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cmeta%20charset%3D%5C%22utf-8%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22aria_content_in_landmark%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/head[1]",
-                "aria": "/document[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 0,
-                "top": 0,
-                "height": 0,
-                "width": 0
-            },
-            "snippet": "<head>",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Chead%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "img_alt_background",
@@ -425,32 +321,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
-        },
-        {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]/h1[1]",
-                "aria": "/document[1]/main[1]/heading[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 48,
-                "height": 74,
-                "width": 784
-            },
-            "snippet": "<h1>",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "img_alt_background",
@@ -661,32 +531,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_block_heading.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_block_heading%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]/div[2]",
-                "aria": "/document[1]/main[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 144,
-                "height": 0,
-                "width": 784
-            },
-            "snippet": "<div id=\"firstDiv\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "img_alt_background",
             "value": [
                 "RECOMMENDATION",
@@ -846,32 +690,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_block_heading.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_block_heading%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]/div[1]",
-                "aria": "/document[1]/main[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 144,
-                "height": 0,
-                "width": 784
-            },
-            "snippet": "<div id=\"firstDiv\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "img_alt_background",
             "value": [
                 "RECOMMENDATION",
@@ -1002,32 +820,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_quoted_correctly.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20name%3D%5C%22navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_quoted_correctly%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]/a[1]",
-                "aria": "/document[1]/main[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 48,
-                "height": 0,
-                "width": 0
-            },
-            "snippet": "<a name=\"navskip\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20name%3D%5C%22navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "img_alt_background",
             "value": [
                 "RECOMMENDATION",
@@ -1156,32 +948,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_block_heading.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22main%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_block_heading%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]",
-                "aria": "/document[1]/main[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 48,
-                "height": 74,
-                "width": 784
-            },
-            "snippet": "<div role=\"main\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22main%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "img_alt_background",
@@ -1481,32 +1247,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/style_focus_visible.html#%7B%22message%22%3A%22The%20keyboard%20focus%20indicator%20is%20visible%20or%20is%20not%20changed%20from%20the%20browser%20default%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass_focus_visible%22%2C%22ruleId%22%3A%22style_focus_visible%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[1]/a[1]",
-                "aria": "/document[1]/navigation[1]/link[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 8,
-                "height": 18,
-                "width": 56
-            },
-            "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "img_alt_background",
             "value": [
                 "RECOMMENDATION",
@@ -1687,32 +1427,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_block_heading.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22navigation%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_block_heading%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[1]",
-                "aria": "/document[1]/navigation[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 8,
-                "height": 19,
-                "width": 784
-            },
-            "snippet": "<div role=\"navigation\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22navigation%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "img_alt_background",
@@ -1952,32 +1666,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/skip_main_described.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cbody%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22skip_main_described%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]",
-                "aria": "/document[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 8,
-                "height": 114,
-                "width": 784
-            },
-            "snippet": "<body>",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cbody%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "img_alt_background",
             "value": [
                 "RECOMMENDATION",
@@ -2028,32 +1716,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/page_title_exists.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Chtml%20lang%3D%5C%22en%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22page_title_exists%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "ruleId": "list_markup_review",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]",
-                "aria": "/document[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 0,
-                "top": 0,
-                "height": 144,
-                "width": 800
-            },
-            "snippet": "<html lang=\"en\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Chtml%20lang%3D%5C%22en%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "img_alt_background",
@@ -2162,7 +1824,7 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/html_lang_exists.html#%7B%22message%22%3A%22Page%20language%20detected%20as%20%5C%22en%5C%22%22%2C%22snippet%22%3A%22%3Chtml%20lang%3D%5C%22en%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22html_lang_exists%22%2C%22msgArgs%22%3A%5B%22en%22%5D%7D"
         }
     ],
-    "numExecuted": 82,
+    "numExecuted": 69,
     "ruleTime": 999,
     "nls": {
         "html_lang_valid": {
@@ -2183,10 +1845,6 @@
         },
         "img_alt_background": {
             "0": "Background images that convey important information must have a text alternative that describes the image",
-            "Pass_0": "Rule Passed"
-        },
-        "list_markup_review": {
-            "0": "Use proper HTML list elements to create lists",
             "Pass_0": "Rule Passed"
         },
         "aria_content_in_landmark": {
@@ -2282,7 +1940,7 @@
             "recommendation": 0,
             "potentialrecommendation": 0,
             "manual": 0,
-            "pass": 81,
+            "pass": 68,
             "ignored": 1,
             "elements": 13,
             "elementsViolation": 0,

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
@@ -367,32 +367,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "text_sensory_misuse",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]/h1[1]",
-                "aria": "/document[1]/main[1]/heading[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 48,
-                "height": 74,
-                "width": 784
-            },
-            "snippet": "<h1>",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "text_quoted_correctly",
             "value": [
                 "VIOLATION",
@@ -635,32 +609,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "text_sensory_misuse",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]/div[2]",
-                "aria": "/document[1]/main[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 144,
-                "height": 0,
-                "width": 784
-            },
-            "snippet": "<div id=\"firstDiv\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "text_quoted_correctly",
             "value": [
                 "VIOLATION",
@@ -846,32 +794,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "text_sensory_misuse",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]/div[1]",
-                "aria": "/document[1]/main[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 144,
-                "height": 0,
-                "width": 784
-            },
-            "snippet": "<div id=\"firstDiv\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "text_quoted_correctly",
             "value": [
                 "VIOLATION",
@@ -1054,32 +976,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20name%3D%5C%22navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "text_sensory_misuse",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]/a[1]",
-                "aria": "/document[1]/main[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 48,
-                "height": 0,
-                "width": 0
-            },
-            "snippet": "<a name=\"navskip\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20name%3D%5C%22navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "text_quoted_correctly",
             "value": [
                 "VIOLATION",
@@ -1208,32 +1104,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22main%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "ruleId": "text_sensory_misuse",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[2]",
-                "aria": "/document[1]/main[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 48,
-                "height": 74,
-                "width": 784
-            },
-            "snippet": "<div role=\"main\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22main%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "text_quoted_correctly",
@@ -1525,32 +1395,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "text_sensory_misuse",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[1]/a[1]",
-                "aria": "/document[1]/navigation[1]/link[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 8,
-                "height": 18,
-                "width": 56
-            },
-            "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "text_quoted_correctly",
             "value": [
                 "VIOLATION",
@@ -1793,32 +1637,6 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22navigation%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
-            "ruleId": "text_sensory_misuse",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]/div[1]",
-                "aria": "/document[1]/navigation[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 8,
-                "height": 19,
-                "width": 784
-            },
-            "snippet": "<div role=\"navigation\">",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22navigation%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
             "ruleId": "text_quoted_correctly",
             "value": [
                 "VIOLATION",
@@ -2054,32 +1872,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cbody%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "ruleId": "text_sensory_misuse",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "path": {
-                "dom": "/html[1]/body[1]",
-                "aria": "/document[1]"
-            },
-            "reasonId": "Pass_0",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "apiArgs": [],
-            "bounds": {
-                "left": 8,
-                "top": 8,
-                "height": 114,
-                "width": 784
-            },
-            "snippet": "<body>",
-            "category": "Accessibility",
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cbody%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "text_quoted_correctly",
@@ -2370,7 +2162,7 @@
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/html_lang_exists.html#%7B%22message%22%3A%22Page%20language%20detected%20as%20%5C%22en%5C%22%22%2C%22snippet%22%3A%22%3Chtml%20lang%3D%5C%22en%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22html_lang_exists%22%2C%22msgArgs%22%3A%5B%22en%22%5D%7D"
         }
     ],
-    "numExecuted": 90,
+    "numExecuted": 82,
     "ruleTime": 999,
     "nls": {
         "html_lang_valid": {
@@ -2411,10 +2203,6 @@
         },
         "skip_main_described": {
             "0": "The description of a hyperlink used to skip content must communicate where it links to",
-            "Pass_0": "Rule Passed"
-        },
-        "text_sensory_misuse": {
-            "0": "Instructions must be meaningful without shape or location words",
             "Pass_0": "Rule Passed"
         },
         "text_quoted_correctly": {
@@ -2494,7 +2282,7 @@
             "recommendation": 0,
             "potentialrecommendation": 0,
             "manual": 0,
-            "pass": 89,
+            "pass": 81,
             "ignored": 1,
             "elements": 13,
             "elementsViolation": 0,

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
@@ -97,10 +97,6 @@
             "0": "Quotations should be marked with <q> or <blockquote> elements",
             "Pass_0": "Rule Passed"
         },
-        "text_sensory_misuse": {
-            "0": "Instructions must be meaningful without shape or location words",
-            "Pass_0": "Rule Passed"
-        },
         "text_whitespace_valid": {
             "0": "Space characters should not be used to control spacing within a word",
             "pass": "Rule Passed"
@@ -114,7 +110,7 @@
             "pass": "Rule Passed"
         }
     },
-    "numExecuted": 90,
+    "numExecuted": 82,
     "results": [
         {
             "apiArgs": [],
@@ -498,32 +494,6 @@
                 "dom": "/html[1]/body[1]/div[2]/h1[1]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "text_sensory_misuse",
-            "snippet": "<h1>",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]/heading[1]",
-                "dom": "/html[1]/body[1]/div[2]/h1[1]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "text_quoted_correctly",
             "snippet": "<h1>",
             "value": [
@@ -766,32 +736,6 @@
                 "dom": "/html[1]/body[1]/div[2]/div[2]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "text_sensory_misuse",
-            "snippet": "<div id=\"firstDiv\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]",
-                "dom": "/html[1]/body[1]/div[2]/div[2]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "text_quoted_correctly",
             "snippet": "<div id=\"firstDiv\">",
             "value": [
@@ -960,32 +904,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]",
-                "dom": "/html[1]/body[1]/div[2]/div[1]"
-            },
-            "reasonId": "Pass_0",
-            "ruleId": "text_sensory_misuse",
-            "snippet": "<div id=\"firstDiv\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],
@@ -1185,32 +1103,6 @@
                 "dom": "/html[1]/body[1]/div[2]/a[1]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "text_sensory_misuse",
-            "snippet": "<a name=\"navskip\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20name%3D%5C%22navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 999,
-                "top": 999,
-                "width": 0
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]",
-                "dom": "/html[1]/body[1]/div[2]/a[1]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "text_quoted_correctly",
             "snippet": "<a name=\"navskip\">",
             "value": [
@@ -1324,32 +1216,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22main%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]",
-                "dom": "/html[1]/body[1]/div[2]"
-            },
-            "reasonId": "Pass_0",
-            "ruleId": "text_sensory_misuse",
-            "snippet": "<div role=\"main\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22main%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],
@@ -1656,32 +1522,6 @@
                 "dom": "/html[1]/body[1]/div[1]/a[1]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "text_sensory_misuse",
-            "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/navigation[1]/link[1]",
-                "dom": "/html[1]/body[1]/div[1]/a[1]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "text_quoted_correctly",
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
             "value": [
@@ -1924,32 +1764,6 @@
                 "dom": "/html[1]/body[1]/div[1]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "text_sensory_misuse",
-            "snippet": "<div role=\"navigation\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22navigation%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/navigation[1]",
-                "dom": "/html[1]/body[1]/div[1]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "text_quoted_correctly",
             "snippet": "<div role=\"navigation\">",
             "value": [
@@ -2170,32 +1984,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_whitespace_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cbody%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_whitespace_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]",
-                "dom": "/html[1]/body[1]"
-            },
-            "reasonId": "Pass_0",
-            "ruleId": "text_sensory_misuse",
-            "snippet": "<body>",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_sensory_misuse.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cbody%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_sensory_misuse%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],
@@ -2494,7 +2282,7 @@
             "recommendation": 0,
             "potentialrecommendation": 0,
             "manual": 0,
-            "pass": 89,
+            "pass": 81,
             "ignored": 1,
             "elements": 13,
             "elementsViolation": 0,

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
@@ -61,10 +61,6 @@
             "0": "Background images that convey important information must have a text alternative that describes the image",
             "Pass_0": "Rule Passed"
         },
-        "list_markup_review": {
-            "0": "Use proper HTML list elements to create lists",
-            "Pass_0": "Rule Passed"
-        },
         "page_title_exists": {
             "0": "The page should have a title that correctly identifies the subject of the page",
             "Pass_0": "Rule Passed"
@@ -110,7 +106,7 @@
             "pass": "Rule Passed"
         }
     },
-    "numExecuted": 82,
+    "numExecuted": 69,
     "results": [
         {
             "apiArgs": [],
@@ -139,32 +135,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/page_title_valid.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ctitle%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22page_title_valid%22%2C%22msgArgs%22%3A%5B%22Helo%20World%22%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 0,
-                "top": 0,
-                "width": 0
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]",
-                "dom": "/html[1]/head[1]/title[1]"
-            },
-            "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<title>",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ctitle%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],
@@ -234,32 +204,6 @@
                 "dom": "/html[1]/head[1]/meta[2]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<meta content=\"text\" name=\"Description\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cmeta%20content%3D%5C%22text%5C%22%20name%3D%5C%22Description%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 0,
-                "top": 0,
-                "width": 0
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]",
-                "dom": "/html[1]/head[1]/meta[2]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "img_alt_background",
             "snippet": "<meta content=\"text\" name=\"Description\">",
             "value": [
@@ -312,32 +256,6 @@
                 "dom": "/html[1]/head[1]/meta[1]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<meta charset=\"utf-8\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cmeta%20charset%3D%5C%22utf-8%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 0,
-                "top": 0,
-                "width": 0
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]",
-                "dom": "/html[1]/head[1]/meta[1]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "img_alt_background",
             "snippet": "<meta charset=\"utf-8\">",
             "value": [
@@ -373,32 +291,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/aria_content_in_landmark.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cmeta%20charset%3D%5C%22utf-8%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22aria_content_in_landmark%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 0,
-                "top": 0,
-                "width": 0
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]",
-                "dom": "/html[1]/head[1]"
-            },
-            "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<head>",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Chead%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],
@@ -537,32 +429,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]/heading[1]",
-                "dom": "/html[1]/body[1]/div[2]/h1[1]"
-            },
-            "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<h1>",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],
@@ -788,32 +654,6 @@
                 "dom": "/html[1]/body[1]/div[2]/div[2]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<div id=\"firstDiv\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]",
-                "dom": "/html[1]/body[1]/div[2]/div[2]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "img_alt_background",
             "snippet": "<div id=\"firstDiv\">",
             "value": [
@@ -973,32 +813,6 @@
                 "dom": "/html[1]/body[1]/div[2]/div[1]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<div id=\"firstDiv\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20id%3D%5C%22firstDiv%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]",
-                "dom": "/html[1]/body[1]/div[2]/div[1]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "img_alt_background",
             "snippet": "<div id=\"firstDiv\">",
             "value": [
@@ -1129,32 +943,6 @@
                 "dom": "/html[1]/body[1]/div[2]/a[1]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<a name=\"navskip\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20name%3D%5C%22navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 0,
-                "left": 999,
-                "top": 999,
-                "width": 0
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]",
-                "dom": "/html[1]/body[1]/div[2]/a[1]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "img_alt_background",
             "snippet": "<a name=\"navskip\">",
             "value": [
@@ -1268,32 +1056,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_block_heading.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22main%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_block_heading%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/main[1]",
-                "dom": "/html[1]/body[1]/div[2]"
-            },
-            "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<div role=\"main\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22main%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],
@@ -1608,32 +1370,6 @@
                 "dom": "/html[1]/body[1]/div[1]/a[1]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/navigation[1]/link[1]",
-                "dom": "/html[1]/body[1]/div[1]/a[1]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "img_alt_background",
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
             "value": [
@@ -1799,32 +1535,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_block_heading.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22navigation%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22text_block_heading%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]/navigation[1]",
-                "dom": "/html[1]/body[1]/div[1]"
-            },
-            "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<div role=\"navigation\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cdiv%20role%3D%5C%22navigation%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],
@@ -2079,32 +1789,6 @@
                 "dom": "/html[1]/body[1]"
             },
             "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<body>",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Cbody%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 999,
-                "top": 999,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]",
-                "dom": "/html[1]/body[1]"
-            },
-            "reasonId": "Pass_0",
             "ruleId": "img_alt_background",
             "snippet": "<body>",
             "value": [
@@ -2140,32 +1824,6 @@
             "ignored": false,
             "level": "pass",
             "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/page_title_exists.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Chtml%20lang%3D%5C%22en%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22page_title_exists%22%2C%22msgArgs%22%3A%5B%5D%7D"
-        },
-        {
-            "apiArgs": [],
-            "bounds": {
-                "height": 999,
-                "left": 0,
-                "top": 0,
-                "width": 999
-            },
-            "category": "Accessibility",
-            "message": "Rule Passed",
-            "messageArgs": [],
-            "path": {
-                "aria": "/document[1]",
-                "dom": "/html[1]"
-            },
-            "reasonId": "Pass_0",
-            "ruleId": "list_markup_review",
-            "snippet": "<html lang=\"en\">",
-            "value": [
-                "VIOLATION",
-                "PASS"
-            ],
-            "ignored": false,
-            "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/list_markup_review.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Chtml%20lang%3D%5C%22en%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22list_markup_review%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],
@@ -2282,7 +1940,7 @@
             "recommendation": 0,
             "potentialrecommendation": 0,
             "manual": 0,
-            "pass": 81,
+            "pass": 68,
             "ignored": 1,
             "elements": 13,
             "elementsViolation": 0,


### PR DESCRIPTION
The following formats should be use for the release notes and PRs.

fixrule(`list_markup_review`) Reduce Needs Review false positives for list

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: list_markup_review

### This PR is related to the following issue(s): 
#1626 


### Testing reference: 
test case: test/v2/checker/accessibility/rules/list_markup_review_ruleunit/list-widget-inapplicable.html
filter to the requirement 1.3.1 Info and Relationships
Before: two NR messages: Verify whether this is a list that should use HTML list elements 
after: the two NR should disappear.

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
