### PR TITLE
fix(`engine`, `extension`, `node`, `karma`, `cypress`): Update README's to reference IBM Equal Access Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Toolkit is a major part of the accessibility information and applications at
 This README covers topics for users who want to find and install the deployed tools as well as topics for developers who want to better understand the various components and build the tools themselves.
 
 The [wiki](https://github.com/IBMa/equal-access/wiki) contains overview information, links to videos, and other resources.
-See the [Release Notes](https://github.com/IBMa/equal-access/releases) for the latest deployed changes in the tools and components.
+See the [Release Notes](https://github.com/IBMa/equal-access/releases) for the latest deployed changes in the tools, rules, and components.
 
 ## Usage
 
@@ -20,9 +20,9 @@ The tools have been deployed to the browser and NPM stores so they can be easily
 
 The browser extensions provide an integrated checking experience and visualizations to help users quickly identify the source of accessibility issues and try fixes:
 
-* [Chrome accessibility-checker-extension](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) : web browser extension that integrates automated accessibility checking capabilities into the Chrome Developer Tools.
-* [Firefox accessibility-checker-extension](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/) : web browser extension that integrates automated accessibility checking capabilities into the Firefox Web Developer Tools.
-* [Edge accessibility-checker-extension](https://microsoftedge.microsoft.com/addons/detail/ibm-equal-access-accessib/ompccpejakabkmfepbijnagedbdfldka) : web browser extension that integrates automated accessibility checking capabilities into the Edge Developer Tools.
+* [Chrome Web Store extension](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) : web browser extension that integrates automated accessibility checking capabilities into the Chrome Developer Tools.
+* [Firefox Add-on extension](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/) : web browser extension that integrates automated accessibility checking capabilities into the Firefox Web Developer Tools.
+* [Edge Add-on extension](https://microsoftedge.microsoft.com/addons/detail/ibm-equal-access-accessib/ompccpejakabkmfepbijnagedbdfldka) : web browser extension that integrates automated accessibility checking capabilities into the Edge Developer Tools.
 
 #### Automated testing packages
 * [Node accessibility-checker](https://www.npmjs.com/package/accessibility-checker): automated accessibility testing within a continuous integration pipeline, such as Travis CI for Node-based test environments, that works works with test frameworks such as Selenium, Puppeteer, Playwright, and Zombie; and provides the ability to validate results against baseline files, and scan local files.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # equal-access
 
 This Git repository hosts tools and supporting components of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
-The Toolkit is a major part of the applications and accessibility information at [ibm.com/able](https://ibm.com/able/).
+The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
+The guidance is organized by phase, such as Plan, Design, Develop, and Verify, and explains how to integrate these automated testing tools into the [Verify phase](https://www.ibm.com/able/toolkit/verify/overview).
+The Toolkit is a major part of the accessibility information and applications at [ibm.com/able](https://ibm.com/able/).
 
 ## Overview
 
@@ -12,13 +14,20 @@ See the [Release Notes](https://github.com/IBMa/equal-access/releases) for the l
 
 ## Usage
 
-The tools have been deployed to the browser and NPM stores so they can be easily downloaded and installed:
+The tools have been deployed to the browser and NPM stores so they can be easily downloaded and installed.
 
-* [Chrome accessibility-checker-extension](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) : web browser extension that integrates automated accessibility checking capabilities into the Chrome Developer Tools
-* [Firefox accessibility-checker-extension](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/) : web browser extension that integrates automated accessibility checking capabilities into the Firefox Web Developer Tools
-* [Node accessibility-checker](https://www.npmjs.com/package/accessibility-checker): automated accessibility testing within a continuous integration pipeline, such as Travis CI for Node-based test environments, such as Selenium, Puppeteer, Playwright, and Zombie; the ability to validate results against baseline files, and scan local files
-* [karma-accessibility-checker](https://www.npmjs.com/package/karma-accessibility-checker): automated accessibility testing for the Karma environment
-* [cypress-accessibility-checker](https://www.npmjs.com/package/cypress-accessibility-checker): wrapper of the `accessibility-checker` in the Cypress environment
+#### Browser extensions
+
+The browser extensions provide an integrated checking experience and visualizations to help users quickly identify the source of accessibility issues and try fixes:
+
+* [Chrome accessibility-checker-extension](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) : web browser extension that integrates automated accessibility checking capabilities into the Chrome Developer Tools.
+* [Firefox accessibility-checker-extension](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/) : web browser extension that integrates automated accessibility checking capabilities into the Firefox Web Developer Tools.
+* [Edge accessibility-checker-extension](https://microsoftedge.microsoft.com/addons/detail/ibm-equal-access-accessib/ompccpejakabkmfepbijnagedbdfldka) : web browser extension that integrates automated accessibility checking capabilities into the Edge Developer Tools.
+
+#### Automated testing packages
+* [Node accessibility-checker](https://www.npmjs.com/package/accessibility-checker): automated accessibility testing within a continuous integration pipeline, such as Travis CI for Node-based test environments, that works works with test frameworks such as Selenium, Puppeteer, Playwright, and Zombie; and provides the ability to validate results against baseline files, and scan local files.
+* [Karma-accessibility-checker](https://www.npmjs.com/package/karma-accessibility-checker): automated accessibility testing for the Karma environment.
+* [Cypress-accessibility-checker](https://www.npmjs.com/package/cypress-accessibility-checker): wrapper of the `accessibility-checker` in the Cypress environment.
 
 ## Requirements for building the tools
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The browser extensions provide an integrated checking experience and visualizati
 * [Edge Add-on extension](https://microsoftedge.microsoft.com/addons/detail/ibm-equal-access-accessib/ompccpejakabkmfepbijnagedbdfldka) : web browser extension that integrates automated accessibility checking capabilities into the Edge Developer Tools.
 
 #### Automated testing packages
-* [Node accessibility-checker](https://www.npmjs.com/package/accessibility-checker): automated accessibility testing within a continuous integration pipeline, such as Travis CI for Node-based test environments, that works works with test frameworks such as Selenium, Puppeteer, Playwright, and Zombie; and provides the ability to validate results against baseline files, and scan local files.
+* [Node accessibility-checker](https://www.npmjs.com/package/accessibility-checker): automated accessibility testing within a continuous integration pipeline, such as Travis CI for Node-based test environments, that works with test frameworks such as Selenium, Puppeteer, Playwright, and Zombie; and provides the ability to validate results against baseline files, and scan local files.
 * [Karma-accessibility-checker](https://www.npmjs.com/package/karma-accessibility-checker): automated accessibility testing for the Karma environment.
 * [Cypress-accessibility-checker](https://www.npmjs.com/package/cypress-accessibility-checker): wrapper of the `accessibility-checker` in the Cypress environment.
 
@@ -110,7 +110,7 @@ Please check the README for each individual tool for its build instructions:
 
 ## Feedback and reporting bugs
 
-If you think you've found a bug, have questions or suggestions, open a [GitHub Issue](https://github.com/IBMa/equal-access/issues). If you are an IBM employee, feel free to ask questions in the IBM internal Slack channel `#accessibility-at-ibm`.
+If you think you've found a bug, have questions or suggestions, open a [GitHub Issue](https://github.com/IBMa/equal-access/issues/new/choose). If you are an IBM employee, feel free to ask questions in the IBM internal Slack channel `#accessibility-at-ibm`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # equal-access
 
 This Git repository hosts tools and supporting components of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
+The Toolkit is a major part of the applications and accessibility information at [ibm.com/able](https://ibm.com/able/).
 
 ## Overview
 
-This README covers topics for users who want to find the deployed tools as well as topics for developers who want to better understand the various components and build the tools.
+This README covers topics for users who want to find and install the deployed tools as well as topics for developers who want to better understand the various components and build the tools themselves.
 
 The [wiki](https://github.com/IBMa/equal-access/wiki) contains overview information, links to videos, and other resources.
+See the [Release Notes](https://github.com/IBMa/equal-access/releases) for the latest deployed changes in the tools and components.
 
 ## Usage
 
-The tools have been deployed to the various stores and NPM so they can be easily downloaded and installed:
+The tools have been deployed to the browser and NPM stores so they can be easily downloaded and installed:
 
 * [Chrome accessibility-checker-extension](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) : web browser extension that integrates automated accessibility checking capabilities into the Chrome Developer Tools
 * [Firefox accessibility-checker-extension](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/) : web browser extension that integrates automated accessibility checking capabilities into the Firefox Web Developer Tools
@@ -18,7 +20,7 @@ The tools have been deployed to the various stores and NPM so they can be easily
 * [karma-accessibility-checker](https://www.npmjs.com/package/karma-accessibility-checker): automated accessibility testing for the Karma environment
 * [cypress-accessibility-checker](https://www.npmjs.com/package/cypress-accessibility-checker): wrapper of the `accessibility-checker` in the Cypress environment
 
-## Requirements
+## Requirements for building the tools
 
 * [Node Version 18](https://nodejs.org/en/download/).
 

--- a/accessibility-checker-engine/README-NPM.md
+++ b/accessibility-checker-engine/README-NPM.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-`accessibility-checker-engine` is a DOM, rule-based engine for detecting issues in web applications. The engine is used by the [IBM Equal Access Accessibility Checker](https://www.ibm.com/able/toolkit/tools#develop) suite of tools. The rules and engine are fully written in JavaScript and can be injected directly into web pages and applications.
+`accessibility-checker-engine` is a rules-based engine for detecting issues in the Document Object Model (DOM) of web applications and content.
+
+- The engine is used by the [IBM Equal Access Accessibility Checker](https://www.ibm.com/able/toolkit/tools#develop) suite of tools.
+- The rules and engine are written in JavaScript and can be injected directly into web pages and applications.
 
 ## Get the engine
 
@@ -43,9 +46,12 @@ checker.check(doc, ["IBM_Accessibility"])
 * `["IBM_Accessibility"]` - apply IBM accessibility ruleset.
 * `report` - accessibility results contains identified accessibility issues and their descriptions from the given `doc`, and a summary of the issues. The report is in JSON format (see [details](#report)).
 
-## Checklist and Rulesets
+## Rules and Rulesets
 
-The rule are based on the IBM [Checklist](https://www.ibm.com/able/guidelines/ci162/accessibility_checklist.html), which is a superset of WCAG 2.1 AA. We also provide a WCAG 2.0 AA rulesets. Mappings from the checklists to rules are defined in the [ruleset file](https://github.com/IBMa/equal-access/blob/master/accessibility-checker-engine/src/v2/checker/accessibility/rulesets/index.ts)
+* Rules are based on the [IBM Accessibility requirements](https://www.ibm.com/able/requirements/requirements/), which is a unified set of WCAG, EN 301 549, and US 508 standards.
+* Rules are harmonized with the open rules published by the [W3C ACT-Rules Community](https://www.w3.org/community/act-r/) group as reported in the [IBM Equal Access Accessibility Checker ACT implementation report](https://wai-wcag-act-rules.netlify.app/standards-guidelines/act/implementations/equal-access/).
+* Rule sets, such as `IBM Accessibility v7.2`, `WCAG 2.2 (A & AA)`, `WCAG 2.1 (A & AA)`, and `WCAG 2.0 (A & AA)`and mappings of the rules to the standards (Requirements), Rule IDs, the individual failure messages, and links to the Help files are published at [Checker rule sets](https://www.ibm.com/able/requirements/checker-rule-sets).
+* Mappings of the rules are defined in the [individual rule_ID_name.ts files](https://github.com/IBMa/equal-access/tree/master/accessibility-checker-engine/src/v4/rules).
 
 ## Report
 
@@ -202,7 +208,7 @@ The following code snippet demonstrates how to use ACE to test a web page for ac
 
 ### Browser extensions
 
-You can use the [accessibility-checker-extension](https://www.ibm.com/able/toolkit/tools/#develop) for Chrome or Firefox. The browser extensions integrate the accessibility web engine (ace.js) and formatted results into the browser developer tool to visually view the accessibility issues and the locations of violating components. For more information and instructions, please view [accessibility-checker-extensions](https://www.ibm.com/able/toolkit/tools/#develop).
+You can use the [accessibility-checker-extension](https://www.ibm.com/able/toolkit/tools/#develop) for Chrome, Edge, or Firefox. The browser extensions integrate the accessibility web engine (ace.js) and formatted results into the browser developer tool to view the accessibility issues and the locations of violating components. For more information and instructions, please view [accessibility-checker-extensions](https://www.ibm.com/able/toolkit/tools/#develop).
 
 ### Integration with test frameworks
 

--- a/accessibility-checker-engine/README-RULES.md
+++ b/accessibility-checker-engine/README-RULES.md
@@ -1,6 +1,10 @@
 # accessibility-checker-engine RULES
 
-This README is oriented toward rule creation or modification. Users who want to modify an existing rule or create a new rule should read this document. Any rule addition or change should be fully reviewed and tested before being approved for public release.
+This README is oriented toward rule creation or modification. Users who want to modify an existing rule or create a new rule should read this document.
+Any rule addition or change should be fully reviewed and tested before being approved for public release.
+
+- The engine and rule server is used by the [IBM Equal Access Accessibility Checker](https://www.ibm.com/able/toolkit/tools#develop) suite of tools.
+- The engine and rules are written in JavaScript and can be injected directly into web pages and applications.
 
 ## Specification and structure
 
@@ -79,10 +83,13 @@ Help integrates the following:
 * About this requirement
 * Who does this affect?
 
-### Rule sets and Mappings
+### Rule sets and mappings
 
-* Rule sets, such as `IBM Accessibility v7.2`, `WCAG 2.2 (A & AA)`, etc. and mappings of the latest rules to the standards (Requirement and Rule IDs), the individual failure messages (by Reasons ID), and links to the Help files are listed in the published [Checker rule sets](https://www.ibm.com/able/requirements/checker-rule-sets)
-* `npm run build:help` in the `.../accessibility-checker-engine` directory creates `dist/help/rules.html` that can be reviewed
+* Rules are based on the [IBM Accessibility requirements](https://www.ibm.com/able/requirements/requirements/), which is a unified set of WCAG, EN 301 549, and US 508 standards.
+* Rules are harmonized with the open rules published by the [W3C ACT-Rules Community](https://www.w3.org/community/act-r/) group as reported in the [IBM Equal Access Accessibility Checker ACT implementation report](https://wai-wcag-act-rules.netlify.app/standards-guidelines/act/implementations/equal-access/).
+* Rule sets, such as `IBM Accessibility v7.2`, `WCAG 2.2 (A & AA)`, `WCAG 2.1 (A & AA)`, and `WCAG 2.0 (A & AA)`and mappings of the rules to the standards (Requirements), Rule IDs, the individual failure messages, and links to the Help files are published at [Checker rule sets](https://www.ibm.com/able/requirements/checker-rule-sets).
+* Mappings of the rules are defined in the [individual rule_ID_name.ts files](https://github.com/IBMa/equal-access/tree/master/accessibility-checker-engine/src/v4/rules).
+* `npm run build:help` in the `.../accessibility-checker-engine` directory creates `dist/help/rules.html` that can be reviewed.
 * Each build creates the `Rules listing` artifact in **Actions** that can be reviewed prior to deployment.
 
 ## Test cases

--- a/accessibility-checker-engine/README.md
+++ b/accessibility-checker-engine/README.md
@@ -7,7 +7,13 @@ This README covers topics for developers who want to better understand the rules
 
 ## Overview
 
-`accessibility-checker-engine` contains accessibility rules and an evaluation engine to help users to check their web pages to identify and report accessibility issues.
+`accessibility-checker-engine` contains accessibility rules, help, and an evaluation engine to help users to check their web pages to identify and report accessibility issues.
+
+The engine is used by the [IBM Equal Access Accessibility Checker](https://www.ibm.com/able/toolkit/tools#develop) suite of tools.
+The engine and tools are supporting components of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
+The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
+The guidance is organized by phase, such as Plan, Design, Develop, and Verify, and explains how to integrate the automated testing tools into the [Verify phase](https://www.ibm.com/able/toolkit/verify/overview).
+The Toolkit is a major part of the accessibility information and applications at [ibm.com/able](https://ibm.com/able/).
 
 ## Accessibility Requirements and Rulesets
 
@@ -15,11 +21,11 @@ The `"IBM Accessibility"` ruleset is based on the [IBM Accessibility Requirement
 
 The rules test conformance against the standards and specifications, such as the [Accessible Rich Internet Applications (ARIA) specification](https://www.w3.org/TR/wai-aria-1.2/).
 The rules are harmonized with open rules published by the [W3C ACT-Rules Community](https://www.w3.org/community/act-r/) group as reported in the [IBM Equal Access Accessibility Checker ACT implementation report](https://wai-wcag-act-rules.netlify.app/standards-guidelines/act/implementations/equal-access/).
-`Rulesets` are also provided for `"WCAG 2.1 (A,AA)"` and `"WCAG 2.0 (A,AA)"`.
+`Rulesets` are also provided for `"WCAG 2.2 (A,AA)"`, `"WCAG 2.1 (A,AA)"`, and `"WCAG 2.0 (A,AA)"`.
 
 Mappings of the latest rules to the standards, the individual failure messages, and links to the Help files explaining _Why it is important_ and _What to do_ are listed in the [Checker rule sets](https://www.ibm.com/able/requirements/checker-rule-sets).
 
-## Install and build
+## Building and running locally
 
 Review [equal-access/README](../README.md) on how to clone the source.
 Once the source code is cloned to your local environment, you can build the source code based on the requirements of your local environment.
@@ -217,13 +223,20 @@ The following code snippet demonstrates how to use ACE to test a web page for ac
 
 ### Browser extensions
 
-You can use the [accessibility-checker-extension](../accessibility-checker-extension) for Chrome or Firefox. The browser extensions integrate the accessibility web engine (ace.js) and formatted results into the browser developer tool to visually view the accessibility issues and the locations of violating components. For more information and instructions, review [accessibility-checker-extensions](../accessibility-checker-extension).
+The [accessibility-checker-extension](../accessibility-checker-extension) has been deployed as a DevTools extension for Chrome, Edge, or Firefox: 
 
-### Integration with test frameworks
+* [Chrome Web store extension](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp)
+* [Firefox Add-on extension](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/)
+* [Edge Add-On extension](https://microsoftedge.microsoft.com/addons/detail/ibm-equal-access-accessib/ompccpejakabkmfepbijnagedbdfldka)
 
-You can use the [karma-accessibility-checker](../karma-accessibility-checker) to integrate accessibility web engine into [Karma](https://karma-runner.github.io/latest/index.html) or [Selenium](https://www.selenium.dev/) test framework. For more information and instructions, view [karma-accessibility-checker](../karma-accessibility-checker).
+The browser extensions integrate the accessibility checker engine (ace.js) and formatted results into the browser developer tool to view the accessibility issues and the locations of violating components.
+The browser extensions provide an integrated checking experience and visualizations to help users quickly identify the source of accessibility issues and try fixes. 
 
-You can use the [cypress-accessibility-checker](../cypress-accessibility-checker) to integrate automated accessibility testing into [Cypress](https://docs.cypress.io/guides/overview/why-cypress) a next generation front end testing tool built for the modern web. For more information and instructions, view [cypress-accessibility-checker](../cypress-accessibility-checker).
+### Integration with automated test frameworks
+
+Use the [karma-accessibility-checker](../karma-accessibility-checker) to integrate accessibility web engine into [Karma](https://karma-runner.github.io/latest/index.html) or [Selenium](https://www.selenium.dev/) test framework. For more information and instructions, view [karma-accessibility-checker](../karma-accessibility-checker).
+
+Use the [cypress-accessibility-checker](../cypress-accessibility-checker) to integrate automated accessibility testing into [Cypress](https://docs.cypress.io/guides/overview/why-cypress) a next generation front end testing tool built for the modern web. For more information and instructions, view [cypress-accessibility-checker](../cypress-accessibility-checker).
 
 ## Feedback and reporting bugs
 

--- a/accessibility-checker-engine/README.md
+++ b/accessibility-checker-engine/README.md
@@ -240,7 +240,7 @@ Use the [cypress-accessibility-checker](../cypress-accessibility-checker) to int
 
 ## Feedback and reporting bugs
 
-If you think you've found a bug, have questions or suggestions, open a [GitHub Issue](https://github.com/IBMa/equal-access/issues?q=is%3Aopen+is%3Aissue+label%3Aengine), tagged with `engine`.
+If you think you've found a bug, have questions or suggestions, open a [GitHub Issue](https://github.com/IBMa/equal-access/issues/new/choose), tagged with `engine`.
 
 If you are an IBM employee, feel free to ask questions in the IBM internal Slack channel `#accessibility-at-ibm`.
 

--- a/accessibility-checker-extension/README.md
+++ b/accessibility-checker-extension/README.md
@@ -1,17 +1,25 @@
 # accessibility-checker-extension
 
-Browser extensions integrated with the web developer tools that add automated accessibility checking, automated keyboard checking visualizations, and reporting capabilities
+Browser extensions integrated with the web developer tools (DEvTools) that add automated accessibility checking, automated keyboard checking visualizations, and reporting capabilities.
+
+The extensions are supporting components of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
+The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
+The guidance is organized by phase, such as Plan, Design, Develop, and Verify, and explains how to integrate the automated testing tools into the [Verify phase](https://www.ibm.com/able/toolkit/verify/overview).
+The Toolkit is a major part of the accessibility information and applications at [ibm.com/able](https://ibm.com/able/).
 
 ## Usage
 
 The extensions have been deployed to the various stores so they can be easily downloaded and installed:
 
-* [Chrome accessibility-checker-extension](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) : web browser extension that integrates automated accessibility checking capabilities into the Chrome Developer Tools
-* [Firefox accessibility-checker-extension](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/) : web browser extension that integrates automated accessibility checking capabilities into the Firefox Web Developer Tools
-  
-## Requirements for building the extensions
+* [Chrome Web Store extension](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) : web browser extension that integrates automated accessibility checking capabilities into the Chrome Developer Tools
+* [Firefox Add-on extension](https://addons.mozilla.org/en-US/firefox/addon/accessibility-checker/) : web browser extension that integrates automated accessibility checking capabilities into the Firefox Web Developer Tools
+* [Edge Add-on extension](https://microsoftedge.microsoft.com/addons/detail/ibm-equal-access-accessib/ompccpejakabkmfepbijnagedbdfldka) : web browser extension that integrates automated accessibility checking capabilities into the Edge Developer Tools.
 
-* [Node Version 16](https://nodejs.org/en/download/).
+The browser extensions provide an integrated checking experience and visualizations to help users quickly identify the source of accessibility issues and try fixes.
+
+## Requirements for building and running locally
+
+* [Node Version 18](https://nodejs.org/en/download/).
 
 ### Install dependencies
 

--- a/accessibility-checker-extension/README.md
+++ b/accessibility-checker-extension/README.md
@@ -80,7 +80,7 @@ The commands generate a `package/accessibility-checker-extension.zip` file. The 
 
 ## Feedback and reporting bugs
 
-If you think you've found a bug, have questions or suggestions, open a [GitHub Issue](https://github.com/IBMa/equal-access/issues?q=is%3Aopen+is%3Aissue+label%3Aextension-checker), tagged with `extension-checker`.
+If you think you've found a bug, have questions or suggestions, open a [GitHub Issue](https://github.com/IBMa/equal-access/issues/new/choose), tagged with `extension-checker`.
 
 If you are an IBM employee, feel free to ask questions in the IBM internal Slack channel `#accessibility-at-ibm`.
 

--- a/accessibility-checker/README.md
+++ b/accessibility-checker/README.md
@@ -98,7 +98,7 @@ $ npm test
 
 ## Feedback and reporting bugs
 
-If you think you've found a bug, have questions or suggestions, open a [GitHub Issue](https://github.com/IBMa/equal-access/issues?q=is%3Aopen+is%3Aissue+label%3Anode-accessibility-checker), tagged with `node-accessibility-checker`.
+If you think you've found a bug, have questions or suggestions, open a [GitHub Issue](https://github.com/IBMa/equal-access/issues/new/choose), tagged with `node-accessibility-checker`.
 
 If you are an IBM employee, feel free to ask questions in the IBM internal Slack channel `#accessibility-at-ibm`.
 

--- a/accessibility-checker/README.md
+++ b/accessibility-checker/README.md
@@ -2,7 +2,12 @@
 
 Automated accessibility testing for Node-based test environments.
 
-To get started using the deployed packages, review the [Node accessibility-checker](https://www.npmjs.com/package/accessibility-checker) on NPM.
+To get started using the deployed packages, download the [Node accessibility-checker](https://www.npmjs.com/package/accessibility-checker) from NPM.
+
+This tool is a supporting component of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
+The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
+The guidance is organized by phase, such as Plan, Design, Develop, and Verify, and explains how to integrate this automated testing tool into the [Verify phase](https://www.ibm.com/able/toolkit/verify/overview).
+The Toolkit is a major part of the accessibility information and applications at [ibm.com/able](https://ibm.com/able/).
 
 ## Features
 
@@ -58,7 +63,7 @@ Review the examples of validating automated accessibility testing results agains
 
 ### Requirements
 
-- [Node Version 16](https://nodejs.org/en/download/)
+- [Node Version 18](https://nodejs.org/en/download/)
 
 ### Install
 

--- a/accessibility-checker/src/README.md
+++ b/accessibility-checker/src/README.md
@@ -9,6 +9,11 @@
 - allows users to scan HTML nodes/widgets, URLs, local files, HTML documents, and HTML content in the form of a string
 - aside from just performing accessibility scanning, it provides a framework to validate accessibility scan results against baseline files and/or simply failing the test cases based on the levels of violations found during the scan
 
+The NodeJS module is a component of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
+The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
+The guidance is organized by phase, such as Plan, Design, Develop, and Verify, and explains how to integrate the automated testing tools into the [Verify phase](https://www.ibm.com/able/toolkit/verify/overview).
+The Toolkit is a major part of the accessibility information and applications at [ibm.com/able](https://ibm.com/able/).
+
 Note that we have seen some non-standard CSS parsing with Zombie, so be aware of inconsistencies as a result.
 
 ## Usage
@@ -23,7 +28,7 @@ This module provides some basic command-line utilities that will allow scanning 
 
 ### Programmatic
 
-The following is how to perform an accessibility scan within your test cases and verifying the scan results:
+The following is how to perform an accessibility scan within your test cases and verify the scan results:
 
 ```javascript
 const aChecker = require("accessibility-checker");
@@ -31,7 +36,7 @@ const aChecker = require("accessibility-checker");
 aChecker.getCompliance(testDataFileContent, testLabel).then((results) => {
     const report = results.report;
 
-    // Call the aChecker.assertCompliance API which is used to compare the results with baseline object if we can find one that
+    // Call the aChecker.assertCompliance API which is used to compare the results with the baseline object if we can find one that
     // matches the same label which was provided.
     const returnCode = aChecker.assertCompliance(report);
 
@@ -98,13 +103,13 @@ options for `accessibility-checker`. Following is the structure of the `.achecke
 # Default: latest
 # Run `npx achecker archives` for a list of valid ruleArchive ids and policy ids.
 # If "latest", will use the latest rule release
-# If "versioned" (supported in 3.1.61+), will use latest rule release at
+# If "versioned" (supported in 3.1.61+), will use the latest rule release at
 # the time this version of the tool was released 
 ruleArchive: latest
 
 # optional - Specify one or many policies to scan.
 # i.e. For one policy use policies: IBM_Accessibility
-# i.e. Multiple policies: IBM_Accessibility,WCAG_2_1
+# i.e. Multiple policies: IBM_Accessibility, WCAG_2_1
 # Run `npx achecker archives` for a list of valid ruleArchive ids and policy ids
 policies:
     - IBM_Accessibility
@@ -119,7 +124,7 @@ failLevels:
     - violation
     - potentialviolation
 
-# optional - Specify one or many violation levels which should be reported
+# optional - Specify one or many violation levels that should be reported
 #            i.e. If specified violation then in the report it would only contain
 #                 results which are level of violation.
 # i.e. reportLevels: violation
@@ -207,7 +212,7 @@ Execute accessibility scan on provided content. `content` can be in the followin
 - Puppeteer page
 - Playwright page
 
-Note: When using Selenium WebDriver the aChecker.getCompliance API will only take Selenium WebDriver (WebDriver) instance. When using puppeteer, aChecker.getCompliance expects the Page object.
+Note: When using Selenium WebDriver the aChecker.getCompliance API will only take Selenium WebDriver (WebDriver) instance. When using Puppeteer, aChecker.getCompliance expects the Page object.
 
 Using a callback mechanism (`callback`) to extract the results and perform assertion using accessibility-checker APIs.
 
@@ -313,13 +318,13 @@ Using a callback mechanism (`callback`) to extract the results and perform asser
 
 Perform assertion on the scan results. Will perform one of the following assertions based on the condition that is met:
 
-1. In the case a baseline file is provided and available in memory for these scan results, a compare of baseline to `report` will be made. In this case if `report` matches baseline, it returns 0, otherwise returns 1. For this case, assertion is only run on the xpath and ruleId.
+1. In the case a baseline file is provided and available in memory for these scan results, a compare of baseline to `report` will be made. In this case if `report` matches the baseline, it returns 0, otherwise returns 1. For this case, assertion is only run on the xpath and ruleId.
 
 2. In the case **_no baseline_** file is provided for this particular scan, assertion will be made based on the provided `failLevels`. In this case, it returns 2 if there are failures based on failLevels. (violation level matches at least one provided in the `failLevels` object)
 
 `report` - (Object) results for which assertion needs to be run. See above for report format.
 
-- Returns `0` in the case `actualResults` matches baseline or no violations fall into the failLevels
+- Returns `0` in the case `actualResults` matches the baseline or no violations fall into the failLevels
 - Returns `1` in the case `actualResults` **_don't match_** baseline
 - Returns `2` in the case that there is a failure based on failLevels.
 - Returns `-1` in the case that an exception has occurred during scanning and the results reflected that.
@@ -371,7 +376,7 @@ Retrieve the readable stringified representation of the scan results.
 - `report` - (Object) results which need to be stringified.
     Refer to aChecker.assertCompliance APIs for details on properties to include
 
-Returns `String` representation of the scan results which can be logged to console.
+Returns `String` representation of the scan results which can be logged to the console.
 
 ### async aChecker.getConfig()
 

--- a/cypress-accessibility-checker/README.md
+++ b/cypress-accessibility-checker/README.md
@@ -1,13 +1,22 @@
 # cypress-accessibility-checker
 
-Cypress plugin for automated accessibility testing. This plugin is a Cypress flavor of the NodeJS version of `accessibility-checker` which is also [available on NPM](https://www.npmjs.com/package/accessibility-checker). 
+Cypress plugin for automated accessibility testing.
 
+The [Cypress-accessibility-checker](https://www.npmjs.com/package/cypress-accessibility-checker) is a wrapper of the `accessibility-checker` in the Cypress environment.
+The deployed package can be downloaded and installed from NPM.
+
+This plugin is a Cypress flavor of the NodeJS version of `accessibility-checker` which is also [available on NPM](https://www.npmjs.com/package/accessibility-checker).
 The plugin works by injecting the automated accessibility-checker testing into [Cypress](https://docs.cypress.io/guides/overview/why-cypress), a next generation front end testing tool built for the modern web and scanning the page in context. Please see the `Usage` section in this README for more details.
+
+This package is a supporting component of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
+The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
+The guidance is organized by phase, such as Plan, Design, Develop, and Verify, and explains how to integrate this automated testing tool into the [Verify phase](https://www.ibm.com/able/toolkit/verify/overview).
+The Toolkit is a major part of the accessibility information and applications at [ibm.com/able](https://ibm.com/able/).
 
 ## Requirements
 
 * [Node Version 18](https://nodejs.org/en/download/)
-* Cypress 13
+* Cypress 13 from [cypress.io](https://www.cypress.io/)
 
 ## Installation
 

--- a/cypress-accessibility-checker/README.md
+++ b/cypress-accessibility-checker/README.md
@@ -6,7 +6,8 @@ The [Cypress-accessibility-checker](https://www.npmjs.com/package/cypress-access
 The deployed package can be downloaded and installed from NPM.
 
 This plugin is a Cypress flavor of the NodeJS version of `accessibility-checker` which is also [available on NPM](https://www.npmjs.com/package/accessibility-checker).
-The plugin works by injecting the automated accessibility-checker testing into [Cypress](https://docs.cypress.io/guides/overview/why-cypress), a next generation front end testing tool built for the modern web and scanning the page in context. Please see the `Usage` section in this README for more details.
+The plugin works by injecting the automated accessibility-checker testing into [Cypress](https://docs.cypress.io/guides/overview/why-cypress), a next-generation front-end testing tool built for the modern web and scanning the page in context. 
+Please see the `Usage` section below for more details.
 
 This package is a supporting component of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
 The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
@@ -64,7 +65,7 @@ If you do not want to include `cypress-accessibility-checker` globally, you may 
 
 ## Usage
 
-The commands maps directly to the description of the APIs located [in the accessibility-checker/src/README](https://github.com/IBMa/equal-access/blob/master/accessibility-checker/src/README.md). The names of the APIs within Cypress are just slightly different so they are globally unique in the Cypress namespace.
+The commands map directly to the description of the APIs located [in the accessibility-checker/src/README](https://github.com/IBMa/equal-access/blob/master/accessibility-checker/src/README.md). The names of the APIs within Cypress are just slightly different so they are globally unique in the Cypress namespace.
 
 The typical use case will be to get the accessibility compliance of a document and then assert the accessibility compliance against the configuration that is defined as part of the `.achecker.yml` file and any baselines that are defined. An example of how this looks is below:
 
@@ -74,7 +75,7 @@ The typical use case will be to get the accessibility compliance of a document a
 cy.getCompliance('my scan').assertCompliance()
 ```
 
-Examples on how to use each of the APIs below can be found in the `achecker.js` test file [located here](https://github.com/IBMa/equal-access/blob/master/cypress-accessibility-checker/test/cypress/integration/achecker.js).
+Examples of how to use each of the APIs below can be found in the `achecker.js` test file [located here](https://github.com/IBMa/equal-access/blob/master/cypress-accessibility-checker/test/cypress/integration/achecker.js).
 
 - `cy.getCompliance(label)`
   - Similar to `getCompliance()` in the reference API above.
@@ -83,7 +84,7 @@ Examples on how to use each of the APIs below can be found in the `achecker.js` 
   - Similar to `getCompliance()` in the reference API above, using the passed cy object (typically obtained via `cy.document`).
   - Returned data ([defined here](https://www.npmjs.com/package/accessibility-checker#async-acheckergetcompliance-content--label--string)) will only contain the `report` object.
 - `cy.assertCompliance(failOnError?: boolean)`
-  - If `failOnError` is set to false, this will not fail your test. This is useful for testing what needs to be fixed without failing the test. By default this command will fail your test unless you specify `false` here.
+  - If `failOnError` is set to false, this will not fail your test. This is useful for testing what needs to be fixed without failing the test. By default, this command will fail your test unless you specify `false` here.
 - `cy.getDiffResults(label)`
 - `cy.getBaseline(label)`
 - `cy.diffResultsWithExpected(actual, expected, clean)`
@@ -109,7 +110,7 @@ There is a suite of tests located in the `test/` directory which execute each of
 
 ### Building
 
-The plugin does not really need to be built to be used. However there is a package script to group things for NPM.
+The plugin does not need to be built to be used. However, there is a package script to group things for NPM.
 
 ```bash
 npm install

--- a/karma-accessibility-checker/README.md
+++ b/karma-accessibility-checker/README.md
@@ -1,6 +1,13 @@
 # karma-accessibility-checker
 
-Karma Plugin for Accessibility Testing
+Automated accessibility testing for the Karma environment.
+
+The deployed [Karma-accessibility-checker](https://www.npmjs.com/package/karma-accessibility-checker) package is available from NPM.
+
+This package is a supporting component of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
+The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
+The guidance is organized by phase, such as Plan, Design, Develop, and Verify, and explains how to integrate this automated testing tool into the [Verify phase](https://www.ibm.com/able/toolkit/verify/overview).
+The Toolkit is a major part of the accessibility information and applications at [ibm.com/able](https://ibm.com/able/).
 
 <!-- START doctoc generated TOC please keep comments here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -11,7 +18,6 @@ Karma Plugin for Accessibility Testing
   - [Requirements](#requirements)
   - [Running Locally](#running-locally)
   - [How to Debug](#how-to-debug)
-  - [How to publish to npm repository](#how-to-publish-to-npm-repository)
   - [How to write Karma Reporter:](#how-to-write-karma-reporter)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -22,7 +28,7 @@ All bugs or issues related to the karma-accessibility-checker code can be create
 
 ## Requirements
 
-* [Node Version 16](https://nodejs.org/en/download/).
+* [Node Version 18](https://nodejs.org/en/download/).
 
 ## Running Locally
 
@@ -80,9 +86,6 @@ $ karma start            # Start Karma and runs tests
     - Browser Debugging:
         Since the rules are loaded into the browser, the rules can actually be debugged directly in the browsers debugged as ace.js is just loaded as a script in the browser. Use the normal steps to debug as you would when debugging rules during unit testing. The only difference is that you need to run Karma with either Firefox or Chrome, with autowatch enabled which will allow access to the browser and there will be a DEBUG option enabled.
 
-## How to publish to npm repository
-
-TBD
 
 ## How to write Karma Reporter:
 

--- a/karma-accessibility-checker/src/README.md
+++ b/karma-accessibility-checker/src/README.md
@@ -8,6 +8,11 @@
 - scan HTML nodes/widgets, URLs, local files, HTML documents, and allows you to scan HTML content in the form of a string
 - aside from just performing accessibility scanning, it provides a framework to validate accessibility scan results against baseline files and/or simply failing the test cases based on the levels of violations found during the scan
 
+The Karma plugin is a component of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
+The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
+The guidance is organized by phase, such as Plan, Design, Develop, and Verify, and explains how to integrate the automated testing tools into the [Verify phase](https://www.ibm.com/able/toolkit/verify/overview).
+The Toolkit is a major part of the accessibility information and applications at [ibm.com/able](https://ibm.com/able/).
+
 ### Table of Contents
 
 - [karma-accessibility-checker](#karma-accessibility-checker)
@@ -36,7 +41,7 @@
   - [Errors](#errors)
     - [Error: labelNotProvided](#error-labelnotprovided)
     - [Error: labelNotUnique](#error-labelnotunique)
-    - [Error: slackNotificationTargetIsNotValid](#error-slackNotificationTargetIsNotValid)
+    - [Error: slackNotificationTargetIsNotValid](#error-slacknotificationtargetisnotvalid)
     - [Error: SlackAPIError](#error-slackapierror)
     - [Error: SlackWebHookError](#error-slackwebhookerror)
     - [Error: LoadingConfigError](#error-loadingconfigerror)
@@ -127,7 +132,7 @@ module.exports = function (config) {
 
 #### Configuring `preprocessor`
 
-Use `aChecker` in `preprocessor` to process the baseline files and load them into memory. This saved copy of the files, can then be used for accessibility scan results comparison.
+Use `aChecker` in `preprocessor` to process the baseline files and load them into memory. This saved copy of the files can then be used for accessibility scan results comparison.
 
 ```js
 // karma.conf.js
@@ -152,7 +157,7 @@ module.exports = function (config) {
 
 ### Configuring the plugin
 
-Configuring the `karma-accessibility-checker` plugin involves constructing a `.achecker.yml` file in the project root. This file, will contain all of the configuration
+Configuring the `karma-accessibility-checker` plugin involves constructing a `.achecker.yml` file in the project root. This file will contain all of the configuration
 options for `karma-accessibility-checker`. This is the structure of the `.achecker.yml` file:
 
 ```yml
@@ -160,7 +165,7 @@ options for `karma-accessibility-checker`. This is the structure of the `.acheck
 # i.e. For march rule archive use ruleArchive: 2017MayDeploy
 # Default: latest
 # If "latest", will use the latest rule release
-# If "versioned" (supported in 3.1.61+), will use latest rule release at
+# If "versioned" (supported in 3.1.61+), will use the latest rule release at
 # the time this version of the tool was released 
 # Refer to README.md FAQ section below to get the rule archive ID.
 ruleArchive: latest
@@ -196,7 +201,7 @@ reportLevels:
     - potentialrecommendation
     - manual
 
-# Optional - In what format types the results should be output in (json, html)
+# Optional - In what format types the results should be output (json, html)
 # Default: json
 outputFormat:
     - json
@@ -205,7 +210,7 @@ outputFormat:
 # Default: true
 outputFilenameTimestamp: true
 
-# Optional - Specify labels that you would like associated to your scan
+# Optional - Specify labels that you would like associated with your scan
 #
 # i.e.
 #   label: Firefox,master,V12,Linux
@@ -236,7 +241,7 @@ To perform an accessibility scan within your test cases and verify the scan resu
 ```javascript
 // Perform the accessibility scan using the aChecker.getCompliance API
 aChecker.getCompliance(testDataFileContent, testFile, function (results) {
-    // Call the aChecker.assertCompliance API which is used to compare the results with baseline object if we can find one that
+    // Call the aChecker.assertCompliance API which is used to compare the results with the baseline object if we can find one that
     // matches the same label which was provided.
     var returnCode = aChecker.assertCompliance(results);
 
@@ -361,11 +366,11 @@ Use a callback mechanism (`callback`) to extract the results and perform asserti
 }
 ```
 
-Refer to the `actualResults` parameter in aChecker.assertCompliance API for more details about the properties of results object.
+Refer to the `actualResults` parameter in aChecker.assertCompliance API for more details about the properties of the results object.
 
 ### aChecker.assertCompliance(`actualResults`)
 
-Assertion will be perform one of the following ways based on the condition that is met:
+Assertion will be performed one of the following ways based on the condition that is met:
 
 1. If a baseline file of scan results is available in memory, it will be compared to the `actualResults`. If the `actualResults` matches the baseline, it will return 0. If not, it will return 1. In this case, assertion is only run on the `XPath` and `ruleId`.
 
@@ -391,10 +396,10 @@ Assertion will be perform one of the following ways based on the condition that 
         - **policies**, (Array) policies used for the scan result.
         - **reportLevels**, (Array) list of violation levels to include in the report. (save to file).
         - **startScan**, (Int) start time of the scan in milliseconds since epoch, GMT.
-    - **reports**, (Array) list of reports in the case of multiple iframes are present on the single page. (iframe scanning not support yet) Each array element is an object with these properties:
+    - **reports**, (Array) list of reports in the case of multiple iframes are present on the single page. (iframe scanning not supported yet) Each array element is an object with these properties:
         - **frameIdx**, (Int) frame index in the page represented as an integer value.
         - **frameTitle**, (String) title of the frame on the page that was scanned.
-        - **issues**, (Array) detailed list of violations. Each array element is an objects with these properties:
+        - **issues**, (Array) detailed list of violations. Each array element is an object with these properties:
             - **severityCode**, (String) severity code of the violation.
             - **messageCode**, (String) message code of the violation. Used to map the localized message string.
             - **ruleId**, (String) rule ID of the violation.
@@ -412,7 +417,7 @@ Assertion will be perform one of the following ways based on the condition that 
 - Returns `0` if `actualResults` matches baseline or if no violations match the `failLevels`
 - Returns `1` if `actualResults` _do not_ match the baseline
 - Returns `2` if there is a failure based on `failLevels`
-- Returns `-1` if an exception has occurred during scanning and the results reflected that
+- Returns `-1` if an exception has occurred during scanning and the results reflect that
 
 ### aChecker.getDiffResults(`label`)
 
@@ -524,7 +529,7 @@ Note: The valid policies will vary depending on the selected `ruleArchive`.
 
 ## Known Issues
 
-1. Unable to scan URLs due to "permission denied to access property "document"" when trying to access document of generated iframe. This is due to cross domain frame access restrictions in browsers. On firefox there is no provided alternative, Chrome provides a way to override this by adding the following to karma.config.js:
+1. Unable to scan URLs due to "permission denied to access property "document"" when trying to access the document of the generated iframe. This is due to cross domain frame access restrictions in browsers. On Firefox there is no provided alternative, Chrome provides a way to override this by adding the following to karma.config.js:
 
 ```javascript
  module.exports = function (config) {
@@ -542,7 +547,7 @@ Note: The valid policies will vary depending on the selected `ruleArchive`.
 }
 ```
 
-2. Unable to scan local files when provided to `aChecker.getCompliance(...)` API as a local file URL. This is due to a limitation in Karma where it is not able to load local files using `file://` protocol. For scanning local file, there is a work around which can be used to scan them, following are the steps to update karma.config.js file with the following:
+2. Unable to scan local files when provided to `aChecker.getCompliance(...)` API as a local file URL. This is due to a limitation in Karma where it is not able to load local files using `file://` protocol. For scanning local files, there is a workaround that can be used to scan them, following are the steps to update karma.config.js file with the following:
 
 ````javascript
  module.exports = function (config) {

--- a/rule-server/README.md
+++ b/rule-server/README.md
@@ -1,9 +1,23 @@
 # rule-server
 
-This README covers topics related to build and deploy the rules and rule server.
+This README covers topics to build and deploy the rules and rule server.
+
+All the extensions and automated tools deployed at [IBM Equal Access Accessibility Checker](https://www.ibm.com/able/toolkit/tools#develop) use the same engine and rule server making it easy to replicate finding issues.
 
 - For information on creating and modifying the rules, see [README-RULES](../accessibility-checker-engine/README-RULES.md).
 - For information on installing the engine in a Node or browser environment, see [README-NPM](../accessibility-checker-engine/README-NPM.md).
+
+The rule server, engine, and tools are supporting components of the [IBM Equal Access Toolkit](https://ibm.com/able/toolkit).
+The Toolkit provides the tools and guidance to create experiences that are delightful for people of all abilities.
+The guidance is organized by phase, such as Plan, Design, Develop, and Verify, and explains how to integrate the automated testing tools into the [Verify phase](https://www.ibm.com/able/toolkit/verify/overview).
+The Toolkit is a major part of the accessibility information and applications at [ibm.com/able](https://ibm.com/able/).
+
+### Rules and Rulesets
+
+* Rules are based on the [IBM Accessibility requirements](https://www.ibm.com/able/requirements/requirements/), which is a unified set of WCAG, EN 301 549, and US 508 standards.
+* Rules are harmonized with the open rules published by the [W3C ACT-Rules Community](https://www.w3.org/community/act-r/) group as reported in the [IBM Equal Access Accessibility Checker ACT implementation report](https://wai-wcag-act-rules.netlify.app/standards-guidelines/act/implementations/equal-access/).
+* Rule sets, such as `IBM Accessibility v7.2`, `WCAG 2.2 (A & AA)`, `WCAG 2.1 (A & AA)`, and `WCAG 2.0 (A & AA)`and mappings of the rules to the standards (Requirements), Rule IDs, the individual failure messages, and links to the Help files are published at [Checker rule sets](https://www.ibm.com/able/requirements/checker-rule-sets).
+* Mappings of the rules are defined in the [individual rule_ID_name.ts files](https://github.com/IBMa/equal-access/tree/master/accessibility-checker-engine/src/v4/rules).
 
 ## Branches and rule archives
 


### PR DESCRIPTION
### Description
* Other: The READMEs seem to have an assumption that the users discovered the tool via the Equal Access Toolkit, but some user discover the tools via the browser stores and other means.  They may **_not_** have any information about how the tool fits into the larger context. At a minimum, the overview paragraph at the top now have a sentence or two mentioning the toolkit and how it (the specific tools in its ReadMe) fits into the larger accessibility verification process. 
* Note: The README content will update the stores and NPM when deployed.


### This PR is related to the following issue(s): 
- <!-- Provide each ticket on a new line with # --> #1818 

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) --> none


### Testing reference: 
- <!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior --> open & review the READMEs


### I have conducted the following for this PR: 
- [x] I validated this code (spelling,  grammar & links) in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
