### PR TITLE
fixrule(`img_alt_valid`): Update roles for img elements

### DIFF
--- a/accessibility-checker-engine/help-v4/en-US/img_alt_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/img_alt_valid.html
@@ -45,17 +45,20 @@
 
 ### Why is this important?
 
-When an image contains important information, providing a text alternative makes the same information accessible through audio or other channels, such as a Braille display.
+When an image contains important information, providing a text alternative makes the same information accessible through assistive technologies, such as a Braille display.
+When an image is decorative or redundant, providing correct markup allows assistive technologies to ignore or not repeat the information.
+
 
 <!-- This is where the code snippet is injected -->
 <div id="locSnippet"></div>
 
 ### What to do
 
-* If the image conveys meaning, use the `alt` attribute on the `<img>` element to provide a short description that serves the same purpose as the image
+If the image conveys meaning, provide an `non-empty accessible name`:
+* Use the `alt` attribute on the `<img>` element to provide a short description that serves the same purpose as the image
 * **Or**, use an `aria-label` or `aria-labelledby` to provide a short description that correctly follows the [accessible name calculation](https://www.w3.org/TR/wai-aria-1.2/#namecalculation)
-* **And**, if the image contains important words, include them in the short description (e.g., `alt="submit"`)
-* **Or**, if the image is decorative or redundant, use the attribute with an empty string as its value (e.g., `<img alt="">`)
+* **And**, if the image contains important words, include them in the short description (e.g., `alt="Submit"`) so they match
+* **Or**, if the image is decorative or redundant, use an empty string as the attribute's value (e.g., `<img alt="">`) or set the `role="presentation"`
 
 </script></mark-down>
 <!-- End main panel -->
@@ -70,14 +73,16 @@ When an image contains important information, providing a text alternative makes
 
 * [IBM 1.1.1 Non-text content](https://www.ibm.com/able/requirements/requirements/#1_1_1)
 * [H37: Using alt attributes on img elements](https://www.w3.org/WAI/WCAG22/Techniques/html/H37)
+* [G94: Providing short text alternatives that serve the same purpose as the non-text content](https://www.w3.org/WAI/WCAG22/Techniques/general/G94)
+* [F38: Not marking up decorative images in a way that allows assistive technology to ignore them](https://www.w3.org/WAI/WCAG22/Techniques/failures/F38)
 * [ARIA specification - accessible name calculation](https://www.w3.org/TR/wai-aria-1.2/#namecalculation)
 
 ### Who does this affect?
 
 * People using a screen reader, including blind, low vision, and neurodivergent people
 * People who turn off image-loading on their web browsers
-* People using text only, monochrome, or Braille displays
-* People using text-based browsers (e.g., Lynx) or audio interfaces
+* People using Braille displays
+* People using text-only browsers (e.g., Lynx) or audio interfaces
 
 </script></mark-down>
 <!-- End side panel -->

--- a/accessibility-checker-engine/src/v2/aria/ARIADefinitions.ts
+++ b/accessibility-checker-engine/src/v2/aria/ARIADefinitions.ts
@@ -2374,26 +2374,6 @@ export class ARIADefinitions {
                 validRoles: ["presentation", "none"],
                 globalAriaAttributesValid: false, 
                 otherAllowedAriaAttributes: ["aria-hidden=true"]
-            },
-            "img-with-alt-text": {
-                implicitRole: ["img"],
-                //roleCondition: " when alt attribute has text (is not empty)",
-                validRoles: ["button", "checkbox", "doc-cover", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "progressbar", "radio", "scrollbar", "separator", "slider", "switch", "tab", "treeitem"],
-                globalAriaAttributesValid: true
-            },
-            "img-with-empty-alt": {
-                implicitRole: ["presentation"],
-                //roleCondition: " when alt attribute is empty",
-                validRoles: null,
-                globalAriaAttributesValid: false, 
-                otherAllowedAriaAttributes: ["aria-hidden=true"]
-            },
-            "img-without-alt": {
-                implicitRole: ["img"],
-                //roleCondition: " when alt attribute, aria-label, or aria-labelledby are not present",
-                validRoles: null,
-                globalAriaAttributesValid: false, 
-                otherAllowedAriaAttributes: ["aria-hidden=true"]
             }
         },
         "input": {

--- a/accessibility-checker-engine/src/v2/aria/ARIADefinitions.ts
+++ b/accessibility-checker-engine/src/v2/aria/ARIADefinitions.ts
@@ -2355,6 +2355,26 @@ export class ARIADefinitions {
 
         },
         "img": {
+            "img-with-accname": {
+                implicitRole: ["img"],
+                //roleCondition: "when accessible name presents",
+                validRoles: ["button", "checkbox", "doc-cover", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "meter", "option", "progressbar", "radio", "scrollbar", "separator", "slider", "switch", "tab", "treeitem"],
+                globalAriaAttributesValid: true
+            },
+            "img-without-accname-empty-alt": {
+                implicitRole: ["presentation", "none"],
+                //roleCondition: "when no accessible name presents and alt=''",
+                validRoles: null,
+                globalAriaAttributesValid: false, 
+                otherAllowedAriaAttributes: ["aria-hidden=true"]
+            },
+            "img-without-accname-no-alt": {
+                implicitRole: ["img"],
+                //roleCondition: "when neither accessible name no alt presents",
+                validRoles: ["presentation", "none"],
+                globalAriaAttributesValid: false, 
+                otherAllowedAriaAttributes: ["aria-hidden=true"]
+            },
             "img-with-alt-text": {
                 implicitRole: ["img"],
                 //roleCondition: " when alt attribute has text (is not empty)",

--- a/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
@@ -2868,11 +2868,20 @@ export class RPTUtil {
                             tagProperty = specialTagProperties["other"];   
                         break;
                     case "img":
-                        if (ruleContext.hasAttribute("alt")) {
-                            ruleContext.getAttribute("alt").trim() === "" ? tagProperty = specialTagProperties["img-with-empty-alt"] : tagProperty = specialTagProperties["img-with-alt-text"];
+                        let alt = ruleContext.hasAttribute("alt") ? ruleContext.getAttribute("alt") : null;
+                        let title = ruleContext.hasAttribute("title") ? ruleContext.getAttribute("title") : null;
+                        if ( RPTUtil.getAriaLabel(ruleContext).trim().length !== 0 || (alt !== null && alt.length > 0) || (title !== null && title.length > 0)) {
+                            // If the img has non-empty alt (alt="some text" or alt="  ") or an accessible name is provided
+                            tagProperty = specialTagProperties["img-with-accname"];
                         } else {
-                            RPTUtil.hasAriaLabel(ruleContext) ? tagProperty = specialTagProperties["img-with-alt-text"] : tagProperty = specialTagProperties["img-without-alt"];
-                        }
+                            if (alt !== null) {
+                                // If the img has an empty alt (alt="") 
+                                tagProperty = specialTagProperties["img-without-accname-empty-alt"];
+                            } else {
+                                // If the img lacks an alt attribute 
+                                tagProperty = specialTagProperties["img-without-accname-no-alt"];
+                            }  
+                        }    
                         break;
                     case "input":
                         if (RPTUtil.attributeNonEmpty(ruleContext, "type")) {

--- a/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
+++ b/accessibility-checker-engine/src/v2/checker/accessibility/util/legacy.ts
@@ -920,7 +920,7 @@ export class RPTUtil {
      *       
      * @memberOf RPTUtil
      */
-    public static getResolvedRole(elem: Element) : string {
+    public static getResolvedRole(elem: Element, considerImplicitRoles: boolean = true) : string {
         if (!elem) return null;
         let role = getCache(elem, "RPTUTIL_ELEMENT_RESOLVED_ROLE", null);
         if (role === null) {
@@ -936,7 +936,7 @@ export class RPTUtil {
                 } 
             }
             
-            if (role === null) {
+            if (role === null && considerImplicitRoles) {
                 const implicitRole = RPTUtil.getImplicitRole(elem);
                 role = implicitRole && implicitRole.length > 0 ? implicitRole[0] : undefined;
             }

--- a/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
@@ -41,7 +41,7 @@ export let img_alt_valid: Rule = {
             "fail_blank_alt": "Image 'alt' attribute value consists only of blank space(s)",
             "fail_no_alt": "The image has neither an accessible name nor is marked as decorative or redundant",
             "fail_blank_title": "The image does not have an 'alt' attribute or ARIA label, and the 'title' attribute value consists only of blank space(s)",
-            "group": "Images must have accessible names unless they are decorative or redundance"
+            "group": "Images must have accessible names unless they are decorative or redundant"
         }
     },
     rulesets: [{

--- a/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
@@ -57,20 +57,26 @@ export let img_alt_valid: Rule = {
         if (VisUtil.isNodeHiddenFromAT(ruleContext))
             return null;
         
-        let alt = ruleContext.hasAttribute("alt") ? ruleContext.getAttribute("alt") : null;
-        let title = ruleContext.hasAttribute("title") ? ruleContext.getAttribute("title") : null;
-        if ( RPTUtil.getAriaLabel(ruleContext).trim().length !== 0) {
+        if (RPTUtil.getAriaLabel(ruleContext).trim().length !== 0) {
             // the img has non-empty aria label
             return RulePass("pass");
         }
 
+        let alt = ruleContext.hasAttribute("alt") ? ruleContext.getAttribute("alt") : null;
+        
         // check title attribute
-        if (alt === null || alt.length === 0) {
-            // the img has either no alt or an empty alt (alt=""), further examine the title attribute 
+        if (alt === null) {
+            // the img has no alt or attribute, examine the title attribute
+            let title = ruleContext.hasAttribute("title") ? ruleContext.getAttribute("title") : null;
             if (title === null || title.length === 0) {
-                // no title or title is empty
-                if (alt === null)
+                // no title or title is empty, examine alt further
+                if (alt === null) {
+                    let role = RPTUtil.getResolvedRole(ruleContext, false);
+                    if (role === 'presentation' || role === 'none')
+                        return RulePass("pass");
+                    
                     return RuleFail("fail_no_alt");
+                }    
                 if (alt.length === 0)
                     return RulePass("pass"); 
             } else {
@@ -81,10 +87,9 @@ export let img_alt_valid: Rule = {
                 // title contains some text (title="some text")
                 return RulePass("pass");
             }
-        } else { 
-            // alt contain something
-            if (alt.trim().length > 0) {
-                // the img has non-empty alt (alt="some text")
+        } else {
+            if (alt.length === 0 || alt.trim().length > 0) {
+                // the img has empty alt (alt="") or non-empty alt (alt="some text")
                 return RulePass("pass"); 
             } else {
                 // alt contains blank space only (alt=" ")

--- a/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
@@ -57,43 +57,39 @@ export let img_alt_valid: Rule = {
         if (VisUtil.isNodeHiddenFromAT(ruleContext))
             return null;
         
-        //pass if images with a valid 'alt'    
-        let alt = ruleContext.getAttribute("alt");
-        if (alt !== null) {
-            if (alt.trim().length > 0)
-                return RulePass("pass");   
-            else { 
-                // alt.trim().length === 0
-                if (alt.length > 0) {
-                    // alt contains blank space only (alt=" ")
-                    return RuleFail("fail_blank_alt");  
-                } else {
-                    // alt.length === 0, presentational image, title is optional, handled by other rule(s)
-                    return  RulePass("pass");
-                }
-            }
-        } else {
-            // no alt
-            let label = RPTUtil.getAriaLabel(ruleContext);
-            if (label && label.trim().length > 0)
-                return RulePass("pass");
-            else {
-                let title = ruleContext.getAttribute("title");
-                if (title) {
-                    if (title.trim().length > 0)
-                        return RulePass("pass");   
-                    else { 
-                        // title.trim().length === 0
-                        if (title.length > 0) {
-                            // title contains blank space only (title=" ")
-                            return RuleFail("fail_blank_title");  
-                        }    
-                    }
-                } else {
-                    // neither alt nor aria label or title 
-                    return RuleFail("fail_no_alt"); 
-                }  
-            } 
+        let alt = ruleContext.hasAttribute("alt") ? ruleContext.getAttribute("alt") : null;
+        let title = ruleContext.hasAttribute("title") ? ruleContext.getAttribute("title") : null;
+        if ( RPTUtil.getAriaLabel(ruleContext).trim().length !== 0) {
+            // the img has non-empty aria label
+            return RulePass("pass");
         }
+
+        // check title attribute
+        if (alt === null || alt.length === 0) {
+            // the img has either no alt or an empty alt (alt=""), further examine the title attribute 
+            if (title === null || title.length === 0) {
+                // no title or title is empty
+                if (alt === null)
+                    return RuleFail("fail_no_alt");
+                if (alt.length === 0)
+                    return RulePass("pass"); 
+            } else {
+                if (title.trim().length === 0) {
+                    // title contains blank space only (title="  ")
+                    return RuleFail("fail_blank_title"); 
+                }
+                // title contains some text (title="some text")
+                return RulePass("pass");
+            }
+        } else { 
+            // alt contain something
+            if (alt.trim().length > 0) {
+                // the img has non-empty alt (alt="some text")
+                return RulePass("pass"); 
+            } else {
+                // alt contains blank space only (alt=" ")
+                return RuleFail("fail_blank_alt"); 
+            }    
+        }        
     }
 }

--- a/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
@@ -37,11 +37,11 @@ export let img_alt_valid: Rule = {
     },
     messages: {
         "en-US": {
-            "pass": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "pass": "The image has an accessible name or is correctly marked as decorative or redundant",
             "fail_blank_alt": "Image 'alt' attribute value consists only of blank space(s)",
-            "fail_no_alt": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "fail_no_alt": "The image has neither an accessible name nor is marked as decorative or redundant",
             "fail_blank_title": "The image does not have an 'alt' attribute or ARIA label, and the 'title' attribute value consists only of blank space(s)",
-            "group": "Images require an 'alt' attribute with a short text alternative if they convey meaning, or 'alt=\"\" if decorative"
+            "group": "Images must have accessible names unless they are decorative or redundance"
         }
     },
     rulesets: [{

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/hidden_display_block_test.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/hidden_display_block_test.html
@@ -38,7 +38,7 @@
               "aria": "/document[1]/main[1]/img[1]"
             },
             "reasonId": "fail_no_alt",
-            "message": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "message": "The image has neither an accessible name nor is marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/hidden_display_block_test2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/hidden_display_block_test2.html
@@ -38,7 +38,7 @@
               "aria": "/document[1]/main[1]/img[1]"
             },
             "reasonId": "fail_no_alt",
-            "message": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "message": "The image has neither an accessible name nor is marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/hidden_display_block_test3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/hidden_display_block_test3.html
@@ -38,7 +38,7 @@
               "aria": "/document[1]/main[1]/img[1]"
             },
             "reasonId": "fail_no_alt",
-            "message": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "message": "The image has neither an accessible name nor is marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/hidden_display_block_test4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/hidden_display_block_test4.html
@@ -38,7 +38,7 @@
               "aria": "/document[1]/main[1]/img[1]"
             },
             "reasonId": "fail_no_alt",
-            "message": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "message": "The image has neither an accessible name nor is marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/visibility_override_by_visibility_test.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/Hidden_ruleunit/visibility_override_by_visibility_test.html
@@ -43,7 +43,7 @@
               "aria": "/document[1]/main[1]/img[2]"
             },
             "reasonId": "fail_no_alt",
-            "message": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "message": "The image has neither an accessible name nor is marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_attribute_valid_ruleunit/elementsWithSupportingAttributes.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_attribute_valid_ruleunit/elementsWithSupportingAttributes.html
@@ -1146,11 +1146,11 @@
               "aria": "/document[1]/generic[1]/region[1]/presentation[1]"
             },
             "reasonId": "Fail_invalid_implicit_role_attr",
-            "message": "The ARIA attributes \"aria-pressed\" are not valid for the element <img> with implicit ARIA role \"presentation\"",
+            "message": "The ARIA attributes \"aria-pressed\" are not valid for the element <img> with implicit ARIA role \"presentation, none\"",
             "messageArgs": [
               "aria-pressed",
               "img",
-              "presentation"
+              "presentation, none"
             ],
             "apiArgs": [],
             "category": "Accessibility"
@@ -1366,6 +1366,7 @@
             "apiArgs": [],
             "category": "Accessibility"
           }
+        
             ]
         }
     </script>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_role_valid_ruleunit/act_decorative_fail2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_role_valid_ruleunit/act_decorative_fail2.html
@@ -15,18 +15,18 @@
             "ruleId": "aria_attribute_valid",
             "value": [
               "INFORMATION",
-              "FAIL"
+              "PASS"
             ],
             "path": {
               "dom": "/html[1]/body[1]/main[1]/div[1]/img[1]",
-              "aria": "/document[1]/main[1]/presentation[1]"
+              "aria": "/document[1]/main[1]/img[1]"
             },
-            "reasonId": "Fail_invalid_implicit_role_attr",
-            "message": "The ARIA attributes \"aria-labelledby\" are not valid for the element <img> with implicit ARIA role \"presentation\"",
+            "reasonId": "Pass",
+            "message": "ARIA attributes are valid for the element and ARIA role",
             "messageArgs": [
               "aria-labelledby",
               "img",
-              "presentation"
+              "img"
             ],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_role_valid_ruleunit/act_decorative_pass2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_role_valid_ruleunit/act_decorative_pass2.html
@@ -25,7 +25,7 @@
             "messageArgs": [
               "aria-hidden",
               "img",
-              "presentation"
+              "presentation, none"
             ],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_role_valid_ruleunit/aria_img.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_role_valid_ruleunit/aria_img.html
@@ -20,14 +20,14 @@
             "ruleId": "aria_role_valid",
             "value": [
               "INFORMATION",
-              "FAIL"
+              "PASS"
             ],
             "path": {
               "dom": "/html[1]/body[1]/main[1]/img[1]",
               "aria": "/document[1]/main[1]"
             },
-            "reasonId": "Fail_1",
-            "message": "The ARIA role 'none' is not valid for the element <img>",
+            "reasonId": "Pass_0",
+            "message": "Rule Passed",
             "messageArgs": [
               "none",
               "img"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/Img-hasLabel.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/Img-hasLabel.html
@@ -56,7 +56,7 @@
               "aria": "/document[1]/img[1]"
             },
             "reasonId": "pass",
-            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "message": "The image has an accessible name or is correctly marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-1.html
@@ -26,7 +26,7 @@
               "aria": "/document[1]/img[1]"
             },
             "reasonId": "fail_no_alt",
-            "message": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "message": "The image has neither an accessible name nor is marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-1.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img src="/test-assets/shared/w3c-logo.png" />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[1]",
+              "aria": "/document[1]/img[1]"
+            },
+            "reasonId": "fail_no_alt",
+            "message": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-2.html
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <div role="img" style="width:72px; height:48px; background-image: url(/test-assets/shared/w3c-logo.png)"></div>
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-3.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <div style="margin-left:-9999px;"><img src="/test-assets/shared/w3c-logo.png" /></div>
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/img[1]",
+              "aria": "/document[1]/img[1]"
+            },
+            "reasonId": "fail_no_alt",
+            "message": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-3.html
@@ -26,7 +26,7 @@
               "aria": "/document[1]/img[1]"
             },
             "reasonId": "fail_no_alt",
-            "message": "The image has neither an 'alt' attribute, an ARIA label, nor a title",
+            "message": "The image has neither an accessible name nor is marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-4.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img src="/test-assets/shared/w3c-logo.png" alt=" " />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[1]",
+              "aria": "/document[1]/img[1]"
+            },
+            "reasonId": "fail_blank_alt",
+            "message": "Image 'alt' attribute value consists only of blank space(s)",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-5.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img role="none" tabindex="0" src="/test-assets/shared/w3c-logo.png" />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+         {
+              "ruleId": "img_alt_valid",
+              "value": [
+                "INFORMATION",
+                "PASS"
+              ],
+              "path": {
+                "dom": "/html[1]/body[1]/img[1]",
+                "aria": "/document[1]/img[1]"
+              },
+              "reasonId": "pass",
+              "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+              "messageArgs": [],
+              "apiArgs": [],
+              "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-fail-5.html
@@ -26,7 +26,7 @@
                 "aria": "/document[1]/img[1]"
               },
               "reasonId": "pass",
-              "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+              "message": "The image has an accessible name or is correctly marked as decorative or redundant",
               "messageArgs": [],
               "apiArgs": [],
               "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-1.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <circle cx="50" cy="50" r="40" stroke="green" stroke-width="4" fill="yellow" />
+  </svg>
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-2.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <div
+	role="img"
+	aria-hidden="true"
+	style="width:72px; height:48px; background-image: url(/test-assets/shared/w3c-logo.png)"
+></div>
+
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-3.html
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img src="/test-assets/shared/w3c-logo.png" aria-hidden="true" />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-4.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <div style="display: none">
+    <img src="/test-assets/shared/w3c-logo.png" />
+  </div>
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-inapplicable-5.html
@@ -1,0 +1,26 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <div style="visibility: hidden">
+    <img src="/test-assets/shared/w3c-logo.png" />
+  </div>
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-1.html
@@ -26,7 +26,7 @@
               "aria": "/document[1]/img[1]"
             },
             "reasonId": "pass",
-            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "message": "The image has an accessible name or is correctly marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-1.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img alt="W3C logo" src="/test-assets/shared/w3c-logo.png" />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[1]",
+              "aria": "/document[1]/img[1]"
+            },
+            "reasonId": "pass",
+            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-2.html
@@ -1,0 +1,28 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <div
+	role="img"
+	aria-label="W3C logo"
+	style="width:72px; height:48px; background-image: url(/test-assets/shared/w3c-logo.png)"
+></div>
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-3.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-3.html
@@ -1,0 +1,29 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <div style="display: none" id="img-label">W3C logo</div>
+<div
+	role="img"
+	aria-labelledby="img-label"
+	style="width:72px; height:48px; background-image: url(/test-assets/shared/w3c-logo.png)"
+></div>
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-4.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img title="W3C logo" src="/test-assets/shared/w3c-logo.png" />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[1]",
+              "aria": "/document[1]/img[1]"
+            },
+            "reasonId": "pass",
+            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-4.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-4.html
@@ -26,7 +26,7 @@
               "aria": "/document[1]/img[1]"
             },
             "reasonId": "pass",
-            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "message": "The image has an accessible name or is correctly marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-5.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img alt="" src="/test-assets/shared/background.png" />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[1]",
+              "aria": "/document[1]/presentation[1]"
+            },
+            "reasonId": "pass",
+            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-5.html
@@ -26,7 +26,7 @@
               "aria": "/document[1]/presentation[1]"
             },
             "reasonId": "pass",
-            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "message": "The image has an accessible name or is correctly marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-6.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-6.html
@@ -26,7 +26,7 @@
               "aria": "/document[1]"
             },
             "reasonId": "pass",
-            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "message": "The image has an accessible name or is correctly marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-6.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-6.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img role="presentation" style="width:72px; height:48px; background-image: url(/test-assets/shared/background.png)" />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[1]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "pass",
+            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-7.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-7.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img role="none" src="/test-assets/shared/background.png" />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[1]",
+              "aria": "/document[1]"
+            },
+            "reasonId": "pass",
+            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-7.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-7.html
@@ -26,7 +26,7 @@
               "aria": "/document[1]"
             },
             "reasonId": "pass",
-            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "message": "The image has an accessible name or is correctly marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-8.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-8.html
@@ -28,7 +28,7 @@
               "aria": "/document[1]/presentation[1]"
             },
             "reasonId": "pass",
-            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "message": "The image has an accessible name or is correctly marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-8.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/act-pass-8.html
@@ -1,0 +1,41 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <div style="margin-left:-9999px;">
+    <img alt="" src="/test-assets/shared/background.png" />
+  </div>
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/img[1]",
+              "aria": "/document[1]/presentation[1]"
+            },
+            "reasonId": "pass",
+            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/title-cases.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/title-cases.html
@@ -1,0 +1,73 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+
+<html lang="en">
+
+<head>
+	<title>ACT Test case</title>
+</head>
+
+<body>
+
+  <img src="/test-assets/shared/w3c-logo.png" title="  " />
+  <img src="/test-assets/shared/w3c-logo.png" alt="" title="  " />
+  <img src="/test-assets/shared/w3c-logo.png" alt="logo" title="  " />
+
+<script>
+  UnitTest = {
+    ruleIds: ["img_alt_valid"],
+    results: [
+    {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[1]",
+              "aria": "/document[1]/img[1]"
+            },
+            "reasonId": "fail_blank_title",
+            "message": "The image does not have an 'alt' attribute or ARIA label, and the 'title' attribute value consists only of blank space(s)",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[2]",
+              "aria": "/document[1]/img[2]"
+            },
+            "reasonId": "pass",
+            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "img_alt_valid",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/img[3]",
+              "aria": "/document[1]/img[3]"
+            },
+            "reasonId": "pass",
+            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+</body>
+
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/title-cases.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/img_alt_valid_ruleunit/title-cases.html
@@ -44,7 +44,7 @@
               "aria": "/document[1]/img[2]"
             },
             "reasonId": "pass",
-            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "message": "The image has an accessible name or is correctly marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"
@@ -60,7 +60,7 @@
               "aria": "/document[1]/img[3]"
             },
             "reasonId": "pass",
-            "message": "Image has required 'alt' attribute, ARIA label, or title if it conveys meaning, or 'alt=\"\" if decorative",
+            "message": "The image has an accessible name or is correctly marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "category": "Accessibility"


### PR DESCRIPTION
**Rule/Engine updates:**
fixrule(`img_alt_valid`) Update roles for img elements

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: **img_alt_valid**

### This PR is related to the following issue(s): 
- fixes #1758 


### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->


### Testing reference: 
test cases: Passed Example 6 and 7 in  https://www.w3.org/WAI/standards-guidelines/act/rules/23a2a8/
  Before the fix, a Violation message appears: The image has neither an 'alt' attribute, an ARIA label, nor a title
 After the fix, the violation should be gone.

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
