### PR TITLE
fixrule(`a_text_purpose, meta_viewport_zoomable`, `widget_tabbable_exists`, `widget_tabbable_single`): Re-mapping WCAG SC and help references

### DIFF
--- a/accessibility-checker-engine/help-v4/en-US/meta_viewport_zoomable.html
+++ b/accessibility-checker-engine/help-v4/en-US/meta_viewport_zoomable.html
@@ -76,7 +76,6 @@ this rule maps to [1.4.10 Reflow](https://www.ibm.com/able/requirements/requirem
 ### About this requirement
 
 * [IBM 1.4.4 Resize text](https://www.ibm.com/able/requirements/requirements/#1_4_4)
-* [IBM 1.4.10 Reflow](https://www.ibm.com/able/requirements/requirements/#1_4_10)
 * [ACT rule: meta viewport allows for zoom](https://act-rules.github.io/rules/b4f0c3)
 
 ### Who does this affect?

--- a/accessibility-checker-engine/help-v4/en-US/meta_viewport_zoomable.html
+++ b/accessibility-checker-engine/help-v4/en-US/meta_viewport_zoomable.html
@@ -51,9 +51,7 @@ and most modern mobile browsers either ignore it by default or have an accessibi
 Only users with older mobile browsers can experience issues tested by this rule.
 
 This rule is designed specifically for testing [1.4.4 Resize text](https://www.ibm.com/able/requirements/requirements/#1_4_4), 
-which requires that text can be resized up to 200%. 
-Because text that cannot be resized up to 200% cannot fit in an area of 320 by 256 CSS pixels, 
-this rule maps to [1.4.10 Reflow](https://www.ibm.com/able/requirements/requirements/#1_4_10) as well. 
+which requires that text can be resized up to 200%.
 
 <!-- This is where the code snippet is injected -->
 <div id="locSnippet"></div>

--- a/accessibility-checker-engine/help-v4/en-US/widget_tabbable_single.html
+++ b/accessibility-checker-engine/help-v4/en-US/widget_tabbable_single.html
@@ -72,6 +72,8 @@ In addition, the keyboard operations should be consistent with common keyboard i
 * [IBM 2.4.3 Focus Order](https://www.ibm.com/able/requirements/requirements/#2_4_3)
 * [ARIA practices - Patterns](https://www.w3.org/WAI/ARIA/apg/patterns/)    
 * [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
+* [Verify - Check tab or navigation order](https://www.ibm.com/able/toolkit/verify/manual/#tabnavorder)
+* [Verify - Maintaining user's point of regard](https://www.ibm.com/able/toolkit/verify/manual/#pointofregard)    
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/widget_tabbable_single.html
+++ b/accessibility-checker-engine/help-v4/en-US/widget_tabbable_single.html
@@ -47,7 +47,8 @@
 
 The primary keyboard navigation convention uses `Tab` and `Shift+Tab` keys to move focus from one UI component to another.
 Other keys (primarily the arrow keys) move focus within components comprised of multiple focusable elements.
-Authors must follow this convention and provide no more than one tab stop per component (providing keyboard focus).
+Authors must follow this convention and provide no more than one tab stop per component (providing keyboard focus) and insure the keyboard tab sequence is logical.
+In addition, the keyboard operations should be consistent with common keyboard interface conventions described in the [ARIA Patterns](https://www.w3.org/WAI/ARIA/apg/patterns/), especially for assistive technology users.
 
 <!-- This is where the code snippet is injected -->
 <div id="locSnippet"></div>
@@ -68,6 +69,8 @@ Authors must follow this convention and provide no more than one tab stop per co
 ### About this requirement
 
 * [IBM 2.1.1 Keyboard](https://www.ibm.com/able/requirements/requirements/#2_1_1)
+* [IBM 2.4.3 Focus Order](https://www.ibm.com/able/requirements/requirements/#2_4_3)
+* [ARIA practices - Patterns](https://www.w3.org/WAI/ARIA/apg/patterns/)    
 * [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
 
 ### Who does this affect?

--- a/accessibility-checker-engine/src/v4/rules/a_text_purpose.ts
+++ b/accessibility-checker-engine/src/v4/rules/a_text_purpose.ts
@@ -12,7 +12,7 @@
  *****************************************************************************/
 
 import { ARIAMapper } from "../../v2/aria/ARIAMapper";
-import { Rule, RuleResult, RuleFail, RuleContext, RulePotential, RuleManual, RulePass, RuleContextHierarchy } from "../api/IRule";
+import { Rule, RuleResult, RuleFail, RuleContext, RulePass } from "../api/IRule";
 import { RPTUtil } from "../../v2/checker/accessibility/util/legacy";
 import { VisUtil } from "../../v2/dom/VisUtil";
 import { eRulePolicy, eToolkitLevel } from "../api/IRule";
@@ -23,22 +23,22 @@ export let a_text_purpose: Rule = {
     context: "aria:link,aria:doc-biblioref",
     refactor: {
         "WCAG20_A_HasText": {
-            "Pass_0": "Pass_0",
-            "Fail_1": "Fail_1"
+            "Pass_0": "pass",
+            "Fail_1": "fail_acc_name"
         }
     },
     help: {
         "en-US": {
             "group": `a_text_purpose.html`,
-            "Pass_0": `a_text_purpose.html`,
-            "Fail_1": `a_text_purpose.html`
+            "pass": `a_text_purpose.html`,
+            "fail_acc_name": `a_text_purpose.html`
         }
     },
     messages: {
         "en-US": {
             "group": "Hyperlinks must have an accessible name for their purpose",
-            "Pass_0": "Hyperlink has a description of its purpose",
-            "Fail_1": "Hyperlink has no link text, label or image with a text alternative"
+            "pass": "Hyperlink has a description of its purpose",
+            "fail_acc_name": "Hyperlink has no link text, label or image with a text alternative"
         }
     },
     rulesets: [{
@@ -62,9 +62,9 @@ export let a_text_purpose: Rule = {
             ARIAMapper.computeName(ruleContext).trim().length > 0
             || RPTUtil.nonTabableChildCheck(ruleContext);
         if (!passed) {
-            return RuleFail("Fail_1");
+            return RuleFail("fail_acc_name");
         } else {
-            return RulePass("Pass_0");
+            return RulePass("pass");
         }
     }
 }

--- a/accessibility-checker-engine/src/v4/rules/meta_viewport_zoomable.ts
+++ b/accessibility-checker-engine/src/v4/rules/meta_viewport_zoomable.ts
@@ -11,42 +11,35 @@
   limitations under the License.
 *****************************************************************************/
 
-import { Rule, RuleResult, RuleFail, RuleContext, RulePotential, RuleManual, RulePass, RuleContextHierarchy } from "../api/IRule";
+import { Rule, RuleResult, RuleContext, RulePotential, RulePass, RuleContextHierarchy } from "../api/IRule";
 import { eRulePolicy, eToolkitLevel } from "../api/IRule";
-import { RPTUtil } from "../../v2/checker/accessibility/util/legacy";
 
 export let meta_viewport_zoomable: Rule = {
     id: "meta_viewport_zoomable",
     context: "dom:meta[name][content]",
     refactor: {
         "meta_viewport_zoom": {
-            "Pass_0": "Pass_0",
-            "Potential_1": "Potential_1"
+            "Pass_0": "pass",
+            "Potential_1": "potential_zoomable"
         }
     },
     help: {
         "en-US": {
             "group": "meta_viewport_zoomable.html",
-            "Pass_0": "meta_viewport_zoomable.html",
-            "Potential_1": "meta_viewport_zoomable.html"
+            "pass": "meta_viewport_zoomable.html",
+            "potential_zoomable": "meta_viewport_zoomable.html"
         }
     },
     messages: {
         "en-US": {
             "group": "The 'meta[name=viewport]' should not prevent the browser zooming the content",
-            "Pass_0": "The 'meta[name=viewport]' does not prevent the browser zooming the content",
-            "Potential_1": "Confirm the 'meta[name=viewport]' with \"{0}\" can be zoomed by user"
+            "pass": "The 'meta[name=viewport]' does not prevent the browser zooming the content",
+            "potential_zoomable": "Confirm the 'meta[name=viewport]' with \"{0}\" can be zoomed by user"
         }
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.4.4"],
-        "level": eRulePolicy.RECOMMENDATION,
-        "toolkitLevel": eToolkitLevel.LEVEL_THREE
-    },
-    {
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_2"],
-        "num": ["1.4.10"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE
     }],
@@ -107,12 +100,12 @@ export let meta_viewport_zoomable: Rule = {
 
         // user-scalable is not set to 'yes', ignore maximum_scale
         if (user_scale_value !== 'yes') {
-            return RulePotential("Potential_1", [user_msg]);
+            return RulePotential("potential_zoomable", [user_msg]);
         }
         // user-scalable is 'yes', but maximum_scale is too small
         if (maximum_scale < 2.0) {
-            return RulePotential("Potential_1", [max_msg]);
+            return RulePotential("potential_zoomable", [max_msg]);
         }
-        return RulePass("Pass_0");
+        return RulePass("pass");
     }
 }

--- a/accessibility-checker-engine/src/v4/rules/widget_tabbable_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/widget_tabbable_exists.ts
@@ -41,7 +41,7 @@ export let widget_tabbable_exists: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["2.4.3"],
+        "num": ["2.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/src/v4/rules/widget_tabbable_single.ts
+++ b/accessibility-checker-engine/src/v4/rules/widget_tabbable_single.ts
@@ -43,7 +43,7 @@ export let widget_tabbable_single: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["2.4.3"],
+        "num": ["2.1.1", "2.4.3"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-nonTabable.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-nonTabable.html
@@ -83,7 +83,7 @@
                     "dom": "/html[1]/body[1]/a[1]",
                     "aria": "/document[1]/link[1]"
                 },
-                "reasonId": "Fail_1",
+                "reasonId": "fail_acc_name",
                 //"message": "Hyperlink is missing link text or an image with alt text.",
                 "message": "Hyperlink has no link text, label or image with a text alternative",
                 "messageArgs": [],
@@ -98,7 +98,7 @@
                     "dom": "/html[1]/body[1]/a[2]",
                     "aria": "/document[1]/link[2]"
                 },
-                "reasonId": "Pass_0",
+                "reasonId": "pass",
                 //"message": "Hyperlink contains content that is readable by assistive technologies.",
                 "message": "Hyperlink has a description of its purpose",
                 "messageArgs": [],
@@ -113,7 +113,7 @@
                     "dom": "/html[1]/body[1]/a[3]",
                     "aria": "/document[1]/link[3]"
                 },
-                "reasonId": "Fail_1",
+                "reasonId": "fail_acc_name",
                 //"message": "Hyperlink is missing link text or an image with alt text.",
                 "message": "Hyperlink has no link text, label or image with a text alternative",
                 "messageArgs": [],
@@ -128,7 +128,7 @@
                     "dom": "/html[1]/body[1]/a[4]",
                     "aria": "/document[1]/link[4]"
                 },
-                "reasonId": "Fail_1",
+                "reasonId": "fail_acc_name",
                 //"message": "Hyperlink is missing link text or an image with alt text.",
                 "message": "Hyperlink has no link text, label or image with a text alternative",
                 "messageArgs": [],
@@ -143,7 +143,7 @@
                     "dom": "/html[1]/body[1]/a[5]",
                     "aria": "/document[1]/link[5]"
                 },
-                "reasonId": "Pass_0",
+                "reasonId": "pass",
                 //"message": "Hyperlink contains content that is readable by assistive technologies.",
                 "message": "Hyperlink has a description of its purpose",
                 "messageArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-slot-text-error1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-slot-text-error1.html
@@ -42,7 +42,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/a[1]",
               "aria": "/document[1]/main[1]/link[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],
@@ -58,7 +58,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[2]/#document-fragment[1]/div[1]/a[1]",
               "aria": "/document[1]/main[1]/link[2]"
             },
-            "reasonId": "Fail_1",
+            "reasonId": "fail_acc_name",
             "message": "Hyperlink has no link text, label or image with a text alternative",
             "messageArgs": [],
             "apiArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-slot-text-error2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-slot-text-error2.html
@@ -43,7 +43,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/a[1]",
               "aria": "/document[1]/main[1]/link[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],
@@ -59,7 +59,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[2]/#document-fragment[1]/div[1]/a[1]",
               "aria": "/document[1]/main[1]/link[2]"
             },
-            "reasonId": "Fail_1",
+            "reasonId": "fail_acc_name",
             "message": "Hyperlink has no link text, label or image with a text alternative",
             "messageArgs": [],
             "apiArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-slot-text-pass.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-slot-text-pass.html
@@ -44,7 +44,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/a[1]",
               "aria": "/document[1]/main[1]/link[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],
@@ -60,7 +60,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[2]/#document-fragment[1]/div[1]/a[1]",
               "aria": "/document[1]/main[1]/link[2]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-slot-text-pass1.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/A-slot-text-pass1.html
@@ -44,7 +44,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/a[1]",
               "aria": "/document[1]/main[1]/link[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],
@@ -60,7 +60,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[2]/#document-fragment[1]/div[1]/a[1]",
               "aria": "/document[1]/main[1]/link[2]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/Hyperlinks_img.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/Hyperlinks_img.html
@@ -57,7 +57,7 @@
                     "dom": "/html[1]/body[1]/a[1]",
                     "aria": "/document[1]/link[1]"
                 },
-                "reasonId": "Pass_0",
+                "reasonId": "pass",
                 //"message": "Hyperlink contains content that is readable by assistive technologies.",
                 "message": "Hyperlink has a description of its purpose",
                 "messageArgs": [],
@@ -70,7 +70,7 @@
                     "dom": "/html[1]/body[1]/a[2]",
                     "aria": "/document[1]/link[2]"
                 },
-                "reasonId": "Pass_0",
+                "reasonId": "pass",
                 //"message": "Hyperlink contains content that is readable by assistive technologies.",
                 "message": "Hyperlink has a description of its purpose",
                 "messageArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/a-with-slot.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/a-with-slot.html
@@ -46,7 +46,7 @@
               "dom": "/html[1]/body[1]/main[1]/my-link[1]/#document-fragment[1]/a[1]",
               "aria": "/document[1]/main[1]/link[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/svg-title.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/svg-title.html
@@ -57,7 +57,7 @@
               "dom": "/html[1]/body[1]/header[1]/a[1]",
               "aria": "/document[1]/banner[1]/link[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],
@@ -73,7 +73,7 @@
               "dom": "/html[1]/body[1]/header[2]/a[1]",
               "aria": "/document[1]/banner[2]/link[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/webComponent.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/a_text_purpose_ruleunit/webComponent.html
@@ -46,7 +46,7 @@
               "dom": "/html[1]/body[1]/main[1]/my-link[1]/#document-fragment[1]/a[1]",
               "aria": "/document[1]/main[1]/link[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_maximum_user_scale_1.0.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_maximum_user_scale_1.0.html
@@ -42,7 +42,7 @@
                 "dom": "/html[1]/head[1]/meta[2]",
                 "aria": "/document[1]"
               },
-              "reasonId": "Potential_1",
+              "reasonId": "potential_zoomable",
               "message": "Confirm the 'meta[name=viewport]' with \"maximum-scale=1.0\" can be zoomed by user",
               "messageArgs": [
                 "maximum-scale=1.0"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_maximum_user_scale_1.5.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_maximum_user_scale_1.5.html
@@ -41,7 +41,7 @@
                 "dom": "/html[1]/head[1]/meta[2]",
                 "aria": "/document[1]"
               },
-              "reasonId": "Potential_1",
+              "reasonId": "potential_zoomable",
               "message": "Confirm the 'meta[name=viewport]' with \" maximum-scale=1.5\" can be zoomed by user",
               "messageArgs": [
                 " maximum-scale=1.5"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_unknown_maximum_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_unknown_maximum_user_scale.html
@@ -41,7 +41,7 @@
                 "dom": "/html[1]/head[1]/meta[2]",
                 "aria": "/document[1]"
               },
-              "reasonId": "Potential_1",
+              "reasonId": "potential_zoomable",
               "message": "Confirm the 'meta[name=viewport]' with \"maximum-scale=ok\" can be zoomed by user",
               "messageArgs": [
                 "maximum-scale=ok"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_user_scale_no.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_user_scale_no.html
@@ -41,7 +41,7 @@
                 "dom": "/html[1]/head[1]/meta[2]",
                 "aria": "/document[1]"
               },
-              "reasonId": "Potential_1",
+              "reasonId": "potential_zoomable",
               "message": "Confirm the 'meta[name=viewport]' with \"user-scalable=no\" can be zoomed by user",
               "messageArgs": [
                 "user-scalable=no"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_yes_maximum_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_yes_maximum_user_scale.html
@@ -42,7 +42,7 @@
                         "dom": "/html[1]/head[1]/meta[2]",
                         "aria": "/document[1]"
                     },
-                    "reasonId": "Potential_1",
+                    "reasonId": "potential_zoomable",
                     "message": "Confirm the 'meta[name=viewport]' with \"maximum-scale=yes\" can be zoomed by user",
                     "messageArgs": [
                         "maximum-scale=yes"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_pass_allow_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_pass_allow_user_scale.html
@@ -41,7 +41,7 @@
                   "dom": "/html[1]/head[1]/meta[2]",
                   "aria": "/document[1]"
                 },
-                "reasonId": "Pass_0",
+                "reasonId": "pass",
                 "message": "The 'meta[name=viewport]' does not prevent the browser zooming the content",
                 "messageArgs": [],
                 "apiArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_pass_enough_maxium_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_pass_enough_maxium_user_scale.html
@@ -41,7 +41,7 @@
                   "dom": "/html[1]/head[1]/meta[2]",
                   "aria": "/document[1]"
                 },
-                "reasonId": "Pass_0",
+                "reasonId": "pass",
                 "message": "The 'meta[name=viewport]' does not prevent the browser zooming the content",
                 "messageArgs": [],
                 "apiArgs": [],

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_pass_ignored_maximum_user_scale.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_pass_ignored_maximum_user_scale.html
@@ -41,7 +41,7 @@
                 "dom": "/html[1]/head[1]/meta[2]",
                 "aria": "/document[1]"
               },
-              "reasonId": "Pass_0",
+              "reasonId": "pass",
               "message": "The 'meta[name=viewport]' does not prevent the browser zooming the content",
               "messageArgs": [],
               "apiArgs": [],

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
@@ -320,7 +320,7 @@
             "category": "Accessibility",
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doctext_contrast_sufficient_pass#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
         },
         {
             "ruleId": "img_alt_background",
@@ -468,7 +468,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -494,7 +494,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -520,7 +520,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -549,7 +549,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -575,7 +575,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -601,7 +601,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -627,7 +627,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -653,7 +653,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -679,7 +679,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -705,7 +705,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 144,
+                "top": 143,
                 "height": 0,
                 "width": 784
             },
@@ -1021,7 +1021,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1047,7 +1047,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1073,7 +1073,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1099,7 +1099,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1133,14 +1133,14 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
             "category": "Accessibility",
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doctext_contrast_sufficient_pass#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%229.40%22%2C16%2C400%2C%22%230000ee%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%229.40%22%2C16%2C400%2C%22%230000ee%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
         },
         {
             "ruleId": "style_focus_visible",
@@ -1159,7 +1159,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1185,7 +1185,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1211,7 +1211,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1237,7 +1237,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1263,14 +1263,14 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 17,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
             "category": "Accessibility",
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doca_text_purpose_pass#%7B%22message%22%3A%22Hyperlink%20has%20a%20description%20of%20its%20purpose%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22a_text_purpose%22%2C%22msgArgs%22%3A%5B%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/a_text_purpose.html#%7B%22message%22%3A%22Hyperlink%20has%20a%20description%20of%20its%20purpose%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22a_text_purpose%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "text_whitespace_valid",
@@ -1289,7 +1289,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 19,
+                "height": 18,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1315,7 +1315,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 19,
+                "height": 18,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1341,7 +1341,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 19,
+                "height": 18,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1370,7 +1370,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 19,
+                "height": 18,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1396,7 +1396,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 19,
+                "height": 18,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1422,7 +1422,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 19,
+                "height": 18,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1448,7 +1448,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 19,
+                "height": 18,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1604,7 +1604,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 144,
+                "height": 143,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1630,7 +1630,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 144,
+                "height": 143,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1656,7 +1656,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 144,
+                "height": 143,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1682,7 +1682,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 144,
+                "height": 143,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1710,7 +1710,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 144,
+                "height": 143,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
@@ -320,7 +320,7 @@
             "category": "Accessibility",
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doctext_contrast_sufficient_pass#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
         },
         {
             "ruleId": "img_alt_background",
@@ -468,7 +468,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -494,7 +494,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -520,7 +520,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -549,7 +549,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -575,7 +575,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -601,7 +601,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -627,7 +627,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -653,7 +653,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -679,7 +679,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -705,7 +705,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -1021,7 +1021,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1047,7 +1047,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1073,7 +1073,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1099,7 +1099,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1133,14 +1133,14 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
             "category": "Accessibility",
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%229.40%22%2C16%2C400%2C%22%230000ee%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doctext_contrast_sufficient_pass#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%229.40%22%2C16%2C400%2C%22%230000ee%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
         },
         {
             "ruleId": "style_focus_visible",
@@ -1159,7 +1159,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1185,7 +1185,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1211,7 +1211,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1237,7 +1237,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1256,21 +1256,21 @@
                 "dom": "/html[1]/body[1]/div[1]/a[1]",
                 "aria": "/document[1]/navigation[1]/link[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "message": "Hyperlink has a description of its purpose",
             "messageArgs": [],
             "apiArgs": [],
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
             "category": "Accessibility",
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/a_text_purpose.html#%7B%22message%22%3A%22Hyperlink%20has%20a%20description%20of%20its%20purpose%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22a_text_purpose%22%2C%22msgArgs%22%3A%5B%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doca_text_purpose_pass#%7B%22message%22%3A%22Hyperlink%20has%20a%20description%20of%20its%20purpose%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22a_text_purpose%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "text_whitespace_valid",
@@ -1289,7 +1289,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1315,7 +1315,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1341,7 +1341,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1370,7 +1370,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1396,7 +1396,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1422,7 +1422,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1448,7 +1448,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1604,7 +1604,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1630,7 +1630,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1656,7 +1656,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1682,7 +1682,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1710,7 +1710,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1797,7 +1797,7 @@
         },
         "a_text_purpose": {
             "0": "Hyperlinks must have an accessible name for their purpose",
-            "Pass_0": "Hyperlink has a description of its purpose"
+            "pass": "Hyperlink has a description of its purpose"
         },
         "widget_tabbable_exists": {
             "0": "Component must have at least one tabbable element",

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
@@ -424,7 +424,7 @@
             ],
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doctext_contrast_sufficient_pass#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
         },
         {
             "apiArgs": [],
@@ -1244,7 +1244,7 @@
             ],
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doctext_contrast_sufficient_pass#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%229.40%22%2C16%2C400%2C%22%230000ee%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%229.40%22%2C16%2C400%2C%22%230000ee%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
         },
         {
             "apiArgs": [],
@@ -1374,7 +1374,7 @@
             ],
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doca_text_purpose_pass#%7B%22message%22%3A%22Hyperlink%20has%20a%20description%20of%20its%20purpose%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22a_text_purpose%22%2C%22msgArgs%22%3A%5B%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/a_text_purpose.html#%7B%22message%22%3A%22Hyperlink%20has%20a%20description%20of%20its%20purpose%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22a_text_purpose%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
@@ -2,7 +2,7 @@
     "nls": {
         "a_text_purpose": {
             "0": "Hyperlinks must have an accessible name for their purpose",
-            "Pass_0": "Hyperlink has a description of its purpose"
+            "pass": "Hyperlink has a description of its purpose"
         },
         "aria_accessiblename_exists": {
             "0": "Elements with certain roles should have accessible names",
@@ -424,7 +424,7 @@
             ],
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doctext_contrast_sufficient_pass#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%2221.00%22%2C32%2C700%2C%22%23000000%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
         },
         {
             "apiArgs": [],
@@ -1244,7 +1244,7 @@
             ],
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/text_contrast_sufficient.html#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%229.40%22%2C16%2C400%2C%22%230000ee%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doctext_contrast_sufficient_pass#%7B%22message%22%3A%22The%20contrast%20ratio%20of%20text%20with%20its%20background%20meets%20WCAG%20AA%20requirements%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22text_contrast_sufficient%22%2C%22msgArgs%22%3A%5B%229.40%22%2C16%2C400%2C%22%230000ee%22%2C%22%23ffffff%22%2Cfalse%2Cfalse%5D%7D"
         },
         {
             "apiArgs": [],
@@ -1365,7 +1365,7 @@
                 "aria": "/document[1]/navigation[1]/link[1]",
                 "dom": "/html[1]/body[1]/div[1]/a[1]"
             },
-            "reasonId": "Pass_0",
+            "reasonId": "pass",
             "ruleId": "a_text_purpose",
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
             "value": [
@@ -1374,7 +1374,7 @@
             ],
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/a_text_purpose.html#%7B%22message%22%3A%22Hyperlink%20has%20a%20description%20of%20its%20purpose%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22Pass_0%22%2C%22ruleId%22%3A%22a_text_purpose%22%2C%22msgArgs%22%3A%5B%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doca_text_purpose_pass#%7B%22message%22%3A%22Hyperlink%20has%20a%20description%20of%20its%20purpose%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22a_text_purpose%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],

--- a/accessibility-checker/test/mocha/aChecker.Fast/aChecker.ObjectStructure/aChecker.getCompliance.JSONObjectVerification.test.js
+++ b/accessibility-checker/test/mocha/aChecker.Fast/aChecker.ObjectStructure/aChecker.getCompliance.JSONObjectVerification.test.js
@@ -127,7 +127,7 @@ describe("JSON Structure Verification Zombie", function () {
                             return b.ruleId.localeCompare(a.ruleId);
                         })
                         // Run the diff algo to get the list of differences
-                        differences = aChecker.diffResultsWithExpected(report, expected, false);console.log("report=" + JSON.stringify(report));
+                        differences = aChecker.diffResultsWithExpected(report, expected, false);
                     }
                     expect(typeof differences).to.equal("undefined", "\nDoes not follow the correct JSON structure or can't load baselines" + JSON.stringify(differences, null, '  '));
                     // Mark the testcase as done.

--- a/accessibility-checker/test/mocha/aChecker.Slow1/aChecker.ObjectStructure/aChecker.getCompliance.JSONObjectVerificationSelenium.test.js
+++ b/accessibility-checker/test/mocha/aChecker.Slow1/aChecker.ObjectStructure/aChecker.getCompliance.JSONObjectVerificationSelenium.test.js
@@ -181,7 +181,7 @@ describe("JSON Structure Verification Selenium", function () {
                                         return b.ruleId.localeCompare(a.ruleId);
                                     })
                                     // Run the diff algo to get the list of differences
-                                    differences = aChecker.diffResultsWithExpected(report, expected, false);
+                                    differences = aChecker.diffResultsWithExpected(report, expected, false);console.log("report=" + JSON.stringify(report));
                                 }
 
                                 expect(typeof differences).to.equal("undefined", "\nDoes not follow the correct JSON structure or can't load baselines" + JSON.stringify(differences, null, '  '));

--- a/accessibility-checker/test/mocha/aChecker.Slow1/aChecker.ObjectStructure/aChecker.getCompliance.JSONObjectVerificationSelenium.test.js
+++ b/accessibility-checker/test/mocha/aChecker.Slow1/aChecker.ObjectStructure/aChecker.getCompliance.JSONObjectVerificationSelenium.test.js
@@ -181,7 +181,7 @@ describe("JSON Structure Verification Selenium", function () {
                                         return b.ruleId.localeCompare(a.ruleId);
                                     })
                                     // Run the diff algo to get the list of differences
-                                    differences = aChecker.diffResultsWithExpected(report, expected, false);console.log("report=" + JSON.stringify(report));
+                                    differences = aChecker.diffResultsWithExpected(report, expected, false);
                                 }
 
                                 expect(typeof differences).to.equal("undefined", "\nDoes not follow the correct JSON structure or can't load baselines" + JSON.stringify(differences, null, '  '));


### PR DESCRIPTION
**Rule/Engine updates:**
fixrule(`a_text_purpose, meta_viewport_zoomable`): Re-mapping WCAG SC

<!-- Specify what this PR is doing. Remove all that do not apply -->
* New Rule(s): **List rule IDs**
* New or modified help files: meta_viewport_zoomable.html
* Rule bug: a_text_purpose, meta_viewport_zoomable

### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with # -->
- fixes: #1468  
- fixes: #1469 
- fixes #1834 

### Additional information can be found here: 
- <!-- Provide the name of the rule & reference link or doc(s) -->


### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
- test cases: test/v2/checker/accessibility/rules/meta_viewport_zoomable_ruleunit/viewport_fail_maximum_user_scale_1.0.html
Click "Learn More" for Recommendation Message: Confirm the 'meta[name=viewport]' with "maximum-scale=1.0" can be zoomed by user 
- Before fix: Two SC mappings (Requirements): IBM 1.4.4 Resize text and IBM 1.4.10 Reflow
- After fix:   only one SC mapping (Requirements): IBM 1.4.4 Resize text
- Review the mapping in the [Checker rule set](https://www.ibm.com/able/requirements/checker-rule-sets/) for the rules mapped to 1.4.4, 1.4.10, 2.1.1 and 2..4.3. The mapping is also available in the Actions -> Artifacts: Rule listing (generated are build time)
- Review the help text changes for the `widget_tabbable_single` rule 
 
### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.
