### PR TITLE
feature(engine): Add an IBM_Accessibility_next guideline to preview the IBM Accessibility 7.3 requirements

### DIFF
--- a/accessibility-checker-engine/src/v4/rules/a_target_warning.ts
+++ b/accessibility-checker-engine/src/v4/rules/a_target_warning.ts
@@ -40,7 +40,7 @@ export let a_target_warning: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "3.2.2", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.RECOMMENDATION,
         toolkitLevel: eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/a_text_purpose.ts
+++ b/accessibility-checker-engine/src/v4/rules/a_text_purpose.ts
@@ -42,7 +42,7 @@ export let a_text_purpose: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: ["2.4.4", "4.1.2"], // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/applet_alt_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/applet_alt_exists.ts
@@ -46,7 +46,7 @@ export let applet_alt_exists: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "1.1.1", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/application_content_accessible.ts
+++ b/accessibility-checker-engine/src/v4/rules/application_content_accessible.ts
@@ -41,7 +41,7 @@ export let application_content_accessible: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "2.1.1", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/area_alt_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/area_alt_exists.ts
@@ -40,7 +40,7 @@ export let area_alt_exists: Rule = {
             }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "1.1.1", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_accessiblename_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_accessiblename_exists.ts
@@ -36,7 +36,7 @@ export let aria_accessiblename_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_activedescendant_tabindex_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_activedescendant_tabindex_valid.ts
@@ -38,7 +38,7 @@ export let aria_activedescendant_tabindex_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_activedescendant_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_activedescendant_valid.ts
@@ -50,7 +50,7 @@ export let aria_activedescendant_valid: Rule = {
         }
     },
     rulesets: [{ 
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"], 
         "level": eRulePolicy.VIOLATION, 
         "toolkitLevel": eToolkitLevel.LEVEL_ONE 

--- a/accessibility-checker-engine/src/v4/rules/aria_application_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_application_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_application_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_application_labelled.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_application_labelled.ts
@@ -39,7 +39,7 @@ export let aria_application_labelled: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_article_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_article_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_article_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_attribute_allowed.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_attribute_allowed.ts
@@ -40,7 +40,7 @@ export let aria_attribute_allowed: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "4.1.2", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_attribute_conflict.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_attribute_conflict.ts
@@ -36,7 +36,7 @@ export let aria_attribute_conflict: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_attribute_deprecated.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_attribute_deprecated.ts
@@ -37,7 +37,7 @@ export let aria_attribute_deprecated: Rule = {
         }
     },
     rulesets: [{ 
-        "id": ["IBM_Accessibility"], 
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next"], 
         "num": ["ARIA"], 
         "level": eRulePolicy.RECOMMENDATION, 
         "toolkitLevel": eToolkitLevel.LEVEL_THREE 

--- a/accessibility-checker-engine/src/v4/rules/aria_attribute_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_attribute_exists.ts
@@ -42,7 +42,7 @@ export let aria_attribute_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_attribute_redundant.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_attribute_redundant.ts
@@ -37,7 +37,7 @@ export let aria_attribute_redundant: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_attribute_required.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_attribute_required.ts
@@ -42,7 +42,7 @@ export let aria_attribute_required: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "4.1.2", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_attribute_value_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_attribute_value_valid.ts
@@ -41,7 +41,7 @@ export let aria_attribute_value_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_banner_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_banner_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_banner_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_banner_single.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_banner_single.ts
@@ -38,7 +38,7 @@ export let aria_banner_single: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_child_tabbable.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_child_tabbable.ts
@@ -41,7 +41,7 @@ export let aria_child_tabbable: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_child_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_child_valid.ts
@@ -39,7 +39,7 @@ export let aria_child_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_complementary_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_complementary_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_complementary_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_complementary_label_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_complementary_label_visible.ts
@@ -39,7 +39,7 @@ export let aria_complementary_label_visible: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_complementary_labelled.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_complementary_labelled.ts
@@ -39,7 +39,7 @@ export let aria_complementary_labelled: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_content_in_landmark.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_content_in_landmark.ts
@@ -41,7 +41,7 @@ export let aria_content_in_landmark: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_contentinfo_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_contentinfo_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_contentinfo_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_contentinfo_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_contentinfo_misuse.ts
@@ -39,7 +39,7 @@ export let aria_contentinfo_misuse: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_contentinfo_single.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_contentinfo_single.ts
@@ -38,7 +38,7 @@ export let aria_contentinfo_single: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_descendant_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_descendant_valid.ts
@@ -37,7 +37,7 @@ export let aria_descendant_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_document_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_document_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_document_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_eventhandler_role_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_eventhandler_role_valid.ts
@@ -38,7 +38,7 @@ export let aria_eventhandler_role_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_form_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_form_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_form_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_graphic_labelled.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_graphic_labelled.ts
@@ -46,7 +46,7 @@ export let aria_graphic_labelled: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"], /*Change mapping to 1.1.1 from 4.1.2 */
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_hidden_nontabbable.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_hidden_nontabbable.ts
@@ -39,7 +39,7 @@ export let aria_hidden_nontabbable: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: ["1.3.1", "4.1.2"], // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/aria_id_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_id_unique.ts
@@ -41,7 +41,7 @@ export let aria_id_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_img_labelled.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_img_labelled.ts
@@ -46,7 +46,7 @@ export let aria_img_labelled: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"], /*Change mapping to 1.1.1 from 4.1.2 */
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_keyboard_handler_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_keyboard_handler_exists.ts
@@ -41,7 +41,7 @@ export let aria_keyboard_handler_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_landmark_name_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_landmark_name_unique.ts
@@ -41,7 +41,7 @@ export let aria_landmark_name_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_main_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_main_label_unique.ts
@@ -38,7 +38,7 @@ export let aria_main_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_main_label_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_main_label_visible.ts
@@ -38,7 +38,7 @@ export let aria_main_label_visible: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_navigation_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_navigation_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_navigation_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_parent_required.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_parent_required.ts
@@ -42,7 +42,7 @@ export let aria_parent_required: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_region_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_region_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_region_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_region_labelled.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_region_labelled.ts
@@ -42,7 +42,7 @@ export let aria_region_labelled: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_role_allowed.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_role_allowed.ts
@@ -43,7 +43,7 @@ export let aria_role_allowed: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "4.1.2", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_role_redundant.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_role_redundant.ts
@@ -35,7 +35,7 @@ export let aria_role_redundant: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next"],
         "num": ["ARIA"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_search_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_search_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_search_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/aria_semantics.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_semantics.ts
@@ -44,7 +44,7 @@ export let aria_role_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
@@ -130,7 +130,7 @@ export let aria_attribute_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["ARIA"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_toolbar_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_toolbar_label_unique.ts
@@ -39,7 +39,7 @@ export let aria_toolbar_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/aria_widget_labelled.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_widget_labelled.ts
@@ -43,7 +43,7 @@ export let aria_widget_labelled: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/asciiart_alt_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/asciiart_alt_exists.ts
@@ -40,7 +40,7 @@ export let asciiart_alt_exists: Rule = {
     /**
      * Decision in planning 9/7/23 that this rule causes more reviews that we see actual problems in content, so turn these rules off
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/blink_css_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/blink_css_review.ts
@@ -39,7 +39,7 @@ export let blink_css_review: Rule = {
         }
     },
     rulesets: [{
-        id: ["IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "2.2.2", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/blink_elem_deprecated.ts
+++ b/accessibility-checker-engine/src/v4/rules/blink_elem_deprecated.ts
@@ -38,7 +38,7 @@ export let blink_elem_deprecated: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "2.2.2", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/blockquote_cite_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/blockquote_cite_exists.ts
@@ -38,7 +38,7 @@ export let blockquote_cite_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/canvas_content_described.ts
+++ b/accessibility-checker-engine/src/v4/rules/canvas_content_described.ts
@@ -38,7 +38,7 @@ export let canvas_content_described: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1", "4.1.2"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/caption_track_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/caption_track_exists.ts
@@ -37,7 +37,7 @@ export let caption_track_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.2.1", "1.2.2", "1.2.4"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/combobox_active_descendant.ts
+++ b/accessibility-checker-engine/src/v4/rules/combobox_active_descendant.ts
@@ -43,7 +43,7 @@ export let combobox_active_descendant: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/combobox_autocomplete_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/combobox_autocomplete_valid.ts
@@ -44,7 +44,7 @@ export let combobox_autocomplete_valid: Rule = {
         }
     },
     rulesets: [{ 
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
         "num": ["4.1.2"], 
         "level": eRulePolicy.VIOLATION, 
         "toolkitLevel": eToolkitLevel.LEVEL_ONE 

--- a/accessibility-checker-engine/src/v4/rules/combobox_design_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/combobox_design_valid.ts
@@ -61,7 +61,7 @@ export let combobox_design_valid: Rule = {
         }
     },
     rulesets: [{ 
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
         "num": ["4.1.2"], 
         "level": eRulePolicy.VIOLATION, 
         "toolkitLevel": eToolkitLevel.LEVEL_ONE 

--- a/accessibility-checker-engine/src/v4/rules/combobox_focusable_elements.ts
+++ b/accessibility-checker-engine/src/v4/rules/combobox_focusable_elements.ts
@@ -38,7 +38,7 @@ export let combobox_focusable_elements: Rule = {
         }
     },
     rulesets: [{ 
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"], 
         "level": eRulePolicy.VIOLATION, 
         "toolkitLevel": eToolkitLevel.LEVEL_ONE 

--- a/accessibility-checker-engine/src/v4/rules/combobox_haspopup_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/combobox_haspopup_valid.ts
@@ -43,7 +43,7 @@ export let combobox_haspopup_valid: Rule = {
         }
     },
     rulesets: [{ 
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
         "num": ["4.1.2"], 
         "level": eRulePolicy.VIOLATION, 
         "toolkitLevel": eToolkitLevel.LEVEL_ONE 

--- a/accessibility-checker-engine/src/v4/rules/combobox_popup_reference.ts
+++ b/accessibility-checker-engine/src/v4/rules/combobox_popup_reference.ts
@@ -52,7 +52,7 @@ export let combobox_popup_reference: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/dir_attribute_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/dir_attribute_valid.ts
@@ -38,7 +38,7 @@ export let dir_attribute_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/download_keyboard_controllable.ts
+++ b/accessibility-checker-engine/src/v4/rules/download_keyboard_controllable.ts
@@ -39,7 +39,7 @@ export let download_keyboard_controllable: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.1.2"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/draggable_alternative_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/draggable_alternative_exists.ts
@@ -37,7 +37,7 @@ export let draggable_alternative_exists: Rule = {
         }
     },
     rulesets: [{
-        id: ["WCAG_2_2"],
+        id: ["IBM_Accessibility_next", "WCAG_2_2"],
         num: ["2.5.7"],
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/element_accesskey_labelled.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_accesskey_labelled.ts
@@ -41,7 +41,7 @@ export let element_accesskey_labelled: Rule = {
         }
     },
     rulesets: [{ 
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
         "num": ["3.3.2"],
         "level": eRulePolicy.RECOMMENDATION, 
         "toolkitLevel": eToolkitLevel.LEVEL_ONE 

--- a/accessibility-checker-engine/src/v4/rules/element_accesskey_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_accesskey_unique.ts
@@ -38,7 +38,7 @@ export let element_accesskey_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next"],
         "num": ["HTML"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/element_attribute_deprecated.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_attribute_deprecated.ts
@@ -123,7 +123,7 @@ export let element_attribute_deprecated: Rule = {
         }
     },
     rulesets: [{ 
-        "id": ["IBM_Accessibility"], 
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next"], 
         "num": ["HTML"], 
         "level": eRulePolicy.RECOMMENDATION, 
         "toolkitLevel": eToolkitLevel.LEVEL_THREE 

--- a/accessibility-checker-engine/src/v4/rules/element_id_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_id_unique.ts
@@ -43,7 +43,7 @@ export let element_id_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next"],
         "num": ["HTML"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/element_lang_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_lang_valid.ts
@@ -74,7 +74,7 @@ export let html_lang_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
@@ -141,7 +141,7 @@ export let element_lang_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/element_mouseevent_keyboard.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_mouseevent_keyboard.ts
@@ -38,7 +38,7 @@ export let element_mouseevent_keyboard: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.1.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/element_orientation_unlocked.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_orientation_unlocked.ts
@@ -37,7 +37,7 @@ export let element_orientation_unlocked: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.4"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/element_scrollable_tabbable.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_scrollable_tabbable.ts
@@ -38,7 +38,7 @@ export let element_scrollable_tabbable: Rule = {
         }
     },
     rulesets: [{
-        id: ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         num: ["2.1.1"],
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/element_tabbable_role_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_tabbable_role_valid.ts
@@ -37,7 +37,7 @@ export let element_tabbable_role_valid: Rule = {
         }
     },
     rulesets: [{
-            "id": ["IBM_Accessibility"],
+            "id": ["IBM_Accessibility", "IBM_Accessibility_next"],
             "num": ["4.1.2"],
             "level": eRulePolicy.VIOLATION,
             "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/element_tabbable_unobscured.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_tabbable_unobscured.ts
@@ -36,7 +36,7 @@ export let element_tabbable_unobscured: Rule = {
         }
     },
     rulesets: [{
-        id: ["WCAG_2_2"],
+        id: ["IBM_Accessibility_next", "WCAG_2_2"],
         num: ["2.4.11"],
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/element_tabbable_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_tabbable_visible.ts
@@ -36,7 +36,7 @@ export let element_tabbable_visible: Rule = {
         }
     },
     rulesets: [{
-        id: ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         num: ["2.4.7"],
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/embed_alt_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/embed_alt_exists.ts
@@ -39,7 +39,7 @@ export let embed_alt_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_FOUR

--- a/accessibility-checker-engine/src/v4/rules/embed_noembed_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/embed_noembed_exists.ts
@@ -38,7 +38,7 @@ export let embed_noembed_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_FOUR

--- a/accessibility-checker-engine/src/v4/rules/emoticons_alt_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/emoticons_alt_exists.ts
@@ -41,7 +41,7 @@ export let emoticons_alt_exists: Rule = {
      * Decision in planning 9/7/23 that this rule causes more reviews that we see actual problems in content, so turn these rules off
     
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/error_message_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/error_message_exists.ts
@@ -43,7 +43,7 @@ export let error_message_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/fieldset_label_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/fieldset_label_valid.ts
@@ -45,7 +45,7 @@ export let fieldset_label_valid: Rule = {
         }
     },
     rulesets: [{ 
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"], 
         "num": ["1.3.1", "3.3.2"], 
         "level": eRulePolicy.VIOLATION, 
         "toolkitLevel": eToolkitLevel.LEVEL_THREE 

--- a/accessibility-checker-engine/src/v4/rules/fieldset_legend_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/fieldset_legend_valid.ts
@@ -45,7 +45,7 @@ export let fieldset_legend_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],  //https://www.w3.org/WAI/WCAG22/Techniques/html/H71
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/figure_label_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/figure_label_exists.ts
@@ -39,7 +39,7 @@ export let figure_label_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/form_font_color.ts
+++ b/accessibility-checker-engine/src/v4/rules/form_font_color.ts
@@ -38,7 +38,7 @@ export let form_font_color: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/form_interaction_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/form_interaction_review.ts
@@ -38,7 +38,7 @@ export let form_interaction_review: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.2.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/form_label_unique.ts
+++ b/accessibility-checker-engine/src/v4/rules/form_label_unique.ts
@@ -39,7 +39,7 @@ export let form_label_unique: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/form_submit_button_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/form_submit_button_exists.ts
@@ -38,7 +38,7 @@ export let form_submit_button_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.2.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/form_submit_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/form_submit_review.ts
@@ -38,7 +38,7 @@ export let form_submit_review: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.2.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/frame_src_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/frame_src_valid.ts
@@ -39,7 +39,7 @@ export let frame_src_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/frame_title_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/frame_title_exists.ts
@@ -40,7 +40,7 @@ export let frame_title_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"], /*Change mapping to 4.1.2 from 2.4.1 typo? */
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/heading_content_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/heading_content_exists.ts
@@ -38,7 +38,7 @@ export let heading_content_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.6"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/heading_markup_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/heading_markup_misuse.ts
@@ -39,7 +39,7 @@ export let heading_markup_misuse: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/html_lang_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/html_lang_exists.ts
@@ -58,7 +58,7 @@ export let html_lang_exists: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "3.1.1", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/html_skipnav_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/html_skipnav_exists.ts
@@ -40,7 +40,7 @@ export let html_skipnav_exists: Rule = {
         }
     },
     rulesets: [{
-        id: [ "IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "2.4.1", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/iframe_interactive_tabbable.ts
+++ b/accessibility-checker-engine/src/v4/rules/iframe_interactive_tabbable.ts
@@ -36,7 +36,7 @@ export let iframe_interactive_tabbable: Rule = {
         }
     },
     rulesets: [{
-        id: ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         num: ["2.1.1"],
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/imagebutton_alt_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/imagebutton_alt_exists.ts
@@ -44,7 +44,7 @@ export let imagebutton_alt_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/imagemap_alt_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/imagemap_alt_exists.ts
@@ -39,7 +39,7 @@ export let imagemap_alt_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/img_alt_background.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_background.ts
@@ -38,7 +38,7 @@ export let img_alt_background: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/img_alt_decorative.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_decorative.ts
@@ -39,7 +39,7 @@ export let img_alt_decorative: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/img_alt_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_misuse.ts
@@ -38,7 +38,7 @@ export let img_alt_misuse: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/img_alt_null.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_null.ts
@@ -39,7 +39,7 @@ export let img_alt_null: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/img_alt_redundant.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_redundant.ts
@@ -44,7 +44,7 @@ export let img_alt_redundant: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_valid.ts
@@ -45,7 +45,7 @@ export let img_alt_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/img_ismap_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_ismap_misuse.ts
@@ -39,7 +39,7 @@ export let img_ismap_misuse: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/img_longdesc_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_longdesc_misuse.ts
@@ -39,7 +39,7 @@ export let img_longdesc_misuse: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/input_autocomplete_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_autocomplete_valid.ts
@@ -46,7 +46,7 @@ export let input_autocomplete_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.5"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/input_checkboxes_grouped.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_checkboxes_grouped.ts
@@ -63,7 +63,7 @@ export let input_checkboxes_grouped: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/input_fields_grouped.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_fields_grouped.ts
@@ -38,7 +38,7 @@ export let input_fields_grouped: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/input_haspopup_conflict.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_haspopup_conflict.ts
@@ -40,7 +40,7 @@ export let input_haspopup_conflict: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/input_label_after.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_label_after.ts
@@ -41,7 +41,7 @@ export let input_label_after: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.3.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/input_label_before.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_label_before.ts
@@ -41,7 +41,7 @@ export let input_label_before: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.3.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/input_label_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_label_exists.ts
@@ -47,7 +47,7 @@ export let input_label_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"], /* remove 1.1.1 mapping, keep 4.1.2 */
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/input_label_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_label_visible.ts
@@ -42,7 +42,7 @@ export let input_label_visible: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.3.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/input_onchange_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_onchange_review.ts
@@ -38,7 +38,7 @@ export let input_onchange_review: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.2.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/input_placeholder_label_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_placeholder_label_visible.ts
@@ -40,7 +40,7 @@ export let input_placeholder_label_visible: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.3.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/label_content_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/label_content_exists.ts
@@ -47,7 +47,7 @@ export let label_content_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/label_name_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/label_name_visible.ts
@@ -43,7 +43,7 @@ export let label_name_visible: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_2"],
         "num": ["2.5.3"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/label_ref_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/label_ref_valid.ts
@@ -39,7 +39,7 @@ export let label_ref_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/list_children_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/list_children_valid.ts
@@ -39,7 +39,7 @@ export let list_children_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/list_markup_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/list_markup_review.ts
@@ -39,7 +39,7 @@ export let list_markup_review: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/list_structure_proper.ts
+++ b/accessibility-checker-engine/src/v4/rules/list_structure_proper.ts
@@ -38,7 +38,7 @@ export let list_structure_proper: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/marquee_elem_avoid.ts
+++ b/accessibility-checker-engine/src/v4/rules/marquee_elem_avoid.ts
@@ -38,7 +38,7 @@ export let marquee_elem_avoid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.2.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/media_alt_brief.ts
+++ b/accessibility-checker-engine/src/v4/rules/media_alt_brief.ts
@@ -38,7 +38,7 @@ export let media_alt_brief: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/media_alt_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/media_alt_exists.ts
@@ -39,7 +39,7 @@ export let media_alt_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/media_audio_transcribed.ts
+++ b/accessibility-checker-engine/src/v4/rules/media_audio_transcribed.ts
@@ -39,7 +39,7 @@ export let media_audio_transcribed: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.2.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/media_autostart_controllable.ts
+++ b/accessibility-checker-engine/src/v4/rules/media_autostart_controllable.ts
@@ -38,7 +38,7 @@ export let media_autostart_controllable: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.4.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/media_keyboard_controllable.ts
+++ b/accessibility-checker-engine/src/v4/rules/media_keyboard_controllable.ts
@@ -38,7 +38,7 @@ export let media_keyboard_controllable: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/media_live_captioned.ts
+++ b/accessibility-checker-engine/src/v4/rules/media_live_captioned.ts
@@ -38,7 +38,7 @@ export let media_live_captioned: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.2.4"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/media_track_available.ts
+++ b/accessibility-checker-engine/src/v4/rules/media_track_available.ts
@@ -39,7 +39,7 @@ export let media_track_available: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.2.3", "1.2.5"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/meta_redirect_optional.ts
+++ b/accessibility-checker-engine/src/v4/rules/meta_redirect_optional.ts
@@ -43,7 +43,7 @@ export let meta_redirect_optional: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.2.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/meta_refresh_delay.ts
+++ b/accessibility-checker-engine/src/v4/rules/meta_refresh_delay.ts
@@ -38,7 +38,7 @@ export let meta_refresh_delay: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.2.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/meta_viewport_zoomable.ts
+++ b/accessibility-checker-engine/src/v4/rules/meta_viewport_zoomable.ts
@@ -38,7 +38,7 @@ export let meta_viewport_zoomable: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.4.4"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/noembed_content_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/noembed_content_exists.ts
@@ -40,7 +40,7 @@ export let noembed_content_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_FOUR

--- a/accessibility-checker-engine/src/v4/rules/object_text_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/object_text_exists.ts
@@ -41,7 +41,7 @@ export let object_text_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/page_title_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/page_title_exists.ts
@@ -46,7 +46,7 @@ export let page_title_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/page_title_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/page_title_valid.ts
@@ -41,7 +41,7 @@ export let page_title_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/script_focus_blur_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/script_focus_blur_review.ts
@@ -38,7 +38,7 @@ export let script_focus_blur_review: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.7", "3.2.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/script_onclick_avoid.ts
+++ b/accessibility-checker-engine/src/v4/rules/script_onclick_avoid.ts
@@ -39,7 +39,7 @@ export let script_onclick_avoid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_FOUR

--- a/accessibility-checker-engine/src/v4/rules/script_onclick_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/script_onclick_misuse.ts
@@ -38,7 +38,7 @@ export let script_onclick_misuse: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/script_select_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/script_select_review.ts
@@ -38,7 +38,7 @@ export let script_select_review: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.2.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/select_options_grouped.ts
+++ b/accessibility-checker-engine/src/v4/rules/select_options_grouped.ts
@@ -38,7 +38,7 @@ export let select_options_grouped: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/skip_main_described.ts
+++ b/accessibility-checker-engine/src/v4/rules/skip_main_described.ts
@@ -42,7 +42,7 @@ export let skip_main_described: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/skip_main_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/skip_main_exists.ts
@@ -41,7 +41,7 @@ export let skip_main_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.4.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/style_background_decorative.ts
+++ b/accessibility-checker-engine/src/v4/rules/style_background_decorative.ts
@@ -38,7 +38,7 @@ export let style_background_decorative: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/style_before_after_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/style_before_after_review.ts
@@ -46,7 +46,7 @@ export let style_before_after_review: Rule = {
     },
     rulesets: [{
         // Turn off the rule due to the obsolete requirement
-        //id: ["IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        //id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         id: [],
         num: "1.3.1", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,

--- a/accessibility-checker-engine/src/v4/rules/style_color_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/style_color_misuse.ts
@@ -40,7 +40,7 @@ export let style_color_misuse: Rule = {
         }
     },
     rulesets: [{
-        id: ["IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "1.4.1", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/style_focus_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/style_focus_visible.ts
@@ -40,7 +40,7 @@ export let style_focus_visible: Rule = {
         }
     },
     rulesets: [{
-        id: ["IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "2.4.7", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/style_highcontrast_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/style_highcontrast_visible.ts
@@ -38,7 +38,7 @@ export let style_highcontrast_visible: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next"],
         "num": ["1.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/style_hover_persistent.ts
+++ b/accessibility-checker-engine/src/v4/rules/style_hover_persistent.ts
@@ -41,7 +41,7 @@ export let style_hover_persistent: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_2"],
         "num": ["1.4.13"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/style_viewport_resizable.ts
+++ b/accessibility-checker-engine/src/v4/rules/style_viewport_resizable.ts
@@ -42,7 +42,7 @@ export let style_viewport_resizable: Rule = {
         }
     },
     rulesets: [{
-        id: ["IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "1.4.4", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/table_aria_descendants.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_aria_descendants.ts
@@ -32,7 +32,7 @@ export let table_aria_descendants: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["4.1.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/table_caption_empty.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_caption_empty.ts
@@ -38,7 +38,7 @@ export let table_caption_empty: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/table_caption_nested.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_caption_nested.ts
@@ -38,7 +38,7 @@ export let table_caption_nested: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/table_headers_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_headers_exists.ts
@@ -38,7 +38,7 @@ export let table_headers_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/table_headers_ref_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_headers_ref_valid.ts
@@ -42,7 +42,7 @@ export let table_headers_ref_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/table_headers_related.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_headers_related.ts
@@ -39,7 +39,7 @@ export let table_headers_related: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/table_layout_linearized.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_layout_linearized.ts
@@ -39,7 +39,7 @@ export let table_layout_linearized: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_FOUR

--- a/accessibility-checker-engine/src/v4/rules/table_scope_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_scope_valid.ts
@@ -40,7 +40,7 @@ export let table_scope_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/table_structure_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_structure_misuse.ts
@@ -39,7 +39,7 @@ export let table_structure_misuse: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/table_summary_redundant.ts
+++ b/accessibility-checker-engine/src/v4/rules/table_summary_redundant.ts
@@ -40,7 +40,7 @@ export let table_summary_redundant: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/target_spacing_sufficient.ts
+++ b/accessibility-checker-engine/src/v4/rules/target_spacing_sufficient.ts
@@ -47,14 +47,14 @@
             }
         },
         rulesets: [{
-            id: ["WCAG_2_2"],
+            id: ["IBM_Accessibility_next", "WCAG_2_2"],
             num: ["2.5.8"],
             level: eRulePolicy.VIOLATION,
             toolkitLevel: eToolkitLevel.LEVEL_THREE,
             reasonCodes: ["pass_spacing","pass_sized", "pass_inline","pass_default", "violation_spacing", "potential_overlap"]
         },
         {
-            id: ["WCAG_2_2"],
+            id: ["IBM_Accessibility_next", "WCAG_2_2"],
             num: ["2.5.8"],
             level: eRulePolicy.RECOMMENDATION,
             toolkitLevel: eToolkitLevel.LEVEL_THREE,

--- a/accessibility-checker-engine/src/v4/rules/text_block_heading.ts
+++ b/accessibility-checker-engine/src/v4/rules/text_block_heading.ts
@@ -41,7 +41,7 @@ export let text_block_heading: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/text_contrast_sufficient.ts
+++ b/accessibility-checker-engine/src/v4/rules/text_contrast_sufficient.ts
@@ -55,7 +55,7 @@ export let text_contrast_sufficient: Rule = {
         }
     },
     rulesets: [{
-        id: ["IBM_Accessibility", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
+        id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
         num: "1.4.3", // num: [ "2.4.4", "x.y.z" ] also allowed
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/text_quoted_correctly.ts
+++ b/accessibility-checker-engine/src/v4/rules/text_quoted_correctly.ts
@@ -34,7 +34,7 @@ export let text_quoted_correctly: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/text_sensory_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/text_sensory_misuse.ts
@@ -43,7 +43,7 @@ export let text_sensory_misuse: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.3"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO

--- a/accessibility-checker-engine/src/v4/rules/text_spacing_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/text_spacing_valid.ts
@@ -40,7 +40,7 @@ export let text_spacing_valid: Rule = {
         }
     },
     rulesets: [{
-         "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
          "num": ["1.4.12"],
          "level": eRulePolicy.VIOLATION,
          "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/text_whitespace_valid.ts
+++ b/accessibility-checker-engine/src/v4/rules/text_whitespace_valid.ts
@@ -33,7 +33,7 @@ export let text_whitespace_valid: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["1.3.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE

--- a/accessibility-checker-engine/src/v4/rules/widget_tabbable_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/widget_tabbable_exists.ts
@@ -40,7 +40,7 @@ export let widget_tabbable_exists: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.1.1"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rules/widget_tabbable_single.ts
+++ b/accessibility-checker-engine/src/v4/rules/widget_tabbable_single.ts
@@ -42,7 +42,7 @@ export let widget_tabbable_single: Rule = {
         }
     },
     rulesets: [{
-        "id": ["IBM_Accessibility", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
+        "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["2.1.1", "2.4.3"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE

--- a/accessibility-checker-engine/src/v4/rulesets.ts
+++ b/accessibility-checker-engine/src/v4/rulesets.ts
@@ -126,6 +126,22 @@ export let a11yRulesets: Guideline[] = [
             }))
     },
     {
+        id: "IBM_Accessibility_next",
+        name: "IBM Accessibility 7.3",
+        category: eGuidelineCategory.ACCESSIBILITY,
+        description: "Rules for WCAG 2.0, 2.1, 2.2 A and AA plus additional IBM supplemental requirements.",
+        // This ruleset has all 2.0 and 2.1 checkpoints that are A or AA
+        checkpoints: SCs
+            .filter(sc => (sc.level === "A" || sc.level === "AA" || sc.level === "NA") && (sc.wcagType === "2.0" || sc.wcagType === "2.1" || sc.wcagType === "2.2" || sc.wcagType === "NA"))
+            .map(sc => ({
+                num: sc.num,
+                scId: sc.scId,
+                name: sc.handle,
+                wcagLevel: sc.level,
+                summary: summaries[sc.num]
+            }))
+    },
+    {
         id: "WCAG_2_2",
         name: "WCAG 2.2 (A, AA)",
         category: eGuidelineCategory.ACCESSIBILITY,

--- a/accessibility-checker-extension/src/ts/docs/QuickGuideACApp.tsx
+++ b/accessibility-checker-extension/src/ts/docs/QuickGuideACApp.tsx
@@ -102,7 +102,7 @@ export class QuickGuideACApp extends React.Component<{}, quickGuideACAppState> {
                 <h1>Quick guide - IBM Accessibility Checker</h1>
                     <p>
                         The IBM Equal Access Toolkit: Accessibility Checker ("<strong>the Checker</strong>") tests web pages for accessibility issues with
-                        W3C Web Content Accessibility Guidelines (WCAG 2.2), IBM Accessibility requirements, and other standards.
+                        W3C Web Content Accessibility Guidelines (WCAG 2.x), IBM Accessibility requirements, and other standards.
                         The Checker is <Link href="https://www.ibm.com/able/toolkit/tools/#develop" target="_blank" rel="noopener noreferred" inline={true}
                         size="lg">also available as a Node package</Link> for automated testing within a continuous integration / continuous delivery (CI/CD) pipeline. 
                         The Checker rules include explanations and help for suggested fixes.
@@ -470,6 +470,7 @@ export class QuickGuideACApp extends React.Component<{}, quickGuideACAppState> {
                         Select one of the following:</p>
                         <UnorderedList>
                             <ListItem><strong>IBM Accessibility 7.2</strong>: includes checking against WCAG 2.1 plus additional IBM requirements</ListItem>
+                            <ListItem><strong>IBM Accessibility 7.3</strong>: includes checking against WCAG 2.2 plus additional IBM requirements. This will be the default starting Oct 1, 2024.</ListItem>
                             <ListItem><strong>WCAG 2.2 (A, AA)</strong>: this is the latest W3C specification. Content that conforms to WCAG 2.2 also conforms to WCAG 2.1 and 2.0</ListItem>
                             <ListItem><strong>WCAG 2.1 (A, AA)</strong>: referenced by EN 301 549 and other policies, but not the latest W3C specification</ListItem>
                             <ListItem><strong>WCAG 2.0 (A, AA)</strong>: referenced by US Section 508</ListItem>

--- a/accessibility-checker-extension/src/ts/docs/UsingACApp.tsx
+++ b/accessibility-checker-extension/src/ts/docs/UsingACApp.tsx
@@ -86,7 +86,7 @@ class UsingACApp extends React.Component<{}, UsingACAppState> {
                 <h1>User guide - IBM Accessibility Checker</h1>
                 <p>
                     The IBM Equal Access Toolkit: Accessibility Checker ("<strong>the Checker</strong>") tests web pages for accessibility issues with
-                    W3C Web Content Accessibility Guidelines (WCAG 2.2), IBM Accessibility requirements, and other standards.
+                    W3C Web Content Accessibility Guidelines (WCAG 2.x), IBM Accessibility requirements, and other standards.
                     The Checker is <Link 
                         href="https://www.ibm.com/able/toolkit/tools/#develop" target="_blank" rel="noopener noreferred" inline={true}
                         size="lg">also available as a Node package</Link> for automated testing within a continuous integration / continuous delivery (CI/CD) pipeline. 
@@ -972,6 +972,7 @@ class UsingACApp extends React.Component<{}, UsingACAppState> {
                 </p>
                     <UnorderedList>
                         <ListItem><strong>IBM Accessibility 7.2</strong>: includes checking against WCAG 2.1 plus additional IBM requirements</ListItem>
+                        <ListItem><strong>IBM Accessibility 7.3</strong>: includes checking against WCAG 2.2 plus additional IBM requirements. This will be the default starting Oct 1, 2024.</ListItem>
                         <ListItem><strong>WCAG 2.2 (A, AA)</strong>: this is the latest W3C specification. Content that conforms to WCAG 2.2 also conforms to WCAG 2.1 and 2.0</ListItem>
                         <ListItem><strong>WCAG 2.1 (A, AA)</strong>: referenced by EN 301 549 and other policies, but not the latest W3C specification</ListItem>
                         <ListItem><strong>WCAG 2.0 (A, AA)</strong>: referenced by US Section 508</ListItem>

--- a/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
+++ b/accessibility-checker-extension/src/ts/options/OptionsApp.tsx
@@ -545,16 +545,12 @@ export class OptionsApp extends React.Component<{}, OptionsAppState> {
                             }).bind(this)}
                         >
                             <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.2</strong>: Rules for WCAG 2.1 plus additional IBM requirements.</p>
-                            
+                            <p style={{ maxWidth: "100%" }}><strong>IBM Accessibility 7.3</strong>: Rules for WCAG 2.2 plus additional IBM requirements. This will be the default starting Oct 1, 2024.</p>
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.2 (A, AA)</strong>: Rules for the latest W3C specification. Content that conforms to WCAG 2.2 also conforms to 2.1 and 2.0.</p>
-                            
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.1 (A, AA)</strong>: Content that conforms to WCAG 2.1 also conforms to WCAG 2.0. Referenced by EN 301 549 and other policies, but not the latest W3C specification.</p>
-                            
                             <p style={{ maxWidth: "100%" }}><strong>WCAG 2.0 (A, AA)</strong>: Referenced by US Section 508, but not the latest W3C specification.</p>
-                            
                             <p style={{ maxWidth: "100%" }}><strong>Rule sets</strong>: A packaged set for a guideline, each of which is a collection of rules mapped to requirements in the accessibility guideline, 
                                 see the <Link inline={true} size="md" className="link" href="https://www.ibm.com/able/requirements/checker-rule-sets" target="_blank" style={{ color: '#002D9C' }}>Checker rule sets</Link>.</p>
-                            
                         </Modal>, document.body)}
                     </div>
 

--- a/rule-server/src/static/archives.json
+++ b/rule-server/src/static/archives.json
@@ -6,266 +6,266 @@
     },
     {
         "id": "09May2024",
-        "name": "09 May 2024 Deployment",
+        "name": "09 May 2024 Deployment (IBM 7.2)",
         "version": "3.1.71",
         "path": "/archives/2024.05.09"
     },
     {
         "id": "19April2024",
-        "name": "19 April 2024 Deployment",
+        "name": "19 April 2024 Deployment (IBM 7.2)",
         "version": "3.1.70",
         "path": "/archives/2024.04.19"
     },
     {
         "id": "18March2024",
-        "name": "18 March 2024 Deployment",
+        "name": "18 March 2024 Deployment (IBM 7.2)",
         "version": "3.1.68",
         "path": "/archives/2024.03.18"
     },
     {
         "id": "02February2024",
-        "name": "02 February 2024 Deployment",
+        "name": "02 February 2024 Deployment (IBM 7.2)",
         "version": "3.1.67",
         "path": "/archives/2024.02.02"
     },
     {
         "id": "24January2024",
-        "name": "24 January 2024 Deployment",
+        "name": "24 January 2024 Deployment (IBM 7.2)",
         "version": "3.1.66",
         "path": "/archives/2024.01.24"
     },
     {
         "id": "10November2023",
-        "name": "10 November 2023 Deployment",
+        "name": "10 November 2023 Deployment (IBM 7.2)",
         "version": "3.1.64",
         "path": "/archives/2023.11.10"
     },
     {
         "id": "12October2023",
-        "name": "12 October 2023 Deployment",
+        "name": "12 October 2023 Deployment (IBM 7.2)",
         "version": "3.1.62",
         "path": "/archives/2023.10.12"
     },
     {
         "id": "19September2023",
-        "name": "19 September 2023 Deployment",
+        "name": "19 September 2023 Deployment (IBM 7.2)",
         "version": "3.1.61",
         "path": "/archives/2023.09.19"
     },
     {
         "id": "30August2023",
-        "name": "30 August 2023 Deployment",
+        "name": "30 August 2023 Deployment (IBM 7.2)",
         "version": "3.1.60",
         "path": "/archives/2023.08.30"
     },
     {
         "id": "09August2023",
-        "name": "09 August 2023 Deployment",
+        "name": "09 August 2023 Deployment (IBM 7.2)",
         "version": "3.1.59",
         "path": "/archives/2023.08.09"
     },
     {
         "id": "26July2023",
-        "name": "26 July 2023 Deployment",
+        "name": "26 July 2023 Deployment (IBM 7.2)",
         "version": "3.1.58",
         "path": "/archives/2023.07.26"
     },
     {
         "id": "01July2023",
-        "name": "01 July 2023 Deployment",
+        "name": "01 July 2023 Deployment (IBM 7.2)",
         "version": "3.1.51",
         "path": "/archives/2023.07.01"
     },
     {
         "id": "26May2023",
-        "name": "26 May 2023 Deployment",
+        "name": "26 May 2023 Deployment (IBM 7.2)",
         "version": "3.1.49",
         "path": "/archives/2023.05.26"
     },
     {
         "id": "15May2023",
-        "name": "15 May 2023 Deployment",
+        "name": "15 May 2023 Deployment (IBM 7.2)",
         "version": "3.1.48",
         "path": "/archives/2023.05.15"
     },
     {
         "id": "31March2023",
-        "name": "31 March 2023 Deployment",
+        "name": "31 March 2023 Deployment (IBM 7.2)",
         "version": "3.1.47",
         "path": "/archives/2023.03.31"
     },
     {
         "id": "09March2023",
-        "name": "09 March 2023 Deployment",
+        "name": "09 March 2023 Deployment (IBM 7.2)",
         "version": "3.1.46",
         "path": "/archives/2023.03.09"
     },
     {
         "id": "23February2023",
-        "name": "23 February 2023 Deployment",
+        "name": "23 February 2023 Deployment (IBM 7.2)",
         "version": "3.1.45",
         "path": "/archives/2023.02.23"
     },
     {
         "id": "27January2023",
-        "name": "27 January 2023 Deployment",
+        "name": "27 January 2023 Deployment (IBM 7.2)",
         "version": "3.1.43",
         "path": "/archives/2023.01.27"
     },
     {
         "id": "11January2023",
-        "name": "11 January 2023 Deployment",
+        "name": "11 January 2023 Deployment (IBM 7.2)",
         "version": "3.1.42",
         "path": "/archives/2023.01.11"
     },
     {
         "id": "08November2022",
-        "name": "08 November 2022 Deployment",
+        "name": "08 November 2022 Deployment (IBM 7.2)",
         "version": "3.1.41",
         "path": "/archives/2022.11.08"
     },
     {
         "id": "13October2022",
-        "name": "13 October 2022 Deployment",
+        "name": "13 October 2022 Deployment (IBM 7.2)",
         "version": "3.1.39",
         "path": "/archives/2022.10.13"
     },
     {
         "id": "21September2022",
-        "name": "21 September 2022 Deployment",
+        "name": "21 September 2022 Deployment (IBM 7.2)",
         "version": "3.1.38",
         "path": "/archives/2022.09.21"
     },
     {
         "id": "10August2022",
-        "name": "10 August 2022 Deployment",
+        "name": "10 August 2022 Deployment (IBM 7.2)",
         "version": "3.1.35",
         "path": "/archives/2022.08.10"
     },
     {
         "id": "06July2022",
-        "name": "06 July 2022 Deployment",
+        "name": "06 July 2022 Deployment (IBM 7.2)",
         "version": "3.1.33",
         "path": "/archives/2022.07.06"
     },
     {
         "id": "09June2022",
-        "name": "09 June 2022 Deployment",
+        "name": "09 June 2022 Deployment (IBM 7.2)",
         "version": "3.1.31",
         "path": "/archives/2022.06.09"
     },
     {
         "id": "04May2022",
-        "name": "04 May 2022 Deployment",
+        "name": "04 May 2022 Deployment (IBM 7.2)",
         "version": "3.1.29",
         "path": "/archives/2022.05.04"
     },
     {
         "id": "19April2022",
-        "name": "19 April 2022 Deployment",
+        "name": "19 April 2022 Deployment (IBM 7.2)",
         "version": "3.1.28",
         "path": "/archives/2022.04.19"
     },
     {
         "id": "18March2022",
-        "name": "18 March 2022 Deployment",
+        "name": "18 March 2022 Deployment (IBM 7.2)",
         "version": "3.1.24",
         "path": "/archives/2022.03.18"
     },
     {
         "id": "12March2022",
-        "name": "12 March 2022 Deployment",
+        "name": "12 March 2022 Deployment (IBM 7.2)",
         "version": "3.1.19",
         "path": "/archives/2022.03.12"
     },
     {
         "id": "03March2022",
-        "name": "03 March 2022 Deployment",
+        "name": "03 March 2022 Deployment (IBM 7.2)",
         "version": "3.1.18",
         "path": "/archives/2022.03.03"
     },
     {
         "id": "01February2022",
-        "name": "01 February 2022 Deployment",
+        "name": "01 February 2022 Deployment (IBM 7.2)",
         "version": "3.1.15",
         "path": "/archives/2022.02.01"
     },
     {
         "id": "17Nov2021",
-        "name": "17 November 2021 Deployment",
+        "name": "17 November 2021 Deployment (IBM 7.2)",
         "version": "3.1.12",
         "path": "/archives/2021.11.17"
         
     },
     {
         "id": "25Oct2021",
-        "name": "25 October 2021 Deployment",
+        "name": "25 October 2021 Deployment (IBM 7.2)",
         "version": "3.1.11",
         "path": "/archives/2021.10.25"
     },
     {
         "id": "27Aug2021",
-        "name": "27 August 2021 Deployment",
+        "name": "27 August 2021 Deployment (IBM 7.2)",
         "version": "3.1.10",
         "path": "/archives/2021.08.27"
     },
     {
         "id": "21July2021",
-        "name": "21 July 2021 Deployment",
+        "name": "21 July 2021 Deployment (IBM 7.2)",
         "version": "3.1.9",
         "path": "/archives/2021.07.21"
     },
     {
         "id": "16June2021",
-        "name": "16 June 2021 Deployment",
+        "name": "16 June 2021 Deployment (IBM 7.2)",
         "version": "3.1.8",
         "path": "/archives/2021.06.16"
     },
     {
         "id": "27April2021",
-        "name": "27 April 2021 Deployment",
+        "name": "27 April 2021 Deployment (IBM 7.2)",
         "version": "3.1.6",
         "path": "/archives/2021.04.27"
     },
     {
         "id": "10Feb2021",
-        "name": "10 February 2021 Deployment",
+        "name": "10 February 2021 Deployment (IBM 7.2)",
         "version": "3.1.2",
         "path": "/archives/2021.02.10"
     },
     {
         "id": "07Oct2020",
-        "name": "07 October 2020 Deployment",
+        "name": "07 October 2020 Deployment (IBM 7.2)",
         "version": "3.1.0",
         "path": "/archives/2020.10.07"
     },
     {
         "id": "12Aug2020",
-        "name": "12 August 2020 Deployment",
+        "name": "12 August 2020 Deployment (IBM 7.2)",
         "version": "3.0.8",
         "path": "/archives/2020.08.12"
     },
     {
         "id": "18June2020",
-        "name": "18 June 2020 Deployment",
+        "name": "18 June 2020 Deployment (IBM 7.2)",
         "version": "3.0.6",
         "path": "/archives/2020.06.18"
     },
     {
         "id": "03June2020",
-        "name": "03 June 2020 Deployment",
+        "name": "03 June 2020 Deployment (IBM 7.2)",
         "version": "3.0.5",
         "path": "/archives/2020.06.03"
     },
     {
         "id": "12May2020",
-        "name": "12 May 2020 Deployment",
+        "name": "12 May 2020 Deployment (IBM 7.2)",
         "version": "3.0.1",
         "path": "/archives/2020.05.12"
     },
     {
         "id": "2020AprilDeploy",
-        "name": "02 April 2020 Deployment",
+        "name": "02 April 2020 Deployment (IBM 7.2)",
         "version": "3.0.0",
         "path": "/archives/2020.04.02"
     },


### PR DESCRIPTION
<!-- For instructions regarding the PR title, see the bottom of the PR template -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Other (Provide information)
This PR is related to providing an ability to check against the upcoming [IBM Accessibility 7.3 requirements](https://www.ibm.com/able/requirements/requirements/?version=v7_3), which will become default on Oct 1, 2024. Users will be able to select in the extension, and choose an IBM_Accessibility_next id in the other tools

Fixes [#6463](https://github.ibm.com/IBMa/E2E/issues/6463) in internal repo

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [ ] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [ ] I understand that the title of this PR will be used for the next release notes.

### New test item
- [x] Make sure to check the [Checker rule sets](https://www.ibm.com/able/requirements/checker-rule-sets) tab content to confirm that 7.3 appears as a new tab. This new/additional test step is mentioned in https://github.ibm.com/IBMa/E2E/issues/6463

<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->