### PR TITLE
fixrule(`widget_tabbable_single`):  Radio inputs in the same group should have only one tab stop

### DIFF
--- a/accessibility-checker-engine/src/v4/rules/widget_tabbable_single.ts
+++ b/accessibility-checker-engine/src/v4/rules/widget_tabbable_single.ts
@@ -24,21 +24,21 @@ export let widget_tabbable_single: Rule = {
     refactor: {
         "IBMA_Focus_MultiTab": {
             "pass": "pass",
-            "fail_multiple_tabbable": "fail_multiple_tabbable"
+            "potential_multiple_tabbable": "potential_multiple_tabbable"
         }
     },
     help: {
         "en-US": {
             "pass": "widget_tabbable_single.html",
-            "fail_multiple_tabbable": "widget_tabbable_single.html",
+            "potential_multiple_tabbable": "widget_tabbable_single.html",
             "group": "widget_tabbable_single.html"
         }
     },
     messages: {
         "en-US": {
-            "pass": "Rule Passed",
-            "fail_multiple_tabbable": "Component with \"{0}\" role has more than one tabbable element",
-            "group": "Certain components must have no more than one tabbable element"
+            "pass": "Components with a widget role should have no more than one tabbable element",
+            "potential_multiple_tabbable": "Component with \"{0}\" role has more than one tabbable element",
+            "group": "Components with a widget role must have no more than one tabbable element"
         }
     },
     rulesets: [{
@@ -66,17 +66,26 @@ export let widget_tabbable_single: Rule = {
         }
         // If node has children, look for tab stops in the children
         //skip the count if the element requires presentational children only
+        let name = [];
         if (count < 2 && !RPTUtil.containsPresentationalChildrenOnly(ruleContext) && ruleContext.firstChild) {
             let nw = new NodeWalker(ruleContext);
             while (count < 2 && nw.nextNode() && nw.node != ruleContext) {
                 if (nw.node.nodeType == 1 && !nw.bEndTag && RPTUtil.isTabbable(nw.node)) {
+                    // Radio inputs with the same name natively are only one tab stop
+                    if (nw.node.nodeName.toLowerCase() === 'input' && (nw.node as Element).getAttribute("type") === 'radio') {
+                        let curName = (nw.node as Element).getAttribute("name");
+                        if (name.includes(curName)) 
+                            continue;
+                        else
+                            name.push(curName);
+                    }
                     ++count;
                 }
             }
         }
         let passed = count < 2;
         if (!passed)
-            setCache(ruleContext, "widget_tabbable_single", "fail_multiple_tabbable");
-        return passed ? RulePass("pass") : RulePotential("fail_multiple_tabbable", [role]);
+            setCache(ruleContext, "widget_tabbable_single", "potential_multiple_tabbable");
+        return passed ? RulePass("pass") : RulePotential("potential_multiple_tabbable", [role]);
     }
 }

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/group_multiname.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/group_multiname.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+
+<title>RPT Test Suite</title>
+
+</head>
+
+<body>
+
+<label>Main content</a>
+
+<!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+
+<h1>Display Radio Buttons</h1>
+
+<fieldset role="radiogroup" aria-labelledby="desc">
+  <legend id="desc">select your age and favorite pet</legend>
+  <input type="radio" id="age1" name="age" value="30">
+  <label for="age1">0 - 30</label><br>
+  <input type="radio" id="age2" name="age" value="60">
+  <label for="age2">31 - 60</label><br>  
+  <input type="radio" id="age3" name="age" value="100">
+  <label for="age3">61 - 100</label><br><br>
+
+  <input type="radio" id="pet1" name="pet" value="dog" >
+  <label for="pet1">Dog</label><br>
+  <input type="radio" id="pet2" name="pet" value="cat">
+  <label for="pet2">Cat</label><br>  
+  <input type="radio" id="pet3" name="pet" value="other" >
+  <label for="pet3">Other</label><br><br>
+
+  <input type="radio" id="fruit1" value="apple" >
+  <label for="fruit1">Apple</label><br>
+  <input type="radio" id="fruit2" value="pear" >
+  <label for="fruit2">Pear</label><br>  
+  <input type="radio" id="fruit3" value="banana" >
+  <label for="fruit3">Banana</label><br><br>
+</div>
+
+<script type="text/javascript">
+  UnitTest = {
+      ruleIds: ["widget_tabbable_single"],
+      results: [
+      {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]",
+              "aria": "/document[1]/radiogroup[1]"
+            },
+            "reasonId": "potential_multiple_tabbable",
+            "message": "Component with \"radiogroup\" role has more than one tabbable element",
+            "messageArgs": [
+              "radiogroup"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]/input[1]",
+              "aria": "/document[1]/radiogroup[1]/radio[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]/input[2]",
+              "aria": "/document[1]/radiogroup[1]/radio[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]/input[3]",
+              "aria": "/document[1]/radiogroup[1]/radio[3]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]/input[4]",
+              "aria": "/document[1]/radiogroup[1]/radio[4]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]/input[5]",
+              "aria": "/document[1]/radiogroup[1]/radio[5]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]/input[6]",
+              "aria": "/document[1]/radiogroup[1]/radio[6]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]/input[7]",
+              "aria": "/document[1]/radiogroup[1]/radio[7]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]/input[8]",
+              "aria": "/document[1]/radiogroup[1]/radio[8]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/label[1]/fieldset[1]/input[9]",
+              "aria": "/document[1]/radiogroup[1]/radio[9]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+      ]
+  }
+</script></body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/group_same_name_native.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/group_same_name_native.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+
+<title>RPT Test Suite</title>
+</head>
+
+<body>
+
+<!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+
+<h1>Display Radio Buttons</h1>
+
+<div role="textbox" aria-label="input your value">
+  <label for="adult">Adult<input type="radio" id="adult" name="input" value="30">
+  </label><br>
+  <label for="name">Name<input type="text" id="name" name="input">
+  </label><br>  
+  <label for="age">Age<input type="text" id="age" name="input" value="35" /></label>
+</div>
+  
+<script type="text/javascript">
+  UnitTest = {
+      ruleIds: ["widget_tabbable_single"],
+      results: [
+      {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]",
+              "aria": "/document[1]/textbox[1]"
+            },
+            "reasonId": "potential_multiple_tabbable",
+            "message": "Component with \"textbox\" role has more than one tabbable element",
+            "messageArgs": [
+              "textbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/label[1]/input[1]",
+              "aria": "/document[1]/textbox[1]/radio[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/label[2]/input[1]",
+              "aria": "/document[1]/textbox[1]/textbox[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/label[3]/input[1]",
+              "aria": "/document[1]/textbox[1]/textbox[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+      ]
+  }
+</script></body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/radiogroup_native.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/radiogroup_native.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+
+<title>RPT Test Suite</title>
+</head>
+
+<body>
+
+
+<!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+
+<h1>Display Radio Buttons</h1>
+
+<fieldset role="radiogroup" aria-labelledby="desc">
+  <legend id="desc">select your age</legend>
+  <input type="radio" id="age1" name="age" value="30">
+  <label for="age1">0 - 30</label><br>
+  <input type="radio" id="age2" name="age" value="60">
+  <label for="age2">31 - 60</label><br>  
+  <input type="radio" id="age3" name="age" value="100">
+  <label for="age3">61 - 100</label><br><br>
+</fieldset>
+  
+<div role="radiogroup" aria-label="select your favorite pet">
+  <input type="radio" id="pet1" name="pet" value="dog" tabindex="0">
+  <label for="pet1">Dog</label><br>
+  <input type="radio" id="pet2" name="pet" value="cat" tabindex="-1">
+  <label for="pet2">Cat</label><br>  
+  <input type="radio" id="pet3" name="pet" value="other" tabindex="-1">
+  <label for="pet3">Other</label><br><br>
+</div>
+
+<script type="text/javascript">
+  UnitTest = {
+      ruleIds: ["widget_tabbable_single"],
+      results: [
+      {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[1]",
+              "aria": "/document[1]/radiogroup[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[1]/input[1]",
+              "aria": "/document[1]/radiogroup[1]/radio[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[1]/input[2]",
+              "aria": "/document[1]/radiogroup[1]/radio[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[1]/input[3]",
+              "aria": "/document[1]/radiogroup[1]/radio[3]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]",
+              "aria": "/document[1]/radiogroup[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/input[1]",
+              "aria": "/document[1]/radiogroup[2]/radio[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/input[2]",
+              "aria": "/document[1]/radiogroup[2]/radio[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/input[3]",
+              "aria": "/document[1]/radiogroup[2]/radio[3]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+      ]
+  }
+</script></body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/tile_link.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/tile_link.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+    <head>
+        <title>RPT Test Suite</title>
+    </head>
+
+    <body>
+        <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+
+        <h3>Link with a button</h1>
+
+        
+            <a target="_blank" href="https://ibm.com" style="display:block; border:1px solid black;width:150px;margin: 15px;text-align: center;"> 
+                <p>IBM Store</p> 
+                <button type="button">Forward</button> 
+                <button type="button">Backward</button>     
+            </a>
+        
+
+        <script type="text/javascript">
+            UnitTest = {
+                ruleIds: ["widget_tabbable_single"],
+                results: [
+                {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]",
+              "aria": "/document[1]/link[1]"
+            },
+            "reasonId": "potential_multiple_tabbable",
+            "message": "Component with \"link\" role has more than one tabbable element",
+            "messageArgs": [
+              "link"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]/button[1]",
+              "aria": "/document[1]/link[1]/button[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/a[1]/button[2]",
+              "aria": "/document[1]/link[1]/button[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+                ],
+            };
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/tile_link.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/tile_link.html
@@ -33,6 +33,15 @@
                 <button type="button">Forward</button> 
                 <button type="button">Backward</button>     
             </a>
+
+            <button type="button" style="display:block; border:1px solid black;width:150px;margin-top: 85px;margin-left:15px; text-align: center;">Go!
+              <br>
+              <a target="_blank" href="https://ibm.com"> 
+                 IBM Store</a> <br>
+               
+              <a target="_blank" href="https://google.com">  
+                Google Store</a> 
+            </button>
         
 
         <script type="text/javascript">
@@ -82,6 +91,22 @@
             "path": {
               "dom": "/html[1]/body[1]/a[1]/button[2]",
               "aria": "/document[1]/link[1]/button[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/button[1]",
+              "aria": "/document[1]/button[1]"
             },
             "reasonId": "pass",
             "message": "Components with a widget role should have no more than one tabbable element",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/widget-button-multitabbable.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/widget-button-multitabbable.html
@@ -25,8 +25,6 @@
 
 <body>
 
-<a href="#navskip">skip to main content</a>
-
 <h1>Test case: widget-button-tabbable.html</h1>
 
 <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/widget_roving_tabindex.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/widget_roving_tabindex.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+
+<head>
+
+<title>RPT Test Suite</title>
+
+</head>
+
+<body>
+
+<!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+
+<h1>Display Radio Buttons</h1>
+
+<div role="radiogroup" aria-labelledby="group_label_2" id="rg2">
+  <h3 id="group_label_2">Pizza Delivery</h3>
+  <div role="radio" aria-checked="false" tabindex="0">Pickup</div>
+
+  <div role="radio" aria-checked="false" tabindex="-1">Home Delivery</div>
+
+  <div role="radio" aria-checked="false" tabindex="-1">Dine in</div>
+</div>
+
+<div role="radiogroup" aria-labelledby="group_label_1" id="rg1">
+  <h3 id="group_label_1">Pizza Crust</h3>
+
+  <div role="radio" aria-checked="false" tabindex="0">Regular crust</div>
+  <div role="radio" aria-checked="false" tabindex="-1">Deep dish</div>
+  <div role="radio" aria-checked="false" tabindex="-1">Thin crust</div>
+</div>
+
+<script type="text/javascript">
+  UnitTest = {
+      ruleIds: ["widget_tabbable_single"],
+      results: [
+      {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]",
+              "aria": "/document[1]/radiogroup[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/div[1]",
+              "aria": "/document[1]/radiogroup[1]/radio[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/div[2]",
+              "aria": "/document[1]/radiogroup[1]/radio[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[1]/div[3]",
+              "aria": "/document[1]/radiogroup[1]/radio[3]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[2]",
+              "aria": "/document[1]/radiogroup[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[2]/div[1]",
+              "aria": "/document[1]/radiogroup[2]/radio[1]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[2]/div[2]",
+              "aria": "/document[1]/radiogroup[2]/radio[2]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "widget_tabbable_single",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[2]/div[3]",
+              "aria": "/document[1]/radiogroup[2]/radio[3]"
+            },
+            "reasonId": "pass",
+            "message": "Components with a widget role should have no more than one tabbable element",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+      ]
+  }
+</script></body>
+</html>

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerification.html.json
@@ -468,7 +468,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -494,7 +494,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -520,7 +520,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -549,7 +549,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -575,7 +575,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -601,7 +601,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -627,7 +627,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -653,7 +653,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -679,7 +679,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -705,7 +705,7 @@
             "apiArgs": [],
             "bounds": {
                 "left": 8,
-                "top": 143,
+                "top": 144,
                 "height": 0,
                 "width": 784
             },
@@ -1015,20 +1015,20 @@
                 "aria": "/document[1]/navigation[1]/link[1]"
             },
             "reasonId": "pass",
-            "message": "Rule Passed",
+            "message": "Components with a widget role should have no more than one tabbable element",
             "messageArgs": [],
             "apiArgs": [],
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
             "category": "Accessibility",
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/widget_tabbable_single.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22widget_tabbable_single%22%2C%22msgArgs%22%3A%5B%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/widget_tabbable_single.html#%7B%22message%22%3A%22Components%20with%20a%20widget%20role%20should%20have%20no%20more%20than%20one%20tabbable%20element%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22widget_tabbable_single%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "widget_tabbable_exists",
@@ -1047,7 +1047,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1073,7 +1073,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1099,7 +1099,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1133,7 +1133,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1159,7 +1159,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1185,7 +1185,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1211,7 +1211,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1237,7 +1237,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1263,7 +1263,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 17,
+                "height": 18,
                 "width": 56
             },
             "snippet": "<a alt=\"skip to main content\" href=\"#navskip\">",
@@ -1289,7 +1289,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1315,7 +1315,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1341,7 +1341,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1370,7 +1370,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1396,7 +1396,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1422,7 +1422,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1448,7 +1448,7 @@
             "bounds": {
                 "left": 8,
                 "top": 8,
-                "height": 18,
+                "height": 19,
                 "width": 784
             },
             "snippet": "<div role=\"navigation\">",
@@ -1604,7 +1604,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1630,7 +1630,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1656,7 +1656,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1682,7 +1682,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1710,7 +1710,7 @@
             "bounds": {
                 "left": 0,
                 "top": 0,
-                "height": 143,
+                "height": 144,
                 "width": 800
             },
             "snippet": "<html lang=\"en\">",
@@ -1804,8 +1804,8 @@
             "pass": "Rule Passed"
         },
         "widget_tabbable_single": {
-            "0": "Certain components must have no more than one tabbable element",
-            "pass": "Rule Passed"
+            "0": "Components with a widget role must have no more than one tabbable element",
+            "pass": "Components with a widget role should have no more than one tabbable element"
         },
         "heading_content_exists": {
             "0": "Heading elements must provide descriptive text",

--- a/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
+++ b/accessibility-checker/test/baselines/JSONObjectStructureVerificationSelenium.html.json
@@ -98,8 +98,8 @@
             "pass": "Rule Passed"
         },
         "widget_tabbable_single": {
-            "0": "Certain components must have no more than one tabbable element",
-            "pass": "Rule Passed"
+            "0": "Components with a widget role must have no more than one tabbable element",
+            "pass": "Components with a widget role should have no more than one tabbable element"
         }
     },
     "numExecuted": 65,
@@ -1117,7 +1117,7 @@
                 "width": 999
             },
             "category": "Accessibility",
-            "message": "Rule Passed",
+            "message": "Components with a widget role should have no more than one tabbable element",
             "messageArgs": [],
             "path": {
                 "aria": "/document[1]/navigation[1]/link[1]",
@@ -1132,7 +1132,7 @@
             ],
             "ignored": false,
             "level": "pass",
-            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/widget_tabbable_single.html#%7B%22message%22%3A%22Rule%20Passed%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22widget_tabbable_single%22%2C%22msgArgs%22%3A%5B%5D%7D"
+            "help": "https://able.ibm.com/rules/archives/preview/doc/en-US/widget_tabbable_single.html#%7B%22message%22%3A%22Components%20with%20a%20widget%20role%20should%20have%20no%20more%20than%20one%20tabbable%20element%22%2C%22snippet%22%3A%22%3Ca%20alt%3D%5C%22skip%20to%20main%20content%5C%22%20href%3D%5C%22%23navskip%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22PASS%22%5D%2C%22reasonId%22%3A%22pass%22%2C%22ruleId%22%3A%22widget_tabbable_single%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "apiArgs": [],


### PR DESCRIPTION
<!-- For instructions regarding the PR title, see the bottom of the PR template -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: **widget_tabbable_single**


### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with "Fixes" to close when the PR closes (e.g., Fixes #000) -->
Fixes: #1649  

### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
test case: test/v2/checker/accessibility/rules/widget_tabbable_single_ruleunit/radiogroup_native.html
Before fix: Recommendation: "Component with "radiogroup" role has more than one tabbable element"  
After the fix: the recommendation should be gone.

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.

<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->