### PR TITLE
fixrule(`style_highcontrast_visible`): Replace 4.1.4 link in help to 1.1.1

### DIFF
--- a/accessibility-checker-engine/help-v4/en-US/style_highcontrast_visible.html
+++ b/accessibility-checker-engine/help-v4/en-US/style_highcontrast_visible.html
@@ -73,8 +73,6 @@ Another example is the disappearance of visual focus indicators and visual alter
 ### About this requirement
 
 * [IBM 1.1.1 Non-text content](https://www.ibm.com/able/requirements/requirements/#1_1_1)
-* [IBM 1.4.3 Contrast (Minimum)](https://www.ibm.com/able/requirements/requirements/#1_4_3)
-* [IBM 2.4.7 Focus Visible](https://www.ibm.com/able/requirements/requirements/#2_4_7)
 * [Failure F1: CSS positioning that changes the meaning](https://www.w3.org/WAI/WCAG22/Techniques/failures/F1)
 * [Failure F3: CSS images that convey important information](https://www.w3.org/WAI/WCAG22/Techniques/failures/F3)
 * [Failure F78: Styling element that removes the visual focus](https://www.w3.org/WAI/WCAG22/Techniques/failures/F78)

--- a/accessibility-checker-engine/help-v4/en-US/style_highcontrast_visible.html
+++ b/accessibility-checker-engine/help-v4/en-US/style_highcontrast_visible.html
@@ -72,7 +72,9 @@ Another example is the disappearance of visual focus indicators and visual alter
 
 ### About this requirement
 
-* [IBM 4.1.4 Accessibility-supported Technologies](https://www.ibm.com/able/requirements/requirements/#4_1_4)
+* [IBM 1.1.1 Non-text content](https://www.ibm.com/able/requirements/requirements/#1_1_1)
+* [IBM 1.4.3 Contrast (Minimum)](https://www.ibm.com/able/requirements/requirements/#1_4_3)
+* [IBM 2.4.7 Focus Visible](https://www.ibm.com/able/requirements/requirements/#2_4_7)
 * [Failure F1: CSS positioning that changes the meaning](https://www.w3.org/WAI/WCAG22/Techniques/failures/F1)
 * [Failure F3: CSS images that convey important information](https://www.w3.org/WAI/WCAG22/Techniques/failures/F3)
 * [Failure F78: Styling element that removes the visual focus](https://www.w3.org/WAI/WCAG22/Techniques/failures/F78)


### PR DESCRIPTION
### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with "Fixes" to close when the PR closes (e.g., Fixes #000) -->
fixes  4.1.4 issue in E2E https://github.ibm.com/IBMa/E2E/issues/6502

### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
- Check that help displays correctly & link functions correctly
Should look like this:
![Screenshot 2024-06-06 at 10 52 37 AM](https://github.com/IBMa/equal-access/assets/16193609/f4c1ef8e-9cc8-474f-ad18-e4cd57a31897)



### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.

<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->