### PR TITLE
fixrule(`input_label_visible, input_placeholder_label_visible, input_checkboxes_grouped`): tight the scopes of the rules

### DIFF
--- a/accessibility-checker-engine/src/v4/rules/input_checkboxes_grouped.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_checkboxes_grouped.ts
@@ -20,46 +20,46 @@ import { VisUtil } from "../../v2/dom/VisUtil";
 
 export let input_checkboxes_grouped: Rule = {
     id: "input_checkboxes_grouped",
-    context: "dom:input",
+    context: "dom:input[type=radio], dom:input[type=checkbox]",
     refactor: {
         "WCAG20_Input_RadioChkInFieldSet": {
-            "Pass_LoneNogroup": "Pass_LoneNogroup",
-            "Pass_Grouped": "Pass_Grouped",
-            "Pass_RadioNoName": "Pass_RadioNoName",
-            "Fail_ControlNameMismatch": "Fail_ControlNameMismatch",
-            "Fail_NotGroupedOtherGrouped": "Fail_NotGroupedOtherGrouped",
-            "Fail_NotGroupedOtherNotGrouped": "Fail_NotGroupedOtherNotGrouped",
-            "Fail_NotSameGroup": "Fail_NotSameGroup",
-            "Potential_LoneCheckbox": "Potential_LoneCheckbox",
-            "Potential_UnnamedCheckbox": "Potential_UnnamedCheckbox"
+            "Pass_LoneNogroup": "pass_lonenogroup",
+            "Pass_Grouped": "pass_grouped",
+            "Pass_RadioNoName": "pass_radioNoName",
+            "Fail_ControlNameMismatch": "fail_controlnamemismatch",
+            "Fail_NotGroupedOtherGrouped": "fail_notgroupedothergrouped",
+            "Fail_NotGroupedOtherNotGrouped": "fail_notgroupedothernotgrouped",
+            "Fail_NotSameGroup": "fail_notsamegroup",
+            "Potential_LoneCheckbox": "potential_lonecheckbox",
+            "Potential_UnnamedCheckbox": "potential_unnamedcheckbox"
         }
     },
     help: {
         "en-US": {
             "group": "input_checkboxes_grouped.html",
-            "Pass_LoneNogroup": "input_checkboxes_grouped.html",
-            "Pass_Grouped": "input_checkboxes_grouped.html",
-            "Pass_RadioNoName": "input_checkboxes_grouped.html",
-            "Fail_ControlNameMismatch": "input_checkboxes_grouped.html",
-            "Fail_NotGroupedOtherGrouped": "input_checkboxes_grouped.html",
-            "Fail_NotGroupedOtherNotGrouped": "input_checkboxes_grouped.html",
-            "Fail_NotSameGroup": "input_checkboxes_grouped.html",
-            "Potential_LoneCheckbox": "input_checkboxes_grouped.html",
-            "Potential_UnnamedCheckbox": "input_checkboxes_grouped.html"
+            "pass_lonenogroup": "input_checkboxes_grouped.html",
+            "pass_grouped": "input_checkboxes_grouped.html",
+            "pass_radiononame": "input_checkboxes_grouped.html",
+            "fail_controlnamemismatch": "input_checkboxes_grouped.html",
+            "fail_notgroupedothergrouped": "input_checkboxes_grouped.html",
+            "fail_notgroupedothernotgrouped": "input_checkboxes_grouped.html",
+            "fail_notsamegroup": "input_checkboxes_grouped.html",
+            "potential_lonecheckbox": "input_checkboxes_grouped.html",
+            "potential_unnamedcheckbox": "input_checkboxes_grouped.html"
         }
     },
     messages: {
         "en-US": {
             "group": "Related sets of radio buttons or checkboxes should be programmatically grouped",
-            "Pass_LoneNogroup": "{0} grouping not required for a control of this type",
-            "Pass_Grouped": "{0} input is grouped with other related controls with the same name",
-            "Pass_RadioNoName": "Radio input is not grouped, but passes because it has no name to group with other radio inputs",
-            "Fail_ControlNameMismatch": "{0} input found that has the same name, \"{2}\" as a {1} input",
-            "Fail_NotGroupedOtherGrouped": "{0} input is not in the group with another {0} with the name \"{1}\"",
-            "Fail_NotGroupedOtherNotGrouped": "{0} input and others with the name \"{1}\" are not grouped together",
-            "Fail_NotSameGroup": "{0} input is in a different group than another {0} with the name \"{1}\"",
-            "Potential_LoneCheckbox": "Verify that this ungrouped checkbox input is not related to other checkboxes",
-            "Potential_UnnamedCheckbox": "Verify that this un-named, ungrouped checkbox input is not related to other checkboxes"
+            "pass_lonenogroup": "{0} grouping not required for a control of this type",
+            "pass_grouped": "{0} input is grouped with other related controls with the same name",
+            "pass_radiononame": "Radio input is not grouped, but passes because it has no name to group with other radio inputs",
+            "fail_controlnamemismatch": "{0} input found that has the same name, \"{2}\" as a {1} input",
+            "fail_notgroupedothergrouped": "{0} input is not in the group with another {0} with the name \"{1}\"",
+            "fail_notgroupedothernotgrouped": "{0} input and others with the name \"{1}\" are not grouped together",
+            "fail_notsamegroup": "{0} input is in a different group than another {0} with the name \"{1}\"",
+            "potential_lonecheckbox": "Verify that this ungrouped checkbox input is not related to other checkboxes",
+            "potential_unnamedcheckbox": "Verify that this un-named, ungrouped checkbox input is not related to other checkboxes"
         }
     },
     rulesets: [{
@@ -71,7 +71,9 @@ export let input_checkboxes_grouped: Rule = {
     act: [],
     run: (context: RuleContext, options?: {}, contextHierarchies?: RuleContextHierarchy): RuleResult | RuleResult[] => {
         const ruleContext = context["dom"].node as Element;
-        if (context["aria"].role === 'none' || context["aria"].role === 'presentation') return null;
+        
+        //skip the rule
+        if (VisUtil.isNodeHiddenFromAT(ruleContext)) return null;
 
         const getGroup = (e: Element) => {
             let retVal = RPTUtil.getAncestor(e, "fieldset")
@@ -89,11 +91,8 @@ export let input_checkboxes_grouped: Rule = {
         }
 
         // Only radio buttons and checkboxes are in scope
-        let ctxType = ruleContext.hasAttribute("type") ? ruleContext.getAttribute("type").toLowerCase() : "text";
-        if (ctxType !== "checkbox" && ctxType !== "radio") {
-            return null;
-        }
-
+        let ctxType = ruleContext.getAttribute("type").toLowerCase();
+        
         // Determine which form we're in (if any) to determine our scope
         let ctxForm = RPTUtil.getAncestorWithRole(ruleContext, "form")
             || RPTUtil.getAncestor(ruleContext, "html")
@@ -172,20 +171,20 @@ export let input_checkboxes_grouped: Rule = {
             if (ctxType === "Radio") {
                 // Radios without names don't act like groups, so don't enforce grouping
                 if (ctxGroup === null) {
-                    return RulePass("Pass_RadioNoName", [ctxType]);
+                    return RulePass("pass_radiononame", [ctxType]);
                 } else {
-                    return RulePass("Pass_Grouped", [ctxType]);
+                    return RulePass("pass_grouped", [ctxType]);
                 }
             } else {
                 // Must be an unnamed checkbox
                 if (ctxGroup === null) {
                     if ((formCache.checkboxByName[""] || []).length > 1) {
-                        return RulePotential("Potential_UnnamedCheckbox", [ctxType]);
+                        return RulePotential("potential_unnamedcheckbox", [ctxType]);
                     } else {
-                        return RulePass("Pass_LoneNogroup", [ctxType]);
+                        return RulePass("pass_lonenogroup", [ctxType]);
                     }
                 } else {
-                    return RulePass("Pass_Grouped", [ctxType]);
+                    return RulePass("pass_grouped", [ctxType]);
                 }
             }
         } else {
@@ -195,40 +194,40 @@ export let input_checkboxes_grouped: Rule = {
             // Capitalize the input type for messages
             if (numRadiosWithName > 0 && numCheckboxesWithName > 0) {
                 // We have a naming mismatch between different controls
-                return RuleFail("Fail_ControlNameMismatch", [ctxType, ctxType === "checkbox" ? "radio" : "checkbox", ctxName]);
+                return RuleFail("fail_controlnamemismatch", [ctxType, ctxType === "checkbox" ? "radio" : "checkbox", ctxName]);
             } else if (ctxType === "Radio" && (formCache.numRadios === 1 || numRadiosWithName === 1)
                 || ctxType === "Checkbox" && formCache.numCheckboxes === 1) {
                 // This is a lone control (either only control of this type on the page, or a radio button without any others by that name)
                 // We pass this control in all cases
                 if (ctxGroup === null) {
-                    return RulePass("Pass_LoneNogroup", [ctxType]);
+                    return RulePass("pass_lonenogroup", [ctxType]);
                 } else {
-                    return RulePass("Pass_Grouped", [ctxType]);
+                    return RulePass("pass_grouped", [ctxType]);
                 }
             } else if (ctxType === "Checkbox" && formCache.numCheckboxes > 1 && numCheckboxesWithName === 1) {
                 // We have only one checkbox with this name, but there are other checkboxes in the form.
                 // If we're not grouped, ask them to examine it
                 if (ctxGroup === null) {
-                    return RulePotential("Potential_LoneCheckbox", [ctxType]);
+                    return RulePotential("potential_lonecheckbox", [ctxType]);
                 } else {
-                    return RulePass("Pass_Grouped", [ctxType]);
+                    return RulePass("pass_grouped", [ctxType]);
                 }
             } else {
                 // We share a name with another similar control. Are we grouped together?
                 if (ctxGroup === null) {
                     if (formCache.nameToGroup[ctxName] !== null) {
                         // We're not grouped, but some control with the same name is in a group
-                        return RuleFail("Fail_NotGroupedOtherGrouped", [ctxType, ctxName]);
+                        return RuleFail("fail_notgroupedothergrouped", [ctxType, ctxName]);
                     } else {
                         // None of us are grouped
-                        return RuleFail("Fail_NotGroupedOtherNotGrouped", [ctxType, ctxName])
+                        return RuleFail("fail_notgroupedothernotgrouped", [ctxType, ctxName])
                     }
                 } else if (formCache.nameToGroup[ctxName] !== ctxGroup) {
                     // We're not in the main group with the others
-                    return RuleFail("Fail_NotSameGroup", [ctxType, ctxName]);
+                    return RuleFail("fail_notsamegroup", [ctxType, ctxName]);
                 } else {
                     // We're all grouped up!
-                    return RulePass("Pass_Grouped", [ctxType]);
+                    return RulePass("pass_grouped", [ctxType]);
                 }
             }
         }

--- a/accessibility-checker-engine/src/v4/rules/input_label_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_label_visible.ts
@@ -11,7 +11,7 @@
   limitations under the License.
 *****************************************************************************/
 
-import { Rule, RuleResult, RuleFail, RuleContext, RulePotential, RuleManual, RulePass, RuleContextHierarchy } from "../api/IRule";
+import { Rule, RuleResult, RuleContext, RulePotential, RulePass, RuleContextHierarchy } from "../api/IRule";
 import { eRulePolicy, eToolkitLevel } from "../api/IRule";
 import { RPTUtil } from "../../v2/checker/accessibility/util/legacy";
 import { FragmentUtil } from "../../v2/checker/accessibility/util/fragment";
@@ -20,24 +20,28 @@ import { DOMUtil } from "../../v2/dom/DOMUtil";
 
 export let input_label_visible: Rule = {
     id: "input_label_visible",
-    context: "aria:button,aria:checkbox,aria:combobox,aria:listbox,aria:menuitemcheckbox,aria:menuitemradio,aria:radio,aria:searchbox,aria:slider,aria:spinbutton,aria:switch,aria:textbox,aria:progressbar,dom:input[type=file],dom:output",
+    context: "aria:button,aria:checkbox,aria:combobox,aria:listbox,aria:menuitemcheckbox,aria:menuitemradio,aria:radio,aria:searchbox,aria:slider,aria:spinbutton,aria:switch,aria:textbox",
     dependencies: ["input_label_exists"],
     refactor: {
         "WCAG20_Input_VisibleLabel": {
-            "Pass_0": "Pass_0",
-            "Potential_1": "Potential_1"}
+            "Pass_0": "pass",
+            "Potential_1": "potential_no_label",
+            "potential_placeholder_only": "potential_placeholder_only"
+        }
     },
     help: {
         "en-US": {
-            "Pass_0": "input_label_visible.html",
-            "Potential_1": "input_label_visible.html",
+            "pass": "input_label_visible.html",
+            "potential_placeholder_only": "input_label_visible.html",
+            "potential_no_label": "input_label_visible.html",
             "group": "input_label_visible.html"
         }
     },
     messages: {
         "en-US": {
-            "Pass_0": "Rule Passed",
-            "Potential_1": "The input element does not have an associated visible label",
+            "pass": "The input element has an associated visible label",
+            "potential_placeholder_only": "The ‘placeholder’ is the only visible label",
+            "potential_no_label": "The input element does not have an associated visible label",
             "group": "An input element must have an associated visible label"
         }
     },
@@ -56,10 +60,12 @@ export let input_label_visible: Rule = {
         if (nodeName === 'datalist')
             return null;
 
-        if (!VisUtil.isNodeVisible(ruleContext) ||
-            RPTUtil.isNodeDisabled(ruleContext)) {
+        if (!VisUtil.isNodeVisible(ruleContext) || RPTUtil.isNodeDisabled(ruleContext))
             return null;
-        }
+        
+        // if a control is in a table cell, the col headers can act as visible label, which is checked in table heading rule
+        if (RPTUtil.getAncestor(ruleContext, "table"))
+            return null;
 
         // when in a combobox, only look at the input textbox.
         if (RPTUtil.getAncestorWithRole(ruleContext, "combobox") &&
@@ -88,73 +94,50 @@ export let input_label_visible: Rule = {
             }
         }
 
-        // Determine the input type
-        let passed = true;
-
-        let type = "text";
-        if (nodeName == "input" && ruleContext.hasAttribute("type")) {
-            type = ruleContext.getAttribute("type").toLowerCase();
-        } else if (nodeName === "button" || RPTUtil.hasRoleInSemantics(ruleContext, "button")) {
-            type = "buttonelem";
-        }
-        if (nodeName == "input" && type == "") {
-            type = "text";
+        //let passed = false;
+        // first check visible label for input or button
+        if (nodeName === "input" || nodeName === "button") {
+            if (RPTUtil.hasImplicitLabel(ruleContext))
+                return RulePass("pass");
+            
+            let label = RPTUtil.getLabelForElement(ruleContext);
+            if (label && RPTUtil.hasInnerContentHidden(label))
+                return RulePass("pass");     
         }
 
-        let textTypes = ["text", "file", "password",
-            "checkbox", "radio",
-            "search", "tel", "url", "email",
-            "date", "number", "range",
-            "time", "color",
-            "month", "week", "datetime-local"];
-        let buttonTypes = ["button", "reset", "submit"];
-        let buttonTypesWithDefaults = ["reset", "submit"]; // 'submit' and 'reset' have visible defaults.
-        if (textTypes.indexOf(type) !== -1) { // If type is in the list
-            // Get only the non-hidden labels for element, in the case that an label is hidden then it is a violation
-            let labelElem = RPTUtil.getLabelForElementHidden(ruleContext, true);
-            passed = (labelElem != null && RPTUtil.hasInnerContentHidden(labelElem)) ||
-                RPTUtil.hasImplicitLabel(ruleContext) ||
-                type === "file"; // input type=file has a visible default.
-        } else if (buttonTypes.indexOf(type) !== -1 || type == "buttonelem") {
-            // Buttons are not in scope for this success criteria (IBMa/equal-access#204)
-            return null;
+        // buttons are not in scope for this success criteria (IBMa/equal-access#204) if it is not associated with data entry
+        if (nodeName === "button" || (nodeName === "input" && ruleContext.hasAttribute("type") && ruleContext.getAttribute("type").toLowerCase() !== 'button')) {
+            if (!RPTUtil.getAncestor(ruleContext, "form"))
+                return null;
         }
 
+        // check if an alternative tooltip exists that can be made visible through mouseover
+        if (RPTUtil.attributeNonEmpty(ruleContext, "title"))
+            return RulePass("pass"); 
+        
         // check if there is a visible label pointed to by the aria-labelledby attribute.
-        if (!passed && RPTUtil.attributeNonEmpty(ruleContext, "aria-labelledby")) {
+        if (RPTUtil.attributeNonEmpty(ruleContext, "aria-labelledby")) {
             let theLabel = ruleContext.getAttribute("aria-labelledby");
             let labelValues = theLabel.split(/\s+/);
             for (let j = 0; j < labelValues.length; ++j) {
                 let elementById = FragmentUtil.getById(ruleContext, labelValues[j]);
                 if (elementById && !DOMUtil.sameNode(elementById, ruleContext) && VisUtil.isNodeVisible(elementById) && RPTUtil.hasInnerContentHidden(elementById)) {
-                    passed = true;
-                    break;
+                    return RulePass("pass"); 
                 }
             }
         }
 
-        if (!passed && nodeName == "optgroup") {
-            passed = RPTUtil.attributeNonEmpty(ruleContext, "label");
-        }
-        if (!passed && nodeName == "option") {
-            passed = RPTUtil.attributeNonEmpty(ruleContext, "label") || ruleContext.innerHTML.trim().length > 0;
-        }
-
-        // One last check for roles that support name from content
-        if (!passed) {
-            // list from https://www.w3.org/TR/wai-aria-1.1/#namefromcontent
-            let rolesWithNameFromContent = ["button", "cell", "checkbox", "columnheader", "gridcell", "heading", "link",
-                "menuitem", "menuitemcheckbox", "menuitemradio", "option", "radio", "row",
-                "rowgroup", "rowheader", "switch", "tab", "tooltip",/*"tree",*/"treeitem"];
-            //get attribute roles as well as implicit roles.
-            let roles = RPTUtil.getRoles(ruleContext, true);
-            for (let i = 0; i < roles.length; i++) {
-                if (rolesWithNameFromContent.indexOf(roles[i]) !== -1) {
-                    passed = RPTUtil.hasInnerContentHidden(ruleContext);
-                    break;
-                }
-            }
-        }
+        if (nodeName === "optgroup" && RPTUtil.attributeNonEmpty(ruleContext, "label"))
+            return RulePass("pass");
+        
+        if (nodeName == "option" && (RPTUtil.attributeNonEmpty(ruleContext, "label") || ruleContext.innerHTML.trim().length > 0))
+            return RulePass("pass");
+        
+        // check if any visible text from the control. 
+        // note that (1) the text doesn’t need to be associated with the control to form a relationship
+        //  and (2) the text doesn't need to follow accessible name requirement (e.g. name from)
+        if (RPTUtil.hasInnerContentHidden(ruleContext))
+            return RulePass("pass");
 
         // Determine if this is referenced by a combobox. If so, the label belongs to the combobox
         let id = ruleContext.getAttribute("id");
@@ -164,10 +147,10 @@ export let input_label_visible: Rule = {
             }
         }
 
-        if (passed) {
-            return RulePass("Pass_0");
-        } else {
-            return RulePotential("Potential_1");
-        }
+        // check if a placeholder exists even though a placeholder text is not sufficient as a visible text
+        if (RPTUtil.attributeNonEmpty(ruleContext, "placeholder"))
+            return RulePotential("potential_placeholder_only");
+
+        return RulePotential("potential_no_label");
     }
 }

--- a/accessibility-checker-engine/src/v4/rules/input_label_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_label_visible.ts
@@ -94,8 +94,18 @@ export let input_label_visible: Rule = {
             }
         }
 
-        //let passed = false;
-        // first check visible label for input or button
+        // buttons are not in scope for this success criteria (IBMa/equal-access#204) if it is not associated with data entry
+        let role = RPTUtil.getResolvedRole(ruleContext);
+        if (role && role === "button") {
+            //submit type of input has a visible label 'Submit' by default
+            if (nodeName === 'input' && ruleContext.hasAttribute("type") && ruleContext.getAttribute("type").toLowerCase() === 'submit')
+                return null;
+            // likely not associated with data entry
+            if (!RPTUtil.getAncestor(ruleContext, "form"))
+                return null;
+        }
+
+        // check visible label for input or button
         if (nodeName === "input" || nodeName === "button") {
             if (RPTUtil.hasImplicitLabel(ruleContext))
                 return RulePass("pass");
@@ -103,12 +113,6 @@ export let input_label_visible: Rule = {
             let label = RPTUtil.getLabelForElement(ruleContext);
             if (label && RPTUtil.hasInnerContentHidden(label))
                 return RulePass("pass");     
-        }
-
-        // buttons are not in scope for this success criteria (IBMa/equal-access#204) if it is not associated with data entry
-        if (nodeName === "button" || (nodeName === "input" && ruleContext.hasAttribute("type") && ruleContext.getAttribute("type").toLowerCase() !== 'button')) {
-            if (!RPTUtil.getAncestor(ruleContext, "form"))
-                return null;
         }
 
         // check if an alternative tooltip exists that can be made visible through mouseover
@@ -135,8 +139,8 @@ export let input_label_visible: Rule = {
         
         // check if any visible text from the control. 
         // note that (1) the text doesn’t need to be associated with the control to form a relationship
-        //  and (2) the text doesn't need to follow accessible name requirement (e.g. name from)
-        if (RPTUtil.hasInnerContentHidden(ruleContext))
+        //  and (2) the text doesn't need to follow accessible name requirement (e.g. nameFrom)
+        if (!RPTUtil.isInnerTextEmpty(ruleContext))
             return RulePass("pass");
 
         // Determine if this is referenced by a combobox. If so, the label belongs to the combobox

--- a/accessibility-checker-engine/src/v4/rules/input_placeholder_label_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_placeholder_label_visible.ts
@@ -39,12 +39,16 @@ export let input_placeholder_label_visible: Rule = {
             "group": "HTML5 'placeholder' attribute must not be used as a visible label replacement"
         }
     },
+    /**
+     * merge the rule into input_label_visible
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
         "num": ["3.3.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],
+    */
+    rulesets: [],
     act: [],
     run: (context: RuleContext, options?: {}, contextHierarchies?: RuleContextHierarchy): RuleResult | RuleResult[] => {
         const ruleContext = context["dom"].node as Element;

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/Lonecheckbox.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/Lonecheckbox.html
@@ -119,7 +119,7 @@
                         "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[2]/div[1]/span[1]/div[1]/input[1]",
                         "aria": "/document[1]/main[1]/form[1]/checkbox[1]"
                     },
-                    "reasonId": "Potential_LoneCheckbox",
+                    "reasonId": "potential_lonecheckbox",
                     "message": "Verify that this ungrouped checkbox input is not related to other checkboxes",
                     "messageArgs": [
                         "Checkbox"
@@ -137,7 +137,7 @@
                         "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[1]/div[1]/span[1]/div[1]/input[1]",
                         "aria": "/document[1]/main[1]/form[1]/group[1]/checkbox[1]"
                     },
-                    "reasonId": "Pass_Grouped",
+                    "reasonId": "pass_grouped",
                     "message": "Checkbox input is grouped with other related controls with the same name",
                     "messageArgs": [
                         "Checkbox"
@@ -155,7 +155,7 @@
                         "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[2]/div[1]/span[1]/div[1]/input[1]",
                         "aria": "/document[1]/main[1]/form[1]/group[1]/checkbox[2]"
                     },
-                    "reasonId": "Pass_Grouped",
+                    "reasonId": "pass_grouped",
                     "message": "Checkbox input is grouped with other related controls with the same name",
                     "messageArgs": [
                         "Checkbox"
@@ -173,7 +173,7 @@
                         "dom": "/html[1]/body[1]/main[1]/form[1]/div[1]/div[3]/div[1]/fieldset[1]/div[2]/div[3]/div[1]/span[1]/div[1]/input[1]",
                         "aria": "/document[1]/main[1]/form[1]/group[1]/checkbox[3]"
                     },
-                    "reasonId": "Pass_Grouped",
+                    "reasonId": "pass_grouped",
                     "message": "Checkbox input is grouped with other related controls with the same name",
                     "messageArgs": [
                         "Checkbox"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/RadioInGrid.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/RadioInGrid.html
@@ -181,7 +181,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/input[1]",
               "aria": "/document[1]/main[1]/grid[1]/radio[1]"
             },
-            "reasonId": "Pass_Grouped",
+            "reasonId": "pass_grouped",
             "message": "Radio input is grouped with other related controls with the same name",
             "messageArgs": [
               "Radio"
@@ -199,7 +199,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/input[2]",
               "aria": "/document[1]/main[1]/grid[1]/radio[2]"
             },
-            "reasonId": "Pass_Grouped",
+            "reasonId": "pass_grouped",
             "message": "Radio input is grouped with other related controls with the same name",
             "messageArgs": [
               "Radio"
@@ -217,7 +217,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/input[3]",
               "aria": "/document[1]/main[1]/grid[1]/radio[3]"
             },
-            "reasonId": "Pass_Grouped",
+            "reasonId": "pass_grouped",
             "message": "Radio input is grouped with other related controls with the same name",
             "messageArgs": [
               "Radio"
@@ -235,7 +235,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/input[4]",
               "aria": "/document[1]/main[1]/grid[1]/radio[4]"
             },
-            "reasonId": "Pass_Grouped",
+            "reasonId": "pass_grouped",
             "message": "Radio input is grouped with other related controls with the same name",
             "messageArgs": [
               "Radio"
@@ -253,7 +253,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/input[5]",
               "aria": "/document[1]/main[1]/grid[1]/radio[5]"
             },
-            "reasonId": "Pass_Grouped",
+            "reasonId": "pass_grouped",
             "message": "Radio input is grouped with other related controls with the same name",
             "messageArgs": [
               "Radio"
@@ -271,7 +271,7 @@
               "dom": "/html[1]/body[1]/main[1]/div[1]/input[6]",
               "aria": "/document[1]/main[1]/grid[1]/radio[6]"
             },
-            "reasonId": "Pass_Grouped",
+            "reasonId": "pass_grouped",
             "message": "Radio input is grouped with other related controls with the same name",
             "messageArgs": [
               "Radio"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/checkbox_groups.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/checkbox_groups.html
@@ -1,0 +1,487 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text with Purple and Pink Colors</title>
+  </head>
+  <body>
+  
+    <fieldset>
+      <legend> fieldset for checkboxes with same name (preferred for form submission)</legend>
+        <p><label> <input type=checkbox name="topping" value="bacon"> Bacon </label></p>
+        <p><label> <input type=checkbox name="topping" value="cheese"> Extra Cheese </label></p>
+        <p><label> <input type=checkbox name="topping" value="onion"> Onion </label></p>
+        <p><label> <input type=checkbox name="topping" value="mushroom"> Mushroom </label></p>
+    </fieldset>
+
+    <fieldset>
+      <legend> fieldset for checkboxes with different names </legend>
+        <p><label> <input type=checkbox name="bacon" value="bacon"> Bacon </label></p>
+        <p><label> <input type=checkbox name="cheese" value="cheese"> Extra Cheese </label></p>
+        <p><label> <input type=checkbox name="onion" value="onion"> Onion </label></p>
+        <p><label> <input type=checkbox name="mushroom" value="mushroom"> Mushroom </label></p>
+    </fieldset>
+
+    <fieldset>
+      <legend> fieldset for checkboxes with no name (Carbon pattern)</legend>
+        <p><label> <input type=checkbox value="apple"> Apple </label></p>
+        <p><label> <input type=checkbox value="pear"> Pear </label></p>
+        <p><label> <input type=checkbox value="strawberry"> Strawberry </label></p>
+    </fieldset>
+
+    <div id="desc2">group for checkboxes with no name </div>
+    <div role='group' aria-labelledby="desc2">
+        <p><label> <input type=checkbox value="apple"> Apple </label></p>
+        <p><label> <input type=checkbox value="pear"> Pear </label></p>
+        <p><label> <input type=checkbox value="strawberry"> Strawberry </label></p>
+    </div>
+
+    <div id="desc3">list for checkboxes with the same name </div>
+    <ul aria-labelledby="desc3">
+        <li> <input type=checkbox name='fruit' value="apple"> Apple </li>
+        <li> <input type=checkbox name='fruit' value="pear"> Pear </li>
+        <li><input type=checkbox name='fruit' value="strawberry"> Strawberry </li>
+    </ul>
+
+    <div id="desc4">list for checkboxes with different names </div>
+    <ul aria-labelledby="desc4">
+        <li> <input type=checkbox name='apple' value="apple"> Apple </li>
+        <li> <input type=checkbox name='pear' value="pear"> Pear </li>
+        <li><input type=checkbox name='strawberry' value="strawberry"> Strawberry </li>
+    </ul>
+
+    <div id="desc5">list for checkboxes with no name (IBM cloud pattern)</div>
+    <ul aria-labelledby="desc5">
+        <li> <input type=checkbox value="apple"> Apple </li>
+        <li> <input type=checkbox value="pear"> Pear </li>
+        <li><input type=checkbox value="strawberry"> Strawberry </li>
+    </ul>
+
+  </body>
+  <script>
+    UnitTest = {
+      ruleIds: ["input_checkboxes_grouped"],
+      results: [
+      {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[1]/p[1]/label[1]/input[1]",
+              "aria": "/document[1]/group[1]/paragraph[1]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[1]/p[2]/label[1]/input[1]",
+              "aria": "/document[1]/group[1]/paragraph[2]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[1]/p[3]/label[1]/input[1]",
+              "aria": "/document[1]/group[1]/paragraph[3]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[1]/p[4]/label[1]/input[1]",
+              "aria": "/document[1]/group[1]/paragraph[4]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[2]/p[1]/label[1]/input[1]",
+              "aria": "/document[1]/group[2]/paragraph[1]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[2]/p[2]/label[1]/input[1]",
+              "aria": "/document[1]/group[2]/paragraph[2]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[2]/p[3]/label[1]/input[1]",
+              "aria": "/document[1]/group[2]/paragraph[3]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[2]/p[4]/label[1]/input[1]",
+              "aria": "/document[1]/group[2]/paragraph[4]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[3]/p[1]/label[1]/input[1]",
+              "aria": "/document[1]/group[3]/paragraph[1]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[3]/p[2]/label[1]/input[1]",
+              "aria": "/document[1]/group[3]/paragraph[2]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/fieldset[3]/p[3]/label[1]/input[1]",
+              "aria": "/document[1]/group[3]/paragraph[3]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[2]/p[1]/label[1]/input[1]",
+              "aria": "/document[1]/group[4]/paragraph[1]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[2]/p[2]/label[1]/input[1]",
+              "aria": "/document[1]/group[4]/paragraph[2]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/div[2]/p[3]/label[1]/input[1]",
+              "aria": "/document[1]/group[4]/paragraph[3]/checkbox[1]"
+            },
+            "reasonId": "pass_grouped",
+            "message": "Checkbox input is grouped with other related controls with the same name",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/ul[1]/li[1]/input[1]",
+              "aria": "/document[1]/list[1]/listitem[1]/checkbox[1]"
+            },
+            "reasonId": "fail_notgroupedothernotgrouped",
+            "message": "Checkbox input and others with the name \"fruit\" are not grouped together",
+            "messageArgs": [
+              "Checkbox",
+              "fruit"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/ul[1]/li[2]/input[1]",
+              "aria": "/document[1]/list[1]/listitem[2]/checkbox[1]"
+            },
+            "reasonId": "fail_notgroupedothernotgrouped",
+            "message": "Checkbox input and others with the name \"fruit\" are not grouped together",
+            "messageArgs": [
+              "Checkbox",
+              "fruit"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "FAIL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/ul[1]/li[3]/input[1]",
+              "aria": "/document[1]/list[1]/listitem[3]/checkbox[1]"
+            },
+            "reasonId": "fail_notgroupedothernotgrouped",
+            "message": "Checkbox input and others with the name \"fruit\" are not grouped together",
+            "messageArgs": [
+              "Checkbox",
+              "fruit"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/ul[2]/li[1]/input[1]",
+              "aria": "/document[1]/list[2]/listitem[1]/checkbox[1]"
+            },
+            "reasonId": "potential_lonecheckbox",
+            "message": "Verify that this ungrouped checkbox input is not related to other checkboxes",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/ul[2]/li[2]/input[1]",
+              "aria": "/document[1]/list[2]/listitem[2]/checkbox[1]"
+            },
+            "reasonId": "potential_lonecheckbox",
+            "message": "Verify that this ungrouped checkbox input is not related to other checkboxes",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/ul[2]/li[3]/input[1]",
+              "aria": "/document[1]/list[2]/listitem[3]/checkbox[1]"
+            },
+            "reasonId": "potential_lonecheckbox",
+            "message": "Verify that this ungrouped checkbox input is not related to other checkboxes",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/ul[3]/li[1]/input[1]",
+              "aria": "/document[1]/list[3]/listitem[1]/checkbox[1]"
+            },
+            "reasonId": "potential_unnamedcheckbox",
+            "message": "Verify that this un-named, ungrouped checkbox input is not related to other checkboxes",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/ul[3]/li[2]/input[1]",
+              "aria": "/document[1]/list[3]/listitem[2]/checkbox[1]"
+            },
+            "reasonId": "potential_unnamedcheckbox",
+            "message": "Verify that this un-named, ungrouped checkbox input is not related to other checkboxes",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_checkboxes_grouped",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/ul[3]/li[3]/input[1]",
+              "aria": "/document[1]/list[3]/listitem[3]/checkbox[1]"
+            },
+            "reasonId": "potential_unnamedcheckbox",
+            "message": "Verify that this un-named, ungrouped checkbox input is not related to other checkboxes",
+            "messageArgs": [
+              "Checkbox"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+      ]
+    };
+  </script>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/shadow.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/shadow.html
@@ -48,7 +48,7 @@
               "dom": "/html[1]/body[1]/main[1]/my-radio[1]/#document-fragment[1]/input[1]",
               "aria": "/document[1]/main[1]/radio[1]"
             },
-            "reasonId": "Fail_NotGroupedOtherNotGrouped",
+            "reasonId": "fail_notgroupedothernotgrouped",
             "message": "Radio input and others with the name \"test\" are not grouped together",
             "messageArgs": [
               "Radio",
@@ -67,7 +67,7 @@
               "dom": "/html[1]/body[1]/main[1]/my-radio[2]/#document-fragment[1]/input[1]",
               "aria": "/document[1]/main[1]/radio[2]"
             },
-            "reasonId": "Fail_NotGroupedOtherNotGrouped",
+            "reasonId": "fail_notgroupedothernotgrouped",
             "message": "Radio input and others with the name \"test\" are not grouped together",
             "messageArgs": [
               "Radio",

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/shadow2.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_checkboxes_grouped_ruleunit/shadow2.html
@@ -55,7 +55,7 @@
                         "dom": "/html[1]/body[1]/main[1]/fieldset[1]/my-radio[1]/#document-fragment[1]/input[1]",
                         "aria": "/document[1]/main[1]/group[1]/radio[1]"
                     },
-                    "reasonId": "Pass_Grouped",
+                    "reasonId": "pass_grouped",
                     "message": "Radio input is grouped with other related controls with the same name",
                     "messageArgs": [
                         "Radio"
@@ -73,7 +73,7 @@
                         "dom": "/html[1]/body[1]/main[1]/fieldset[1]/my-radio[2]/#document-fragment[1]/input[1]",
                         "aria": "/document[1]/main[1]/group[1]/radio[2]"
                     },
-                    "reasonId": "Pass_Grouped",
+                    "reasonId": "pass_grouped",
                     "message": "Radio input is grouped with other related controls with the same name",
                     "messageArgs": [
                         "Radio"

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/InputPlaceholder.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/InputPlaceholder.html
@@ -41,5 +41,19 @@
 <br>
 <div id="exchange">Enter your 3 digit phone exchange</div>
 <input type="text" placeholder="3 digit phone exchange" name="num2" aria-labelledby="exchange"/>
-</body>
+<script type="text/javascript">
+  if (typeof(OpenAjax) == 'undefined') OpenAjax = {}
+  if (typeof(OpenAjax.a11y) == 'undefined') OpenAjax.a11y = {}
+  OpenAjax.a11y.ruleCoverage = [
+    {
+      ruleId: "1145",
+      passedXpaths: [
+      ],
+      failedXpaths: [
+        "/html/body/input[1]",
+        "/html/body/input[2]"
+      ]
+    }
+  ];
+</script></body>
 </html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/elements_visible_label.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/elements_visible_label.html
@@ -33,57 +33,63 @@
     </table>
 
     <hr style="margin: 20px;">
-    <div>false positive: progress doesn't take user input</div>
+    <div>progress doesn't take user input</div>
     <label>implicit Role: progressbar</label>
     <progress id="file" value="32" max="100"> 32% </progress>   
 
     <hr style="margin: 20px;">
-    <label for="myfile">File upload:</label>
-    <input type="file" id="myfile" name="myfile">
+    <label for="1">File upload:</label>
+    <input type="file" id="1" name="myfile">
 
     <hr style="margin: 20px;">
-    <div>false positive: output elelement doesn't take user input</div>
-    <label for="a">Number a:</label>
-    <input type="number" id="a" value="50">
-    <label for="b">Number b:</label>
-    +<input type="number" id="b" value="25">
+    <div>output elelement doesn't take user input</div>
+    <label for="2">Number a:</label>
+    <input type="number" id="2" value="50">
+    <label for="3">Number b:</label>
+    +<input type="number" id="3" value="25">
     =<output id='output' name="x" for="a b">{Updated value here as output}</output>
 
     
     <hr style="margin: 20px;">
      <div id="label">Pass: visible label is from aria-labelledby element</div>
-     <input type="text" name="input" aria-labelledby="label" placeholder="type a text">
+     <input id='4' type="text" name="input" aria-labelledby="label" placeholder="type a text">
     
 
     <hr style="margin: 20px;">
-    <div>Reported by placeholder rule because of aria-labelledby pointing to itself</div>
-    <input type="text" name="input" id='myinput' aria-labelledby="myinput" placeholder="type a text">
+    <div>The placeholder is the only visible label and the aria-labelledby pointing to itself</div>
+    <input type="text" name="input" id='5' aria-labelledby="5" placeholder="type a text">
     
     <hr style="margin: 20px;">
-    <div>Not reported by placeholder rule even though aria-labelledby element is hidden</div>
-    <div id="ainput" hidden>Text label defined in a hidden div: Not reported by placeholder rule</div>
-    <input type="text" name="input" id='yourinput' aria-labelledby="ainput" placeholder="type a text">
+    <div>The placeholder is the only visible label and the aria-labelledby element is hidden</div>
+    <div id="ainput" hidden>The hidden content</div>
+    <input type="text" name="input" id='6' aria-labelledby="ainput" placeholder="type a text">
 
     <hr style="margin: 20px;">
-    <div>Not reported by placeholder rule even though aria-labelledby doesn't exist</div>
-    <input type="text" name="input" id='yourinput' aria-labelledby="cinput" placeholder="type a text">
-     
-   <hr style="margin: 20px;">
-   <div>Not reported by placeholder rule</div>
-    <input type="text" placeholder="Email address" name="email">
+    <div>The placeholder is the only visible label and the aria-labelledby doesn't exist</div>
+    <input type="text" name="input" id='7' aria-labelledby="cinput" placeholder="type a text">
+   
+    <hr style="margin: 20px;">
+    <form method="post"> 
+        <div>The placeholder is the only visible label</div>
+        <input type="text" placeholder="Email address" name="email">
+
+        <button type="button" aria-label="submit"></button>
+    </form>
 
     <hr style="margin: 20px;">
-    <div>Reported by placeholder rule because of the coexistence of aria-label</div>
-    <input type="text" placeholder="Email address" aria-label='email address' name="email">
+    <form method="post">
+        <div>The placeholder is the only visible label</div>
+        <input type="text" placeholder="Email address" aria-label='email address' name="email">
+
+        <hr style="margin: 10px;">
+        <input type="submit" />
+    </form>
 
     <hr style="margin: 20px;">
-    <input type="button" aria-label="submit" />
+    <input id='8' type="button" />
 
     <hr style="margin: 20px;">
-    <button type="button" aria-label="submit"></button>
-
-    <hr style="margin: 20px;">
-    <input type="submit" />
+    <input id='9' type="submit" />
 
     <hr style="margin: 50px;">
   </body>
@@ -91,7 +97,150 @@
     UnitTest = {
       ruleIds: ["input_label_visible"],
       results: [
-        
+      {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/input[2]",
+              "aria": "/document[1]/spinbutton[1]"
+            },
+            "reasonId": "pass",
+            "message": "The input element has an associated visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/input[3]",
+              "aria": "/document[1]/spinbutton[2]"
+            },
+            "reasonId": "pass",
+            "message": "The input element has an associated visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/input[4]",
+              "aria": "/document[1]/textbox[1]"
+            },
+            "reasonId": "pass",
+            "message": "The input element has an associated visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/input[5]",
+              "aria": "/document[1]/textbox[2]"
+            },
+            "reasonId": "potential_placeholder_only",
+            "message": "The ‘placeholder’ is the only visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/input[6]",
+              "aria": "/document[1]/textbox[3]"
+            },
+            "reasonId": "potential_placeholder_only",
+            "message": "The ‘placeholder’ is the only visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/input[7]",
+              "aria": "/document[1]/textbox[4]"
+            },
+            "reasonId": "potential_placeholder_only",
+            "message": "The ‘placeholder’ is the only visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/form[1]/input[1]",
+              "aria": "/document[1]/form[1]/textbox[1]"
+            },
+            "reasonId": "potential_placeholder_only",
+            "message": "The ‘placeholder’ is the only visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/form[1]/button[1]",
+              "aria": "/document[1]/form[1]/button[1]"
+            },
+            "reasonId": "potential_no_label",
+            "message": "The input element does not have an associated visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/form[2]/input[1]",
+              "aria": "/document[1]/form[2]/textbox[1]"
+            },
+            "reasonId": "potential_placeholder_only",
+            "message": "The ‘placeholder’ is the only visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
       ]
     };
   </script>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/elements_visible_label.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/elements_visible_label.html
@@ -76,6 +76,15 @@
     <div>Reported by placeholder rule because of the coexistence of aria-label</div>
     <input type="text" placeholder="Email address" aria-label='email address' name="email">
 
+    <hr style="margin: 20px;">
+    <input type="button" aria-label="submit" />
+
+    <hr style="margin: 20px;">
+    <button type="button" aria-label="submit"></button>
+
+    <hr style="margin: 20px;">
+    <input type="submit" />
+
     <hr style="margin: 50px;">
   </body>
   <script>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/elements_visible_label.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/elements_visible_label.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Text with Purple and Pink Colors</title>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+
+  </head>
+  <body>
+  
+    <table aria-label="Example table">
+      <tr>
+        <th>Age</th>
+        <th>Gender</th>
+        <th>Years Worked</th>
+      </tr>
+      <tr>
+        <td><input type="text" placeholder="Enter your age" /></td>
+        <td>
+          <select>
+            <option value="male">Male</option>
+            <option value="female">Female</option>
+            <option value="other">Other</option>
+          </select>
+        </td>
+        <td>
+          <input type="text" placeholder="Enter number of years worked" />
+        </td>
+      </tr>
+    </table>
+
+    <hr style="margin: 20px;">
+    <div>false positive: progress doesn't take user input</div>
+    <label>implicit Role: progressbar</label>
+    <progress id="file" value="32" max="100"> 32% </progress>   
+
+    <hr style="margin: 20px;">
+    <label for="myfile">File upload:</label>
+    <input type="file" id="myfile" name="myfile">
+
+    <hr style="margin: 20px;">
+    <div>false positive: output elelement doesn't take user input</div>
+    <label for="a">Number a:</label>
+    <input type="number" id="a" value="50">
+    <label for="b">Number b:</label>
+    +<input type="number" id="b" value="25">
+    =<output id='output' name="x" for="a b">{Updated value here as output}</output>
+
+    
+    <hr style="margin: 20px;">
+     <div id="label">Pass: visible label is from aria-labelledby element</div>
+     <input type="text" name="input" aria-labelledby="label" placeholder="type a text">
+    
+
+    <hr style="margin: 20px;">
+    <div>Reported by placeholder rule because of aria-labelledby pointing to itself</div>
+    <input type="text" name="input" id='myinput' aria-labelledby="myinput" placeholder="type a text">
+    
+    <hr style="margin: 20px;">
+    <div>Not reported by placeholder rule even though aria-labelledby element is hidden</div>
+    <div id="ainput" hidden>Text label defined in a hidden div: Not reported by placeholder rule</div>
+    <input type="text" name="input" id='yourinput' aria-labelledby="ainput" placeholder="type a text">
+
+    <hr style="margin: 20px;">
+    <div>Not reported by placeholder rule even though aria-labelledby doesn't exist</div>
+    <input type="text" name="input" id='yourinput' aria-labelledby="cinput" placeholder="type a text">
+     
+   <hr style="margin: 20px;">
+   <div>Not reported by placeholder rule</div>
+    <input type="text" placeholder="Email address" name="email">
+
+    <hr style="margin: 20px;">
+    <div>Reported by placeholder rule because of the coexistence of aria-label</div>
+    <input type="text" placeholder="Email address" aria-label='email address' name="email">
+
+    <hr style="margin: 50px;">
+  </body>
+  <script>
+    UnitTest = {
+      ruleIds: ["input_label_visible"],
+      results: [
+        
+      ]
+    };
+  </script>
+</html>


### PR DESCRIPTION
<!-- For instructions regarding the PR title, see the bottom of the PR template -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: **input_label_visible, input_placeholder_label_visible, input_checkboxes_grouped**

### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with "Fixes" to close when the PR closes (e.g., Fixes #000) -->
 Fixes #1625
Fixes #1621
Fixes #1623

### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
- 

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [ ] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [ ] I understand that the title of this PR will be used for the next release notes.

<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->