### PR TITLE
fixrule(all rules): Rule help Requirement matches Requirement listing rule

### DIFF
--- a/accessibility-checker-engine/help-v4/en-US/application_content_accessible.html
+++ b/accessibility-checker-engine/help-v4/en-US/application_content_accessible.html
@@ -53,10 +53,11 @@ Therefore, to ensure access to any non-decorative static text or image content t
 
 ### What to do
 
-* Verify that the content is decorative;
-* **Or**, associate the content with a focusable element using the `aria-labelledby` or `aria-describedby` attribute;
-* **Or**, place the content in a focusable element that has role `"document"` or `"article"`;
-* **Or**, manage the focus of descendants as described in [Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/) by updating the value of `aria-activedescendant` to reference the element containing the focused content.
+* Verify that the content is decorative
+* **Or**, associate the content with a focusable element using the `aria-labelledby` or `aria-describedby` attribute
+* **Or**, place the content in a focusable element that has role `"document"` or `"article"`
+* **Or**, manage the focus of descendants as described in [Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/) by updating the value of `aria-activedescendant` to reference the element containing the focused content
+* **And if**, the application provides assistive technology, use platform and other industry standard accessibility services
 
 </script></mark-down>
 <!-- End main panel -->
@@ -65,12 +66,15 @@ Therefore, to ensure access to any non-decorative static text or image content t
             </div>
             <div class="bx--col-sm-4 bx--col-md-3 bx--col-lg-4 toolSide">
 <!-- Start side panel -->
+<!-- Match mapping in rule --> 
 <mark-down><script type="text/plain">
 
 ### About this requirement
 
-* [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
+* [IBM 1.1.1 Non-text content](https://www.ibm.com/able/requirements/requirements/#1_1_1)
+* [IBM 2.1.1 Keyboard](https://www.ibm.com/able/requirements/requirements/#2_1_1)
 * [ARIA practices - Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)
+* See if [503.3 Alternative User Interfaces](https://www.ibm.com/able/requirements/requirements/#503_3) applies
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/aria_attribute_valid.html
+++ b/accessibility-checker-engine/help-v4/en-US/aria_attribute_valid.html
@@ -53,8 +53,8 @@ If invalid ARIA attributes are used, assistive technologies may not be able to i
 
 ### What to do
 
-* Remove ARIA state or property attributes that are not valid for the element role;
-* **Or**, change the `role` value to a role that supports the intended behavior of the element, using the ARIA specification as a guide.
+* Remove ARIA state or property attributes that are not valid for the element role
+* **Or**, change to a role that supports the intended behavior of the element, using the ARIA specification as a guide
 
 In the following example, the element references only valid ARIA attributes for an element with the role of `"tree"`, a global `aria-labelledby` property, and an `aria-expanded` state:
 
@@ -72,12 +72,15 @@ In the following example, the element references only valid ARIA attributes for 
             </div>
             <div class="bx--col-sm-4 bx--col-md-3 bx--col-lg-4 toolSide">
 <!-- Start side panel -->
+<!-- remove 4.1.2 from reference, but include ARIA spec reference --> 
+<!-- rule maps to ACT, so add references if missing -->
 <mark-down><script type="text/plain">
 
 ### About this requirement
 
-* [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
 * [ARIA specification - States and Properties](https://www.w3.org/TR/wai-aria-1.2/#introstates)
+* [ACT rule - ARIA state or property is permitted](https://www.w3.org/WAI/standards-guidelines/act/rules/5c01ea/)
+* [ACT rule - Element marked as decorative is not exposed](https://www.w3.org/WAI/standards-guidelines/act/rules/46ca7f/)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/canvas_content_described.html
+++ b/accessibility-checker-engine/help-v4/en-US/canvas_content_described.html
@@ -91,8 +91,9 @@ This example shows an interactive `<canvas>` with equivalent accessible informat
 
 * [IBM 1.1.1 Non-Text Content](https://www.ibm.com/able/requirements/requirements/#1_1_1)
 * [IBM 2.1.1 Keyboard](https://www.ibm.com/able/requirements/requirements/#2_1_1)
-* [IBM 2.4.7 Focus Visible](https://www.ibm.com/able/requirements/requirements/#2_4_7)
 * [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
+* [Design - Visual states]()
+* [Canvas accessibility by pauljadam.com](https://pauljadam.com/demos/canvas.html)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/input_label_after.html
+++ b/accessibility-checker-engine/help-v4/en-US/input_label_after.html
@@ -68,13 +68,15 @@ For example:
             </div>
             <div class="bx--col-sm-4 bx--col-md-3 bx--col-lg-4 toolSide">
 <!-- Start side panel -->
+<!-- Remove 1.3.1 & 4.1.2 from help add replace with 3.3.2 -->
 <mark-down><script type="text/plain">
 
 ### About this requirement
 
-* [IBM 1.3.1 Info and Relationships](https://www.ibm.com/able/requirements/requirements/#1_3_1)
-* [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
-* [H44: Associate text labels with form controls](https://www.w3.org/WAI/WCAG22/Techniques/html/H44)
+* [IBM 3.3.2 Info and Relationships](https://www.ibm.com/able/requirements/requirements/#3_3_2)
+* [Design - Input labels](https://www.ibm.com/able/toolkit/design/content/#input-labels)
+* [Develop - Programmatically associate inputs with labels](https://www.ibm.com/able/toolkit/develop/user-input/#inputs)
+* [G162: Positioning labels to maximize predictability of relationships](https://www.w3.org/WAI/WCAG22/Techniques/general/G162)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/input_label_before.html
+++ b/accessibility-checker-engine/help-v4/en-US/input_label_before.html
@@ -69,12 +69,15 @@ For example:
             </div>
             <div class="bx--col-sm-4 bx--col-md-3 bx--col-lg-4 toolSide">
 <!-- Start side panel -->
+<!-- Remove 1.3.1 & 4.1.2 from help add replace with 3.3.2 -->
 <mark-down><script type="text/plain">
 
 ### About this requirement
 
-* [IBM 1.3.1 Info and Relationships](https://www.ibm.com/able/requirements/requirements/#1_3_1)
-* [IBM 4.1.2 Name, Role, Value](https://www.ibm.com/able/requirements/requirements/#4_1_2)
+* [IBM 3.3.2 Info and Relationships](https://www.ibm.com/able/requirements/requirements/#3_3_2)
+* [Design - Input labels](https://www.ibm.com/able/toolkit/design/content/#input-labels)
+* [Develop - Programmatically associate inputs with labels](https://www.ibm.com/able/toolkit/develop/user-input/#inputs)
+* [G162: Positioning labels to maximize predictability of relationships](https://www.w3.org/WAI/WCAG22/Techniques/general/G162)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/media_audio_transcribed.html
+++ b/accessibility-checker-engine/help-v4/en-US/media_audio_transcribed.html
@@ -74,10 +74,12 @@ Jeremy Flint's <a href="bc30.wav">podcast on disability rights</a>
 ### About this requirement
 
 * [IBM 1.2.1 Audio-only and Video-only (Prerecorded)](https://www.ibm.com/able/requirements/requirements/#1_2_1)
+* [Design - Video transcripts](https://www.ibm.com/able/toolkit/design/content/#video-transcripts)
 
 ### Who does this affect?
 
  * People who are deaf or hard of hearing
+ * People who are deaf-blind
  * People in a situation where they cannot use audio on their devices
 
 </script></mark-down>

--- a/accessibility-checker-engine/help-v4/en-US/media_track_available.html
+++ b/accessibility-checker-engine/help-v4/en-US/media_track_available.html
@@ -66,11 +66,14 @@ Described video should not be confused with subtitles, captions, or transcripts.
             </div>
             <div class="bx--col-sm-4 bx--col-md-3 bx--col-lg-4 toolSide">
 <!-- Start side panel -->
+<!-- Should be both 1.2.3 and 1.2.5 in Help -->
 <mark-down><script type="text/plain">
 
 ### About this requirement
 
+* [IBM 1.2.3 Audio Description or Media Alternative (Prerecorded)](https://www.ibm.com/able/requirements/requirements/#1_2_3)]
 * [IBM 1.2.5 Audio Description (Prerecorded)](https://www.ibm.com/able/requirements/requirements/#1_2_5)
+* [Design - Visual content in videos](https://www.ibm.com/able/toolkit/design/content/#visual-content-in-videos)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/script_onclick_avoid.html
+++ b/accessibility-checker-engine/help-v4/en-US/script_onclick_avoid.html
@@ -64,12 +64,13 @@ People may be unable to tab to the link using their keyboard, and it may be hard
             </div>
             <div class="bx--col-sm-4 bx--col-md-3 bx--col-lg-4 toolSide">
 <!-- Start side panel -->
+<!-- remove 1.3.1, maps to 2.1.1 only -->
 <mark-down><script type="text/plain">
 
 ### About this requirement
 
-* [IBM 1.3.1 Info and Relationships](https://www.ibm.com/able/requirements/requirements/#1_3_1)
 * [IBM 2.1.1 Keyboard](https://www.ibm.com/able/requirements/requirements/#2_1_1)
+* [Failure F42: When emulating links](https://www.w3.org/WAI/WCAG22/Techniques/failures/F42)
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/help-v4/en-US/script_onclick_misuse.html
+++ b/accessibility-checker-engine/help-v4/en-US/script_onclick_misuse.html
@@ -64,11 +64,11 @@ People may be unable to tab to the link using their keyboard, and it may be hard
             </div>
             <div class="bx--col-sm-4 bx--col-md-3 bx--col-lg-4 toolSide">
 <!-- Start side panel -->
+<!-- remove 1.3.1, maps to 2.1.1 only -->
 <mark-down><script type="text/plain">
 
 ### About this requirement
 
-* [IBM 1.3.1 Info and Relationships](https://www.ibm.com/able/requirements/requirements/#1_3_1)
 * [IBM 2.1.1 Keyboard](https://www.ibm.com/able/requirements/requirements/#2_1_1)
 * [Failure F42: When emulating links](https://www.w3.org/WAI/WCAG22/Techniques/failures/F42)
 

--- a/accessibility-checker-engine/help-v4/en-US/style_highcontrast_visible.html
+++ b/accessibility-checker-engine/help-v4/en-US/style_highcontrast_visible.html
@@ -47,7 +47,7 @@
 
 Windows high contrast mode alters the way Web content is displayed by disabling certain CSS features.
 Applications that use CSS to include, position, or alter non-decorative content may have issues, such as the disappearance of images or UI elements when Windows high contrast mode is enabled.
-Another example is the disappearance of visual focus indicators and visual alterations of UI elements with Windows high contrast mode enabled.
+Another example is the disappearance of icons, visual focus indicators, and visual alterations of UI elements with Windows high contrast mode enabled.
 
 <!-- This is where the code snippet is injected -->
 <div id="locSnippet"></div>
@@ -59,7 +59,7 @@ Another example is the disappearance of visual focus indicators and visual alter
  * **And**, confirm that checkboxes, radio buttons and text entry field boundaries are visible with good contrast
  * **And**, confirm the visual focus indicator is highly visible
  * **And**, confirm that all images that convey information are visible, or a text alternative is displayed
- * **And**, confirm that all decorative images are no longer visible
+ * **And**, confirm that only decorative images are no longer visible
 
 </script></mark-down>
 <!-- End main panel -->
@@ -73,9 +73,13 @@ Another example is the disappearance of visual focus indicators and visual alter
 ### About this requirement
 
 * [IBM 1.1.1 Non-text content](https://www.ibm.com/able/requirements/requirements/#1_1_1)
+* [IBM 1.3.2 Meaningful sequence](https://www.ibm.com/able/requirements/requirements/#1_3_2)
+* [IBM 1.4.11 Non-text contrast](https://www.ibm.com/able/requirements/requirements/#1_4_11)
+* [Design - Component contrast](https://www.ibm.com/able/toolkit/design/visual/#components-contrast)
+* [G207: Ensure contrast for icons](https://www.w3.org/WAI/WCAG22/Techniques/general/G207)
 * [Failure F1: CSS positioning that changes the meaning](https://www.w3.org/WAI/WCAG22/Techniques/failures/F1)
 * [Failure F3: CSS images that convey important information](https://www.w3.org/WAI/WCAG22/Techniques/failures/F3)
-* [Failure F78: Styling element that removes the visual focus](https://www.w3.org/WAI/WCAG22/Techniques/failures/F78)
+
 
 ### Who does this affect?
 

--- a/accessibility-checker-engine/src/v4/rules/application_content_accessible.ts
+++ b/accessibility-checker-engine/src/v4/rules/application_content_accessible.ts
@@ -42,7 +42,7 @@ export let application_content_accessible: Rule = {
     },
     rulesets: [{
         id: [ "IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
-        num: "2.1.1", // num: [ "2.4.4", "x.y.z" ] also allowed
+        num: ["1.1.1", "2.1.1"], //match listing in help
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/src/v4/rules/aria_accessiblename_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_accessiblename_exists.ts
@@ -37,7 +37,7 @@ export let aria_accessiblename_exists: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["1.3.1"],
+        "num": ["4.1.2"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/src/v4/rules/aria_semantics.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_semantics.ts
@@ -131,7 +131,7 @@ export let aria_attribute_valid: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["ARIA"],
+        "num": ["ARIA"], //removed mapping to 4.1.2 from here and help
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/src/v4/rules/canvas_content_described.ts
+++ b/accessibility-checker-engine/src/v4/rules/canvas_content_described.ts
@@ -39,7 +39,7 @@ export let canvas_content_described: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["1.1.1", "4.1.2"],
+        "num": ["1.1.1", "2.1.1", "4.1.2"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_THREE
     }],

--- a/accessibility-checker-engine/src/v4/rules/caption_track_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/caption_track_exists.ts
@@ -38,7 +38,7 @@ export let caption_track_exists: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["1.2.1", "1.2.2", "1.2.4"],
+        "num": ["1.2.2"],
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/src/v4/rules/img_alt_redundant.ts
+++ b/accessibility-checker-engine/src/v4/rules/img_alt_redundant.ts
@@ -45,7 +45,7 @@ export let img_alt_redundant: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["1.1.1"],
+        "num": ["1.1.1", "2.4.4"], //match help references
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_TWO
     }],

--- a/accessibility-checker-engine/src/v4/rules/input_label_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/input_label_visible.ts
@@ -47,7 +47,7 @@ export let input_label_visible: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["3.3.2"],
+        "num": ["2.5.3", "3.3.2"], //map to both requirements in help
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/src/v4/rules/script_focus_blur_review.ts
+++ b/accessibility-checker-engine/src/v4/rules/script_focus_blur_review.ts
@@ -39,7 +39,7 @@ export let script_focus_blur_review: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["2.4.7", "3.2.1"],
+        "num": ["2.1.1", "2.4.7", "3.2.1"], //match requirements listed in help
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/src/v4/rules/script_onclick_avoid.ts
+++ b/accessibility-checker-engine/src/v4/rules/script_onclick_avoid.ts
@@ -40,7 +40,7 @@ export let script_onclick_avoid: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["1.3.1"],
+        "num": ["2.1.1"], //help and match mapping to 2.1.1 only 
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_FOUR
     }],

--- a/accessibility-checker-engine/src/v4/rules/script_onclick_misuse.ts
+++ b/accessibility-checker-engine/src/v4/rules/script_onclick_misuse.ts
@@ -39,7 +39,7 @@ export let script_onclick_misuse: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["1.3.1"],
+        "num": ["2.1.1"], //help and match mapping to 2.1.1 only 
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/src/v4/rules/style_highcontrast_visible.ts
+++ b/accessibility-checker-engine/src/v4/rules/style_highcontrast_visible.ts
@@ -39,13 +39,13 @@ export let style_highcontrast_visible: Rule = {
     },
     rulesets: [{
         "id": ["IBM_Accessibility", "IBM_Accessibility_next"],
-        "num": ["1.1.1"],
+        "num": ["1.1.1", "1.3.2", "1.4.11"],  //other "style" rules for focus, hover, and color
         "level": eRulePolicy.VIOLATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     },
     {
         "id": ["WCAG_2_1", "WCAG_2_0", "WCAG_2_2"],
-        "num": ["1.1.1"],
+        "num": ["1.1.1", "1.3.2", "1.4.11"],
         "level": eRulePolicy.RECOMMENDATION,
         "toolkitLevel": eToolkitLevel.LEVEL_ONE
     }],

--- a/accessibility-checker-engine/src/v4/rules/style_viewport_resizable.ts
+++ b/accessibility-checker-engine/src/v4/rules/style_viewport_resizable.ts
@@ -43,7 +43,7 @@ export let style_viewport_resizable: Rule = {
     },
     rulesets: [{
         id: ["IBM_Accessibility", "IBM_Accessibility_next", "WCAG_2_0", "WCAG_2_1", "WCAG_2_2"],
-        num: "1.4.4", // num: [ "2.4.4", "x.y.z" ] also allowed
+        num: ["1.4.4", "1.4.10"], // match help for both 
         level: eRulePolicy.VIOLATION,
         toolkitLevel: eToolkitLevel.LEVEL_THREE
     }],


### PR DESCRIPTION
### Updates the following rules 
so that the Requirement(s) listed in the help match the rule listed in the Requirements that will be on the [Check rule set](https://www.ibm.com/able/requirements/checker-rule-sets) page when deployed.  In some cases, only the help file was changed to match the mapping/reporting of the rule. In other cases, only the mapping was changed to match the help listing.  In some cases, the requirements listed in the help and the requirement mapping/reporting in the rule were both changed to match:
1. img_alt_redundant
2. style_highcontrast_visible
3. canvas_content_described
4. caption_track_exists
5. media_track_available
6. caption_track_exists
7. script_onclick_avoid
8. script_onclick_misuse
9. aria_accessiblename_exists
10. style_viewport_resizable
11. application_content_accessible
12. aria_content_in_landmark
13. script_focus_blur_review
14. input_label_after
15. input_label_before
16. input_label_visible
17. canvas_content_described
18. aria_attribute_valid

### This PR is related to the following issue(s): 
- [E2E 6522 Checker rules help mismatch with how they are listed in the Requirements tab](https://github.ibm.com/IBMa/E2E/issues/6522)
- See box [RulesTab-issues.xlsx](https://ibm.ent.box.com/file/1609617568377?s=70563pqbsxm5iofc4ntlf3xpj8tt0naa) for details of which changes needed to match.

### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
- Confirm list of rules above by comparing the Help files with the [Rule listing](https://github.com/IBMa/equal-access/actions/runs/10207703433/artifacts/1767287800) built in Actions
    - Is rule listed under Requirement?
    - Is Requirement listed in "**_About this requirement_** section in each help page?
 
For example:
- [x] is `img_alt_redundant` is listed under 1.1.1 and 2.4.4 in he [Rule listing](https://github.com/IBMa/equal-access/actions/runs/10207703433/artifacts/1767287800)
- [x] does [img_alt_redundant.html](https://github.com/IBMa/equal-access/blob/phill-help-mapping/accessibility-checker-engine/help-v4/en-US/img_alt_redundant.html) help list 1.1.1 and 2.4.4 in the "About this requirement" section? 
<img width="724" alt="Screenshot 2024-08-02 at 7 21 46 AM" src="https://github.com/user-attachments/assets/1d5e949a-520f-44fe-a21d-5d79a6b93be1">
<img width="1218" alt="Screenshot 2024-08-02 at 7 24 04 AM" src="https://github.com/user-attachments/assets/f316256a-4363-45dd-8b21-8e6cc5ba63d8">

> ### About this requirement
>
> * [IBM 1.1.1 Non-text content](https://www.ibm.com/able/requirements/requirements/#1_1_1)
> * [IBM 2.4.4 Link Purpose (in Context)](https://www.ibm.com/able/requirements/requirements/#2_4_4)

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.

<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->