### PR TITLE
fixrule(aria_accessiblename_exists): Was firing for img with alt text, which is handled by img_alt_valid #1980Fix build error

### DIFF
--- a/accessibility-checker-engine/src/v4/rules/aria_accessiblename_exists.ts
+++ b/accessibility-checker-engine/src/v4/rules/aria_accessiblename_exists.ts
@@ -18,7 +18,7 @@ import { VisUtil } from "../../v2/dom/VisUtil";
 import { ARIADefinitions } from "../../v2/aria/ARIADefinitions";
 import { getDeprecatedAriaRoles, getDeprecatedAriaAttributes, getRolesUndefinedByAria} from "../util/CommonUtil";
 
-export let aria_accessiblename_exists: Rule = {
+export const aria_accessiblename_exists: Rule = {
     id: "aria_accessiblename_exists",
     context: "aria:columnheader, aria:form, aria:heading, aria:rowheader, aria:table, aria:graphics-document,aria:graphics-symbol, aria:img, doc-backlink, doc-biblioentry, doc-biblioref, doc-glossref, doc-noteref, doc-pagebreak",
     help: {
@@ -51,7 +51,9 @@ export let aria_accessiblename_exists: Rule = {
         let nodeName = ruleContext.nodeName.toLocaleLowerCase();
         // svg element is handled in svg_graphics)labbelled rule
         if (nodeName === 'svg') return;
-
+        // img element handled in img_alt_valid
+        if (nodeName === "img" && ruleContext.hasAttribute("alt")) return RulePass("pass");
+        
         // when table element with a caption as first child
         if (nodeName === 'table' 
             && ruleContext.firstElementChild && ruleContext.firstElementChild.nodeName.toLowerCase() === 'caption'

--- a/cypress-accessibility-checker/test/.achecker.yml
+++ b/cypress-accessibility-checker/test/.achecker.yml
@@ -1,7 +1,11 @@
-# optional - Specify the rule archive
+# Custom Internal settings for testing purposes only
+
+# optional - Specify one rule archive which consist diffrent type of policies.
 # Default: latest
-# Run `npx achecker archives` for a list of valid ruleArchive ids and policy ids
-ruleArchive : latest
+customRuleServer: true
+rulePack: https://localhost:9445/rules/archives/preview/js
+ruleArchive: preview
+ignoreHTTPSErrors: true
 
 # optional - Specify one or many policies to scan.
 # i.e. For one policy use policies: IBM_Accessibility

--- a/cypress-accessibility-checker/test/baselines/violations.json
+++ b/cypress-accessibility-checker/test/baselines/violations.json
@@ -23,8 +23,9 @@
             },
             "snippet": "<html>",
             "category": "Accessibility",
-            "ignored": false,
-            "level": "violation"
+            "ignored": true,
+            "level": "violation",
+            "help": "https://able.ibm.com/rules/archives/2024.08.06/doc/en-US/html_lang_exists.html#%7B%22message%22%3A%22Page%20detected%20as%20HTML%2C%20but%20does%20not%20have%20a%20'lang'%20attribute%22%2C%22snippet%22%3A%22%3Chtml%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22FAIL%22%5D%2C%22reasonId%22%3A%22Fail_3%22%2C%22ruleId%22%3A%22html_lang_exists%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "skip_main_exists",
@@ -49,8 +50,9 @@
             },
             "snippet": "<body>",
             "category": "Accessibility",
-            "ignored": false,
-            "level": "violation"
+            "ignored": true,
+            "level": "violation",
+            "help": "https://able.ibm.com/rules/archives/2024.08.06/doc/en-US/skip_main_exists.html#%7B%22message%22%3A%22The%20page%20does%20not%20provide%20a%20way%20to%20quickly%20navigate%20to%20the%20main%20content%20(ARIA%20%5C%22main%5C%22%20landmark%20or%20a%20skip%20link)%22%2C%22snippet%22%3A%22%3Cbody%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22FAIL%22%5D%2C%22reasonId%22%3A%22Fail_1%22%2C%22ruleId%22%3A%22skip_main_exists%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "aria_content_in_landmark",
@@ -75,8 +77,9 @@
             },
             "snippet": "<h1>",
             "category": "Accessibility",
-            "ignored": false,
-            "level": "violation"
+            "ignored": true,
+            "level": "violation",
+            "help": "https://able.ibm.com/rules/archives/2024.08.06/doc/en-US/aria_content_in_landmark.html#%7B%22message%22%3A%22Content%20is%20not%20within%20a%20landmark%20element%22%2C%22snippet%22%3A%22%3Ch1%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22FAIL%22%5D%2C%22reasonId%22%3A%22Fail_1%22%2C%22ruleId%22%3A%22aria_content_in_landmark%22%2C%22msgArgs%22%3A%5B%5D%7D"
         },
         {
             "ruleId": "img_alt_valid",
@@ -90,7 +93,7 @@
             },
             "ruleTime": 0,
             "reasonId": "fail_no_alt",
-            "message": "The image has neither an alt atttribute nor an ARIA label or title",
+            "message": "The image has neither an accessible name nor is marked as decorative or redundant",
             "messageArgs": [],
             "apiArgs": [],
             "bounds": {
@@ -101,105 +104,94 @@
             },
             "snippet": "<img src=\"missing-alt.jpg\">",
             "category": "Accessibility",
-            "ignored": false,
-            "level": "violation"
+            "ignored": true,
+            "level": "violation",
+            "help": "https://able.ibm.com/rules/archives/2024.08.06/doc/en-US/img_alt_valid.html#%7B%22message%22%3A%22The%20image%20has%20neither%20an%20accessible%20name%20nor%20is%20marked%20as%20decorative%20or%20redundant%22%2C%22snippet%22%3A%22%3Cimg%20src%3D%5C%22missing-alt.jpg%5C%22%3E%22%2C%22value%22%3A%5B%22VIOLATION%22%2C%22FAIL%22%5D%2C%22reasonId%22%3A%22fail_no_alt%22%2C%22ruleId%22%3A%22img_alt_valid%22%2C%22msgArgs%22%3A%5B%5D%7D"
+        },
+        {
+            "ruleId": "aria_accessiblename_exists",
+            "value": [
+                "RECOMMENDATION",
+                "FAIL"
+            ],
+            "path": {
+                "dom": "/html[1]/body[1]/img[1]",
+                "aria": "/document[1]/img[1]"
+            },
+            "ruleTime": 0,
+            "reasonId": "fail_no_accessible_name",
+            "message": "Element <img> with \"img\" role has no accessible name",
+            "messageArgs": [
+                "img",
+                "img"
+            ],
+            "apiArgs": [],
+            "bounds": {
+                "left": 16,
+                "top": 133,
+                "height": 32,
+                "width": 32
+            },
+            "snippet": "<img src=\"missing-alt.jpg\">",
+            "category": "Accessibility",
+            "ignored": true,
+            "level": "recommendation",
+            "help": "https://able.ibm.com/rules/archives/2024.08.06/doc/en-US/aria_accessiblename_exists.html#%7B%22message%22%3A%22Element%20%3Cimg%3E%20with%20%5C%22img%5C%22%20role%20has%20no%20accessible%20name%22%2C%22snippet%22%3A%22%3Cimg%20src%3D%5C%22missing-alt.jpg%5C%22%3E%22%2C%22value%22%3A%5B%22RECOMMENDATION%22%2C%22FAIL%22%5D%2C%22reasonId%22%3A%22fail_no_accessible_name%22%2C%22ruleId%22%3A%22aria_accessiblename_exists%22%2C%22msgArgs%22%3A%5B%22img%22%2C%22img%22%5D%7D"
         }
     ],
-    "numExecuted": 46,
+    "numExecuted": 31,
+    "ruleTime": 0,
     "nls": {
         "html_lang_exists": {
             "0": "Page must identify the default language of the document with a 'lang' attribute",
             "Fail_3": "Page detected as HTML, but does not have a 'lang' attribute"
         },
-        "html_skipnav_exists": {
-            "0": "Provide a way to bypass blocks of content that are repeated on multiple Web pages",
-            "Pass_0": "Rule Passed"
-        },
-        "page_title_exists": {
-            "0": "The page should have a title that correctly identifies the subject of the page",
-            "Pass_0": "Rule Passed"
-        },
-        "emoticons_alt_exists": {
-            "0": "Emoticons must have a short text alternative that describes their purpose",
-            "Pass_0": "Rule Passed"
-        },
-        "img_alt_background": {
-            "0": "Background images that convey important information must have a text alternative that describes the image",
-            "Pass_0": "Rule Passed"
-        },
-        "list_markup_review": {
-            "0": "Use proper HTML list elements to create lists",
-            "Pass_0": "Rule Passed"
-        },
         "aria_content_in_landmark": {
             "0": "All content must reside within an element with a landmark role",
-            "Pass_0": "Rule Passed",
             "Fail_1": "Content is not within a landmark element"
-        },
-        "page_title_valid": {
-            "0": "Page <title> should be a descriptive title, rather than a filename",
-            "Pass_0": "Rule Passed"
         },
         "skip_main_exists": {
             "0": "Pages must provide a way to skip directly to the main content",
             "Fail_1": "The page does not provide a way to quickly navigate to the main content (ARIA \"main\" landmark or a skip link)"
         },
-        "text_sensory_misuse": {
-            "0": "Instructions must be meaningful without shape or location words",
-            "Pass_0": "Rule Passed"
-        },
-        "text_quoted_correctly": {
-            "0": "Quotations should be marked with <q> or <blockquote> elements",
-            "Pass_0": "Rule Passed"
-        },
-        "text_whitespace_valid": {
-            "0": "Space characters should not be used to control spacing within a word",
-            "pass": "Rule Passed"
-        },
-        "heading_content_exists": {
-            "0": "Heading elements must provide descriptive text",
-            "Pass_0": "Heading element has descriptive text"
-        },
-        "heading_markup_misuse": {
-            "0": "Heading elements must not be used for presentation",
-            "Pass_0": "Rule Passed"
-        },
-        "text_contrast_sufficient": {
-            "0": "The contrast ratio of text with its background must meet WCAG AA requirements",
-            "Pass_0": "Rule Passed"
-        },
-        "img_alt_misuse": {
-            "0": "'alt' attribute value must be a good inline replacement for the image",
-            "Pass_0": "Rule Passed"
+        "aria_accessiblename_exists": {
+            "0": "Elements with certain roles should have accessible names",
+            "fail_no_accessible_name": "Element <{0}> with \"{1}\" role has no accessible name"
         },
         "img_alt_valid": {
-            "0": "Images require an 'alt' attribute with a short text alternative if they convey meaning, or 'alt=\"\" if decorative",
-            "fail_no_alt": "The image has neither an alt atttribute nor an ARIA label or title"
-        },
-        "aria_descendant_valid": {
-            "0": "Browsers ignore the explicit and implicit ARIA roles of the descendants of certain elements",
-            "pass": "The element contains valid descendants"
+            "0": "Images must have accessible names unless they are decorative or redundant",
+            "fail_no_alt": "The image has neither an accessible name nor is marked as decorative or redundant"
         }
     },
     "summary": {
         "counts": {
-            "violation": 4,
+            "violation": 0,
             "potentialviolation": 0,
-            "ignored": 0
+            "recommendation": 0,
+            "potentialrecommendation": 0,
+            "manual": 0,
+            "pass": 26,
+            "ignored": 5,
+            "elements": 7,
+            "elementsViolation": 0,
+            "elementsViolationReview": 0
         },
-        "scanTime": 10,
-        "ruleArchive": "Latest Deployment (latest)",
+        "scanTime": 4,
+        "ruleArchive": "Preview Rules (preview)",
         "policies": [
             "IBM_Accessibility"
         ],
         "reportLevels": [
             "violation",
-            "potentialviolation"
+            "potentialviolation",
+            "recommendation",
+            "potentialrecommendation",
+            "manual"
         ],
-        "startScan": 1684344654747,
+        "startScan": 1723480681453,
         "URL": "http://localhost:8080/test/sample-html/violations.html"
     },
-    "scanID": "155b5277-dee6-44a8-a591-9d6fad5241c4",
+    "scanID": "03c0fc62-453a-4b6c-a2b2-869c2818e5ea",
     "toolID": "cypress-accessibility-checker-v3.0.0",
     "label": "violations"
 }


### PR DESCRIPTION
<!-- For instructions regarding the PR title, see the bottom of the PR template -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: aria_accessiblename_exists

### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with "Fixes" to close when the PR closes (e.g., Fixes #000) -->
- 
Build was failing due to cypress using remote archive, which didn't detect scenario of recommendation failing when img had alt text

### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
- 

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [ ] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [ ] I understand that the title of this PR will be used for the next release notes.

<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->