### PR TITLE
fixrule(`aria_landmark_name_unique`): Change the accessible name length limitation

### DIFF
--- a/accessibility-checker-engine/karma.conf.js
+++ b/accessibility-checker-engine/karma.conf.js
@@ -47,12 +47,12 @@
                 //{ pattern: 'test/v2/checker/accessibility/rules/label_name_visible_ruleunit/label_offscreen.html', watched: true },
                 //{ pattern: 'test/v2/checker/accessibility/rules/aria_role_valid_ruleunit/td_attribute_invalid_copy.html', watched: true },
                 //{ pattern: 'test/v2/checker/accessibility/rules/text_block_heading_ruleunit/Headings-noneUsedEmphasizedText.html', watched: true },
-                { pattern: 'test/v2/checker/accessibility/rules/aria_parent_required_ruleunit/webComponentPass.html', watched: true },
-                { pattern: 'test/v2/checker/accessibility/rules/aria_parent_required_ruleunit/webComponentPass2.html', watched: true },
+                { pattern: 'test/v2/checker/accessibility/rules/aria_landmark_name_unique_ruleunit/*.html', watched: true },
+                // { pattern: 'test/v2/checker/accessibility/rules/aria_parent_required_ruleunit/webComponentPass2.html', watched: true },
     
     
-                { pattern: 'test/**/*_ruleunit/*.html', watched: true },
-                { pattern: 'test/**/*_ruleunit/*.htm', watched: true },
+                // { pattern: 'test/**/*_ruleunit/*.html', watched: true },
+                // { pattern: 'test/**/*_ruleunit/*.htm', watched: true },
                 // all files ending in "_test"
                 // { pattern: 'test/*_test.js', watched: true },
                 { pattern: 'test/**/*_test.js', watched: true }

--- a/accessibility-checker-engine/src/v4/rules/element_accesskey_labelled.ts
+++ b/accessibility-checker-engine/src/v4/rules/element_accesskey_labelled.ts
@@ -64,7 +64,7 @@ export const element_accesskey_labelled: Rule = {
         if (!roles || roles.length === 0) return;
 
         let patterns = ARIADefinitions.designPatterns[roles[0]]
-        if (!patterns.nameFrom) 
+        if (!patterns || !patterns.nameFrom) 
             return;
 
         // ignore if accessble name is required (checked in other rules) or prohibited (text element)    

--- a/accessibility-checker-engine/src/v4/util/AriaUtil.ts
+++ b/accessibility-checker-engine/src/v4/util/AriaUtil.ts
@@ -768,7 +768,7 @@ export class AriaUtil {
         if (widget === null) {
             let ret = false;
             const role = AriaUtil.getResolvedRole(element); 
-            if (role && ARIADefinitions.designPatterns[role].roleType === 'widget')
+            if (role && ARIADefinitions.designPatterns[role] && ARIADefinitions.designPatterns[role].roleType === 'widget')
                 ret = true;
             
             CacheUtil.setCache(element.ownerDocument, "is_element_widget", ret);

--- a/accessibility-checker-engine/src/v4/util/CommonUtil.ts
+++ b/accessibility-checker-engine/src/v4/util/CommonUtil.ts
@@ -1646,8 +1646,8 @@ export class CommonUtil {
     }
 
     // truncate the given text to a given number of characters
-    // return truncated text
-    public static truncateText(text: string, len = 60) {
+    // return truncated text to 150 chars, same with the media_alt_brief rule
+    public static truncateText(text: string, len = 150) {
         if (!text) return text;
         text = text.trim();
         if (text.length > len)

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_landmark_name_unique_ruleunit/dcs-example.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_landmark_name_unique_ruleunit/dcs-example.html
@@ -65,7 +65,62 @@
         <script type="text/javascript">
             UnitTest = {
                 ruleIds: ["aria_landmark_name_unique"],
-                results: [],
+                results: [
+                {
+            "ruleId": "aria_landmark_name_unique",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/section[1]",
+              "aria": "/document[1]/main[1]/region[1]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Multiple elements with \"region\" landmarks within the same parent region are distinguished by unique 'aria-label' or 'aria-labelledby'",
+            "messageArgs": [
+              "region"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_landmark_name_unique",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/section[2]",
+              "aria": "/document[1]/main[1]/region[2]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Multiple elements with \"region\" landmarks within the same parent region are distinguished by unique 'aria-label' or 'aria-labelledby'",
+            "messageArgs": [
+              "region"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "aria_landmark_name_unique",
+            "value": [
+              "INFORMATION",
+              "PASS"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/main[1]/section[3]",
+              "aria": "/document[1]/main[1]/region[3]"
+            },
+            "reasonId": "Pass_0",
+            "message": "Multiple elements with \"region\" landmarks within the same parent region are distinguished by unique 'aria-label' or 'aria-labelledby'",
+            "messageArgs": [
+              "region"
+            ],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+                ],
             };
             //]]>
         </script>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_landmark_name_unique_ruleunit/dcs-example.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/aria_landmark_name_unique_ruleunit/dcs-example.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+
+<!--
+   /******************************************************************************
+     Copyright:: 2020- IBM, Inc
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  *****************************************************************************/
+-->
+
+<html lang="en">
+    <head>
+        <title>RPT Test Suite</title>
+    </head>
+
+    <body>
+        <main role="main">
+                <section
+                    role="region"
+                    aria-labelledby="twlp_sec_jca__adeappbind__title__1"
+                    id="twlp_sec_jca__adeappbind"
+                >
+                    <h2
+                        id="twlp_sec_jca__adeappbind__title__1"
+                    >
+                        Configuring authentication data and aliases with
+                        authData and a resource reference
+                    </h2>
+                </section>
+
+                <section
+                    role="region"
+                    aria-labelledby="twlp_sec_jca__cdade__title__1"
+                    id="twlp_sec_jca__cdade"
+                >
+                    <h2 id="twlp_sec_jca__cdade__title__1">
+                        Configuring authentication data and aliases with
+                        containerAuthData
+                    </h2>
+                </section>
+
+                <section
+                    role="region"
+                    aria-labelledby="twlp_sec_jca__adcadr__title__1"
+                    id="twlp_sec_jca__adcadr"
+                >
+                    <h2
+                        id="twlp_sec_jca__adcadr__title__1"
+                    >
+                        Configuring authentication data and aliases with
+                        authData and containerAuthDataRef
+                    </h2>
+                </section>
+        </main>
+        <script type="text/javascript">
+            UnitTest = {
+                ruleIds: ["aria_landmark_name_unique"],
+                results: [],
+            };
+            //]]>
+        </script>
+    </body>
+</html>

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/fieldset_label_valid_ruleunit/FieldSet-hasarialabel.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/fieldset_label_valid_ruleunit/FieldSet-hasarialabel.html
@@ -130,9 +130,9 @@
               "aria": "/document[1]/form[2]/group[1]"
             },
             "reasonId": "Fail_2",
-            "message": "Group/Fieldset \"this is a potentially very long description of the fieldset...\" has a duplicate name to another group",
+            "message": "Group/Fieldset \"this is a potentially very long description of the fieldset and more description is possible\" has a duplicate name to another group",
             "messageArgs": [
-              "this is a potentially very long description of the fieldset..."
+              "this is a potentially very long description of the fieldset and more description is possible"
             ],
             "apiArgs": [],
             "category": "Accessibility"
@@ -148,9 +148,9 @@
               "aria": "/document[1]/form[3]/group[1]"
             },
             "reasonId": "Fail_2",
-            "message": "Group/Fieldset \"this is a potentially very long description of the fieldset...\" has a duplicate name to another group",
+            "message": "Group/Fieldset \"this is a potentially very long description of the fieldset and more description is possible\" has a duplicate name to another group",
             "messageArgs": [
-              "this is a potentially very long description of the fieldset..."
+              "this is a potentially very long description of the fieldset and more description is possible"
             ],
             "apiArgs": [],
             "category": "Accessibility"
@@ -166,9 +166,9 @@
               "aria": "/document[1]/form[4]/group[1]"
             },
             "reasonId": "Fail_2",
-            "message": "Group/Fieldset \"this is a potentially very long description of the fieldset...\" has a duplicate name to another group",
+            "message": "Group/Fieldset \"this is a potentially very long description of the fieldset and more description is possible\" has a duplicate name to another group",
             "messageArgs": [
-              "this is a potentially very long description of the fieldset..."
+              "this is a potentially very long description of the fieldset and more description is possible"
             ],
             "apiArgs": [],
             "category": "Accessibility"


### PR DESCRIPTION
<!-- For instructions regarding the PR title, see the bottom of the PR template -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: **aria_landmark_name_unique**

### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with "Fixes" to close when the PR closes (e.g., Fixes #000) -->
- 

### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
- test/v2/checker/accessibility/rules/aria_landmark_name_unique_ruleunit/dcs-example.html
-   After the fix, two violations with the message should be gone
    "Multiple elements with region landmarks within the same parent region are not distinguished from one another because they have the same "configuring authentication data and aliases with authdata a... label" 

### I have conducted the following for this PR: 
- [ x] I validated this code in Chrome and FF 
- [x ] I validated this fix in my local env
- [ x] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [ ] I understand that the title of this PR will be used for the next release notes.

<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->