### PR TITLE
Fix(input_label_visible): fix issues related to the Firefox css pseudo-element V4

### DIFF
--- a/accessibility-checker-engine/src/v4/util/AccNameUtil.ts
+++ b/accessibility-checker-engine/src/v4/util/AccNameUtil.ts
@@ -144,7 +144,15 @@ export class AccNameUtil {
                 let pair = AccNameUtil.computeAccessibleName(image); 
                 if (pair && pair.name && pair.name.trim().length > 0) 
                     return pair;
-            }       
+            }
+            
+            // for a button with a svg image
+            const svg = elem.querySelector('svg');
+            if (svg && !VisUtil.isNodeHiddenFromAT(svg) && !VisUtil.isNodePresentational(svg)) {
+                let pair = AccNameUtil.computeAccessibleNameForSVGElement(svg); 
+                if (pair && pair.name && pair.name.trim().length > 0) 
+                    return pair;
+            }
         }
 
         // fieldset
@@ -397,7 +405,7 @@ export class AccNameUtil {
         const contentElem = elem.ownerDocument.defaultView.getComputedStyle(elem,type);
         if (contentElem) {
             let content = contentElem.content;
-            if (content && content !== "none") {
+            if (content && content !== "none" && content !== "no" && content !== "normal") {
                 content = content.replace(/^"/,"").replace(/"$/,"");
                 if (content.trim().length > 0)
                     return {"name": CommonUtil.truncateText(content), "nameFrom": "css-"+type};

--- a/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/element_with_aria.html
+++ b/accessibility-checker-engine/test/v2/checker/accessibility/rules/input_label_visible_ruleunit/element_with_aria.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Input with image child</title>
+
+</head>
+
+<body>
+
+  <hr style="margin: 20px;">
+
+  <button aria-hidden="true" tabindex="-1" aria-label="Scroll right"
+    class="cds--tab--overflow-nav-button cds--tab--overflow-nav-button--next cds--tab--overflow-nav-button--hidden"
+    type="button"><svg focusable="false" preserveAspectRatio="xMidYMid meet" fill="currentColor" width="16" height="16"
+      viewBox="0 0 16 16" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+      <path d="M11 8L6 13 5.3 12.3 9.6 8 5.3 3.7 6 3z"></path>
+    </svg>
+  </button>
+
+  <hr style="margin: 20px;">
+  <button type="button">
+      <svg focusable="false">
+          <defs><style>.cls-1{fill:none;}</style></defs>
+          <rect class="cls-1" width="32" height="32"></rect>
+          <title>text</title>
+      </svg>
+  </button>
+
+  <hr style="margin: 20px;">
+  <button type="button">
+      <svg focusable="false" aria-label="svg image">
+          <defs><style>.cls-1{fill:none;}</style></defs>
+          <rect class="cls-1" width="32" height="32"></rect>
+      </svg>
+  </button>
+
+  <hr style="margin: 50px;">
+</body>
+<script>
+  UnitTest = {
+    ruleIds: ["input_label_visible"],
+    results: [
+    {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/button[1]",
+              "aria": "/document[1]/button[1]"
+            },
+            "reasonId": "potential_no_label",
+            "message": "The input element does not have an associated visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/button[2]",
+              "aria": "/document[1]/button[2]"
+            },
+            "reasonId": "potential_no_label",
+            "message": "The input element does not have an associated visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          },
+          {
+            "ruleId": "input_label_visible",
+            "value": [
+              "INFORMATION",
+              "POTENTIAL"
+            ],
+            "path": {
+              "dom": "/html[1]/body[1]/button[3]",
+              "aria": "/document[1]/button[3]"
+            },
+            "reasonId": "potential_no_label",
+            "message": "The input element does not have an associated visible label",
+            "messageArgs": [],
+            "apiArgs": [],
+            "category": "Accessibility"
+          }
+    ]
+  };
+</script>
+
+</html>


### PR DESCRIPTION
<!-- For instructions regarding the PR title, see the bottom of the PR template -->

<!-- Specify what this PR is doing. Remove all that do not apply -->
* Rule bug: **input_label_visible**

### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with "Fixes" to close when the PR closes (e.g., Fixes #000) -->
- Fixes #2085 

### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
- https://react.carbondesignsystem.com/iframe.html?args=&id=components-tabs--default&viewMode=story
- In Firefox, The "An input element must have an associated visible label" was reported on the button element
- Those does not happen in Chrome, 
- [x] A test case `accessibility-checker-engine/tes t/v2/checker/accessibility/rules/input_label_visible_ruleunit/element_with_aria.html` was also added to the automated build process

### I have conducted the following for this PR: 
- [x] I validated this code in Chrome and FF 
- [x] I validated this fix in my local env
- [x] I provided details for testing
- [x] This PR has been reviewed and is ready for test  
- [x] I understand that the title of this PR will be used for the next release notes.


### Assets to aide review attached
<!-- DO NOT EDIT THIS SECTION. This section is for IBM internal review only. Specify the additional artifacts that should be reviewed alongside this PR. -->
- [ ] Links to design artifacts 
- [ ] Links to video walkthrough of user experience 
- [x] Other - Action Artifact

### Definition of Done
<!-- DO NOT EDIT THIS SECTION. This section is for IBM internal review only. Verify that the following requirements are met prior to marking this PR (issue) as Done. -->
- [x] Peer review complete
- [ ] Secondary review complete
- [ ] Staging deployment verified

      
<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->
