### PR TITLE
fix(ACT): ACT errors with scIds for ARIA and HTML

### DIFF
--- a/accessibility-checker-engine/src/v4/sc-urls.json
+++ b/accessibility-checker-engine/src/v4/sc-urls.json
@@ -1046,7 +1046,7 @@
     "HTML": {
       "num": "HTML",
       "url": "https://html.spec.whatwg.org/multipage/",
-      "scId": [],
+      "scId": "",
       "scAltId": [],
       "test": "",
       "howToMeetUrl": "https://html.spec.whatwg.org/multipage/",
@@ -1058,7 +1058,7 @@
     "ARIA": {
       "num": "ARIA",
       "url": "https://www.w3.org/TR/wai-aria-1.2/",
-      "scId": [],
+      "scId": "",
       "scAltId": [],
       "test": "",
       "howToMeetUrl": "https://www.w3.org/TR/wai-aria-1.2/",

--- a/accessibility-checker/test-act-w3/act.js
+++ b/accessibility-checker/test-act-w3/act.js
@@ -98,7 +98,7 @@ async function getAssertion(ruleId, aceRules, result) {
                         && (!rule.reasonCodes || rule.reasonCodes.filter(code => aceRule.reasonIds.includes(code)))
                     )).length > 0
                 // Replace with the scId
-                )).map(cp => cp.scId));            
+                )).map(cp => cp.scId).filter(scId => scId.length > 0));            
         }
     }
     return {


### PR DESCRIPTION
* Other (Provide information)

ACT reported that some of our reports included `[]`. This was due to ARIA and HTML criteria not having an SC to report against. These are filtered out in this PR.

### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with "Fixes" to close when the PR closes (e.g., Fixes #000) -->
- https://github.com/w3c/wcag-act-rules/issues/315

### Testing reference: 
<!-- Provide testing file(s) or/and code sandbox link(s). Also, provide details on the expected behavior -->
- 

### I have conducted the following for this PR: 
- [ ] I validated this code in Chrome and FF 
- [ ] I validated this fix in my local env
- [ ] I provided details for testing
- [ ] This PR has been reviewed and is ready for test  
- [ ] I understand that the title of this PR will be used for the next release notes.


### Assets to aide review attached
<!-- DO NOT EDIT THIS SECTION. This section is for IBM internal review only. Specify the additional artifacts that should be reviewed alongside this PR. -->
- [ ] Links to design artifacts 
- [ ] Links to video walkthrough of user experience 
- [ ] Other

### Definition of Done
<!-- DO NOT EDIT THIS SECTION. This section is for IBM internal review only. Verify that the following requirements are met prior to marking this PR (issue) as Done. -->
- [ ] Peer review complete
- [ ] Secondary review complete
- [ ] Staging deployment verified

      
<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->
