### PR TITLE
chore(engine): No longer need to build old ACT report

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,8 +43,8 @@ jobs:
         working-directory: accessibility-checker
       - run: npm run build
         working-directory: accessibility-checker
-      - run: npm test
-        working-directory: accessibility-checker/test-act
+      # - run: npm test
+      #   working-directory: accessibility-checker/test-act
       - run: npm test
         working-directory: accessibility-checker/test-act-w3
       - run: gitactions/publish/achecker-engine.sh


### PR DESCRIPTION
On publish, the old ACT report was causing hangs. We do not need the old report any longer.