### PR TITLE
fix(extension): Summary counts wrong when a violation level changes

### DIFF
--- a/accessibility-checker-extension/src/ts/devtools/components/scanSection.tsx
+++ b/accessibility-checker-extension/src/ts/devtools/components/scanSection.tsx
@@ -270,14 +270,20 @@ export class ScanSection extends React.Component<{}, ScanSectionState> {
         }
         if (this.state.ignoredIssues) {
             for (const ignoredIssue of this.state.ignoredIssues) {
-                if (!issues.some(issue => issueBaselineMatch(issue, ignoredIssue))) continue;
+                // Find the matching issue in the current scan results. The match
+                // is keyed on ruleId/reasonId/path/messageArgs — not on value
+                // (severity level). Use the fresh issue's value for the decrement
+                // so that a level re-classification between scans cannot drive a
+                // bucket negative.
+                const matchingIssue = issues.find(issue => issueBaselineMatch(issue, ignoredIssue));
+                if (!matchingIssue) continue;
                 ++counts["Hidden" as eLevel].total;
-                if (!this.state.selectedPath || PathMatcher.matchesPath(ignoredIssue.path.dom, this.state.selectedPath)) {
+                if (!this.state.selectedPath || PathMatcher.matchesPath(matchingIssue.path.dom, this.state.selectedPath)) {
                     ++counts["Hidden" as eLevel].focused;
                 }
-                let sing = UtilIssue.valueToStringSingular(ignoredIssue.value);
+                let sing = UtilIssue.valueToStringSingular(matchingIssue.value);
                 --counts[sing as eLevel].total;
-                if (!this.state.selectedPath || PathMatcher.matchesPath(ignoredIssue.path.dom, this.state.selectedPath)) {
+                if (!this.state.selectedPath || PathMatcher.matchesPath(matchingIssue.path.dom, this.state.selectedPath)) {
                     --counts[sing as eLevel].focused;
                 }
             }


### PR DESCRIPTION
<!-- For instructions regarding the PR title, see the bottom of the PR template -->

<!-- Specify what this PR is doing. Provide details if not already covered in the related issue -->
### Summary
* Extension UI changes

The code decremented counts[sing] where sing was derived from ignoredIssue.value (the stored level). If the fresh scan re-classified the same issue to a different level, the decrement hits a bucket that was never incremented for that issue, driving it negative.

### This PR is related to the following issue(s): 
<!-- Provide each ticket on a new line with "Fixes" to close when the PR closes (e.g., Fixes #000) -->
- Fixes #2601 

### Testing reference: 
<!-- Provide information on how what testing you performed (if you performed manual checks, please give an idea of what you checked). -->
- 

### I have conducted the following for this PR: 
- [ ] I validated this fix in my local env and provided testing information above
- [ ] I understand that the title of this PR will be used for the next release notes.
- [ ] I added `I agree to the DCO at https://developercertificate.org/ for this contribution.` as a comment after creating the pull request.

### Assets to aide review attached
<!-- DO NOT EDIT THIS SECTION. This section is for IBM internal review only. Specify the additional artifacts that should be reviewed alongside this PR. -->
- [ ] Links to design artifacts 
- [ ] Links to video walkthrough of user experience 
- [ ] Other

### Definition of Done
<!-- DO NOT EDIT THIS SECTION. This section is for IBM internal review only. Verify that the following requirements are met prior to marking this PR (issue) as Done. -->
- [ ] Peer review complete
- [ ] Secondary review complete
- [ ] Staging deployment verified
      
<!--
-- TITLE INSTRUCTIONS START: DO NOT EDIT THIS SECTION --
The title of this PR will be used for release notes, please provide a relevant title. 
The following templates should be used for the PR titles:
- newrule(`ruleid`): Title of PR
- fixrule(`ruleid`): Title of PR
- feature(engine|extension|node|karma|cypress): Title of PR
- fix(engine|extension|node|karma|cypress): Title of PR
- chore(engine|extension|node|karma|cypress|repo): Title of PR

Please review more info: https://github.com/IBMa/equal-access/wiki/Release-notes 
-- TITLE INSTRUCTIONS END --
-->
